### PR TITLE
chore: drop TruvaAgents trademark notice from www and docs-site

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -138,7 +138,7 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `© 2025–${new Date().getFullYear()} <a href="https://github.com/itsneelabh">Neelabh Tripathi</a> · TruvaG3. Licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.<br/>TruvaG3™ and TruvaAgents™ are trademarks of <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>.`,
+      copyright: `© 2025–${new Date().getFullYear()} <a href="https://github.com/itsneelabh">Neelabh Tripathi</a> · TruvaG3. Licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.<br/>TruvaG3™ is a trademark of <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>.`,
     },
     prism: {
       theme: prismThemes.github,

--- a/www/blogs/index.html
+++ b/www/blogs/index.html
@@ -174,7 +174,7 @@
       <a href="https://github.com/truvaagents/truva-g3/blob/main/LICENSE">License (Apache 2.0)</a>
     </div>
     <div>© 2025–2026 <a href="https://github.com/itsneelabh">Neelabh Tripathi</a> · TruvaG3. Licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</div>
-    <div>TruvaG3™ and TruvaAgents™ are trademarks of <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>.</div>
+    <div>TruvaG3™ is a trademark of <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>.</div>
   </div>
 </footer>
 

--- a/www/index.html
+++ b/www/index.html
@@ -651,7 +651,7 @@ response, _ := orchestrator.ProcessRequest(ctx,
       <a href="https://github.com/truvaagents/truva-g3/blob/main/LICENSE">License (Apache 2.0)</a>
     </div>
     <div>© 2025–2026 <a href="https://github.com/itsneelabh">Neelabh Tripathi</a> · TruvaG3. Licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</div>
-    <div>TruvaG3™ and TruvaAgents™ are trademarks of <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>.</div>
+    <div>TruvaG3™ is a trademark of <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>.</div>
   </div>
 </footer>
 

--- a/www/whitepapers/index.html
+++ b/www/whitepapers/index.html
@@ -258,7 +258,7 @@
       <a href="https://github.com/truvaagents/truva-g3/blob/main/LICENSE">License (Apache 2.0)</a>
     </div>
     <div>© 2025–2026 <a href="https://github.com/itsneelabh">Neelabh Tripathi</a> · TruvaG3. Licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</div>
-    <div>TruvaG3™ and TruvaAgents™ are trademarks of <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>.</div>
+    <div>TruvaG3™ is a trademark of <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>.</div>
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary
- Remove `TruvaAgents™` from the footer trademark line in `www/index.html`, `www/blogs/index.html`, `www/whitepapers/index.html`, and `docs-site/docusaurus.config.ts`.
- Footer now reads: "TruvaG3™ is a trademark of Neelabh Tripathi."

## Test plan
- [x] Confirm footer trademark line on landing, blogs, and whitepapers pages
- [x] Confirm footer trademark line on Docusaurus docs-site