### PR TITLE
Publish 3 whitepapers, agentic-memory blog, and pipeline-hooks guide

### DIFF
--- a/docs/orchestration/PIPELINE_HOOKS_GUIDE.md
+++ b/docs/orchestration/PIPELINE_HOOKS_GUIDE.md
@@ -1,0 +1,563 @@
+# Pipeline Hooks Guide
+
+The extension points that let you inject context, short-circuit work, and post-process responses at every stage of the orchestration pipeline — without forking the framework.
+
+> **Working Example**
+>
+> The hooks described here are exercised by several shipped agents:
+> - **Memory-backed Q&A**: [`examples/qa-agent/`](https://github.com/truvaagents/truva-g3/tree/main/examples/qa-agent) (search for `BuildMemoryHooks`)
+> - **Per-user memory in chat**: [`examples/travel-chat-agent/`](https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent) (search for `BuildUserMemoryHooks`)
+> - **DevOps chat + activity coordination**: [`examples/devops-chat-agent/`](https://github.com/truvaagents/truva-g3/tree/main/examples/devops-chat-agent)
+>
+> If you want a scenario-first cookbook (RAG, semantic caching, guardrails) rather than this mechanism reference, read [Adding Context to Your Agent](../building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md) alongside this guide.
+
+## Table of Contents
+
+1. [Why This Guide Exists](#1-why-this-guide-exists)
+2. [What Are Pipeline Hooks?](#2-what-are-pipeline-hooks)
+3. [The Pipeline Lifecycle](#3-the-pipeline-lifecycle)
+4. [The Hook Stages](#4-the-hook-stages)
+5. [PipelineContext and Enrichments](#5-pipelinecontext-and-enrichments)
+6. [Short-Circuiting the Pipeline](#6-short-circuiting-the-pipeline)
+7. [Writing Your Own Hook](#7-writing-your-own-hook)
+8. [Registering Hooks](#8-registering-hooks)
+9. [Execution Semantics and Guarantees](#9-execution-semantics-and-guarantees)
+10. [Built-in Hooks Reference](#10-built-in-hooks-reference)
+11. [Testing Hooks](#11-testing-hooks)
+12. [Design Decisions and Trade-offs](#12-design-decisions-and-trade-offs)
+13. [Troubleshooting](#13-troubleshooting)
+14. [Further Reading](#14-further-reading)
+
+---
+
+## 1. Why This Guide Exists
+
+Out of the box, a TruvaG3 orchestrator does four things in sequence: it **plans** (asks an LLM which tools to call), **executes** those tools, **synthesizes** a final answer, and returns it. That loop is intentionally closed — it has no opinion about your knowledge base, your conversation history, your cache, or your content policy.
+
+Pipeline hooks are how you open that loop *without touching framework internals*. They let you:
+
+- Inject retrieved context (RAG, memory, conversation history) into the prompt **before** the planner runs.
+- Return a cached answer and skip the entire pipeline (**short-circuit**).
+- Record execution outcomes to memory or analytics **after** tools finish.
+- Filter, redact, or log the final response **after** synthesis.
+
+Memory is the framework's most prominent consumer of hooks — but it has no privileged status. Everything memory does, your own code can do through the same interfaces. This guide documents the mechanism itself: the contracts, where each stage fires, how data flows into the prompt, and the sharp edges to avoid.
+
+> **Who this is for**
+>
+> Developers wiring custom context into an agent, or anyone debugging why a hook didn't fire (or fired but didn't reach the LLM). If you just want to add RAG or caching from a recipe, start with [Adding Context to Your Agent](../building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md) and return here when you need the underlying detail.
+
+---
+
+## 2. What Are Pipeline Hooks?
+
+A pipeline hook is **per-stage middleware**: a small object that the orchestrator calls at a defined point in the request lifecycle. Every hook implements the base `core.PipelineHook` interface — a single `Name()` method used for logging and telemetry span names — plus **one or more** stage-specific interfaces.
+
+```go
+// core/interfaces.go
+type PipelineHook interface {
+    Name() string
+}
+```
+
+There are four stage interfaces. A single hook type can implement as many as it wants; the orchestrator discovers what a hook supports via type assertion at each stage, so partial implementations are normal and expected.
+
+| Hook Stage | When It Runs | Can Mutate? | Can Short-Circuit? | Wired in live path? |
+|---|---|---|---|---|
+| `BeforePlanningHook` | Before the planning phase begins | Enrichments | **Yes** — skips the entire pipeline | Yes |
+| `AfterPlanningHook` | After the LLM produces an execution plan | The plan | No | **No — see §4.2** |
+| `AfterExecutionHook` | After all tools finish executing | No (observe-only) | No | Yes |
+| `AfterSynthesisHook` | After the LLM synthesizes the final response | Response text | No | Yes |
+
+Two properties define the whole system and are worth committing to memory:
+
+- **Hooks fail open.** If a hook returns an error, the orchestrator logs a warning and continues. A failing hook never aborts the request. This is deliberate: context injection is an enhancement, not a dependency.
+- **Hooks run sequentially, in registration order.** There is no concurrent access to the shared context object, so hooks can read and write it without locking.
+
+---
+
+## 3. The Pipeline Lifecycle
+
+Here is where each stage fires relative to the orchestrator's core work. The single `PipelineContext` object (§5) threads through every stage of a request.
+
+```
+Request
+  │
+  ▼
+┌─────────────────────────────────────────────┐
+│  prepareKnownEnrichments()                    │  ← auto-promotes conversation_history /
+│                                               │     rag_context from Metadata (no hook needed)
+└───────────────────────┬───────────────────────┘
+                        ▼
+┌─────────────────────────────────────────────┐
+│  BeforePlanningHook(s)                        │  ← inject RAG / memory / history into Enrichments
+│  ▶ may return PipelineShortCircuit ───────────┼──▶ skip everything, return cached Response
+└───────────────────────┬───────────────────────┘
+                        │  Enrichments copied into ctx via WithPipelineEnrichments()
+                        ▼
+┌─────────────────────────────────────────────┐
+│  Planning (LLM call)                          │  ← prompt builder reads enrichments back out
+└───────────────────────┬───────────────────────┘
+                        ▼
+              [ AfterPlanningHook(s) ]             ← DEFINED but NOT invoked (see §4.2)
+                        ▼
+┌─────────────────────────────────────────────┐
+│  Execution (tool calls, possibly multi-phase) │
+└───────────────────────┬───────────────────────┘
+                        ▼
+┌─────────────────────────────────────────────┐
+│  AfterExecutionHook(s)                        │  ← record outcomes to memory / analytics
+└───────────────────────┬───────────────────────┘
+                        ▼
+┌─────────────────────────────────────────────┐
+│  Synthesis (LLM call)                         │
+└───────────────────────┬───────────────────────┘
+                        ▼
+┌─────────────────────────────────────────────┐
+│  AfterSynthesisHook(s)                        │  ← guardrails, redaction, memory write-back
+└───────────────────────┬───────────────────────┘
+                        ▼
+                     Response
+```
+
+The call sites live in `orchestration/orchestrator.go`: the non-streaming path runs `BeforePlanning` → `AfterExecution` → `AfterSynthesis` around lines 2956–3018, and the streaming path mirrors it around lines 3271–3513. The runners themselves are in `orchestration/pipeline_hooks.go`.
+
+> **Streaming caveat**
+>
+> On the streaming path, tokens are sent to the client *during* synthesis. By the time `AfterSynthesis` hooks run, the user has already seen the text. The returned (possibly mutated) string updates the final `OrchestratorResponse.Response` for recording purposes, but **it cannot un-stream what was already delivered**. If you need to *block* content before the user sees it, do it in a `BeforePlanning` hook, in a guarded prompt builder, or use the non-streaming path. See `orchestrator.go:3510-3513`.
+
+---
+
+## 4. The Hook Stages
+
+All four contracts are defined in `core/interfaces.go:264-301`. Each embeds `PipelineHook`.
+
+### 4.1 BeforePlanningHook
+
+```go
+// core/interfaces.go
+type BeforePlanningHook interface {
+    PipelineHook
+    BeforePlanning(ctx context.Context, pctx *PipelineContext) (*PipelineShortCircuit, error)
+}
+```
+
+Runs before the planner sees the prompt. This is the **only** stage that can both **enrich** (write into `pctx.Enrichments`) and **short-circuit** (return a non-nil `*PipelineShortCircuit` to skip the rest of the pipeline). It is where RAG retrieval, memory recall, conversation-history injection, and semantic-cache lookups belong.
+
+Return `(nil, nil)` for the common "I added some context, carry on" case. Return a non-nil short-circuit only when you have a complete answer and want to bypass planning, execution, and synthesis entirely (§6).
+
+### 4.2 AfterPlanningHook
+
+```go
+// core/interfaces.go
+type AfterPlanningHook interface {
+    PipelineHook
+    AfterPlanning(ctx context.Context, pctx *PipelineContext, plan interface{}) (interface{}, error)
+}
+```
+
+> **Not yet wired into the live request path**
+>
+> `AfterPlanningHook` is a defined, type-checkable contract, and the runner `runAfterPlanningHooks` exists in `orchestration/pipeline_hooks.go:188` — but it has **zero call sites in the production execution path** (it is retained for tests, hence the `//nolint:unused` marker above it). A hook implementing `AfterPlanning` will compile and register without error, but **it will never be invoked during a real request today**. Don't build behavior that depends on it. We document it here so the contract is discoverable and so you aren't surprised when your `AfterPlanning` hook appears dead.
+
+When/if it is wired, the design intent is plan inspection and mutation: each hook receives the current plan and returns a possibly-modified one, chained hook-to-hook.
+
+### 4.3 AfterExecutionHook
+
+```go
+// core/interfaces.go
+type AfterExecutionHook interface {
+    PipelineHook
+    AfterExecution(ctx context.Context, pctx *PipelineContext, results interface{}) error
+}
+```
+
+Runs after all tool execution (including multi-phase loops) completes, before synthesis. It receives the combined execution result and returns only an `error` — there is **no way to change `results`**. This is an **observe-only** stage: record the outcome to memory, emit metrics, log to an analytics pipeline. The built-in `MemoryRecordHook` lives here.
+
+### 4.4 AfterSynthesisHook
+
+```go
+// core/interfaces.go
+type AfterSynthesisHook interface {
+    PipelineHook
+    AfterSynthesis(ctx context.Context, pctx *PipelineContext, response string) (string, error)
+}
+```
+
+Runs after the final response is synthesized. It receives the response string and returns a possibly-modified one; the output of one hook is fed as input to the next (**chaining**, §9). Use it for guardrails, PII redaction, response logging, and memory/knowledge write-back. Mind the **Streaming caveat** blockquote in [§3](#3-the-pipeline-lifecycle) — on the streaming path the mutation is post-hoc.
+
+---
+
+## 5. PipelineContext and Enrichments
+
+### 5.1 The context object
+
+Every stage receives the same `*PipelineContext` for the request:
+
+```go
+// core/interfaces.go:251-255
+type PipelineContext struct {
+    Request     string                 // the raw user request
+    Metadata    map[string]interface{} // caller-supplied request metadata (user_id, session, turns…)
+    Enrichments map[string]interface{} // the scratchpad hooks write into to reach the prompt
+}
+```
+
+- **`Request`** — the original user query, read-only in practice.
+- **`Metadata`** — whatever the caller attached to the request (e.g. `user_id`, conversation turns, session keys). Hooks *read* from this to decide what to do.
+- **`Enrichments`** — a mutable map, initialized empty by the orchestrator. A `BeforePlanning` hook *writes* into it; the orchestrator then makes it available to the prompt builder.
+
+### 5.2 How enrichments reach the LLM
+
+This is the part that trips people up: writing to `pctx.Enrichments` is necessary but the magic that carries it into the prompt is a two-step handoff.
+
+```
+BeforePlanning hook        orchestrator                    prompt builder
+─────────────────────      ─────────────────────────       ────────────────────────
+pctx.Enrichments[key]  ──▶  ctx = core.WithPipeline    ──▶  enrichments :=
+   = value                  Enrichments(ctx,                core.GetPipelineEnrichments(ctx)
+                            pctx.Enrichments)                → emits <agent_memory>, etc.
+```
+
+1. Your hook writes `pctx.Enrichments[core.EnrichmentRAGContext] = "...retrieved docs..."`.
+2. After `BeforePlanning` hooks finish, the orchestrator copies the map into the Go context: `ctx = core.WithPipelineEnrichments(ctx, pctx.Enrichments)` (`orchestrator.go:2960`). The helpers are in `core/context.go:10-19`.
+3. The prompt builder reads it back via `core.GetPipelineEnrichments(ctx)` and emits known keys as tagged sections of the planning prompt (`orchestrator.go:5229-5258`).
+
+> **Default builder vs. custom `PromptBuilder`**
+>
+> The two routes to the prompt are the same map seen from two surfaces. The **default** builder calls `core.GetPipelineEnrichments(ctx)` itself and renders the well-known keys below. If you supply a **custom `PromptBuilder`**, the orchestrator hands it the identical enrichment map as `PromptInput.Metadata` (`orchestrator.go:5199`) — so your builder reads `input.Metadata[core.EnrichmentRAGContext]` rather than calling the context helper. [Adding Context to Your Agent](../building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md) documents the `PromptInput.Metadata` path; this guide documents the default-builder path. They are the same data.
+
+### 5.3 Well-known enrichment keys
+
+The default prompt builder recognizes four keys. Using these keys means your injected context reaches the LLM with zero extra wiring:
+
+| Constant | String value | Rendered as | Typical writer |
+|---|---|---|---|
+| `core.EnrichmentRAGContext` | `"rag_context"` | wrapped in `<agent_memory>…</agent_memory>` | RAG / `MemoryEnrichmentHook` |
+| `core.EnrichmentConversationHistory` | `"conversation_history"` | wrapped in `<conversation_history>…</conversation_history>` | chat history |
+| `core.EnrichmentActivityCoordination` | `"activity_coordination"` | wrapped in `<agent_coordination>…</agent_coordination>` | `ActivityAnnouncementHook` |
+| `core.EnrichmentUserProfile` | `"user_profile"` | **inserted verbatim** — no tag wrapping | `UserMemoryEnrichmentHook` |
+
+The first three are defined at `core/interfaces.go:258-262`; `EnrichmentUserProfile` at `core/interfaces.go:932`. Three are wrapped in their own XML section by the builder; `user_profile` is the exception — the builder writes it **as-is** (`default_prompt_builder.go:284-288`), so a custom user-profile hook must supply its own preformatted `<user_profile>…</user_profile>` block, exactly as `UserMemoryEnrichmentHook` does.
+
+> **Custom keys: enrichments are the only channel**
+>
+> You can put *any* key into `Enrichments`, but only these four are rendered by the default builder — a custom key needs a custom `PromptBuilder` to read it (§5.2). The asymmetry worth remembering: auto-promotion (§5.4) only lifts `conversation_history` and `rag_context` out of request `Metadata`, so putting an arbitrary key in request **metadata** does **nothing** unless a hook copies it into `pctx.Enrichments`.
+
+> **Note: enrichments survive multi-phase planning**
+>
+> Enrichments are set once, before the first planning call, and stored in `ctx`. When the orchestrator runs continuation phases (Phase 2+), the continuation-prompt builder re-reads `GetPipelineEnrichments(ctx)` and re-emits the same sections (`orchestrator.go:5500-5535`). You inject once; every phase sees it.
+
+### 5.4 Auto-promotion: the zero-hook path
+
+Before any hook runs, the orchestrator calls `prepareKnownEnrichments` (`orchestration/pipeline_hooks.go:40-70`). It copies `conversation_history` and `rag_context` straight out of `Metadata` into `Enrichments`, and runs conversation turns through the configured `ConversationHistoryPreparer`. The practical consequence:
+
+> If you can attach your context as request **metadata**, you may not need a hook at all. Pass `metadata[core.EnrichmentRAGContext]` (or conversation turns via `metadata[orchestration.MetadataConversationTurns]`) and the framework promotes it for you. Hooks run *after* this step, so a `BeforePlanning` hook can still override or augment the prepared values. Reach for a hook when retrieval requires logic (a vector query, a cache lookup) rather than data you already hold.
+
+---
+
+## 6. Short-Circuiting the Pipeline
+
+A `BeforePlanning` hook can end the request immediately by returning a non-nil `*PipelineShortCircuit`:
+
+```go
+// core/interfaces.go:298-301
+type PipelineShortCircuit struct {
+    Response string // the pre-computed answer to return to the caller
+    Source   string // a label for metrics, e.g. "semantic_cache"
+}
+```
+
+When a hook returns one:
+
+- The orchestrator **stops running further `BeforePlanning` hooks** — the first short-circuit wins.
+- Planning, execution, and synthesis are **all skipped**.
+- A complete `OrchestratorResponse` is built from the short-circuit, with `Confidence: 1.0` and any already-injected enrichments merged into the response metadata (`buildShortCircuitResponse`, `pipeline_hooks.go:13-35`).
+- A `pipeline.hook.short_circuit` metric is recorded with your `Source` label.
+- On the streaming path, the cached response is chunked and streamed to preserve the streaming contract (`orchestrator.go:3273-3294`).
+
+The canonical use case is a **semantic cache**: hash or embed the request, look for a hit, and return the cached answer without paying for an LLM round trip. None of the *shipped* hooks short-circuit — it's a capability reserved for your caches.
+
+```go
+func (h *SemanticCacheHook) BeforePlanning(ctx context.Context, pctx *core.PipelineContext) (*core.PipelineShortCircuit, error) {
+    hit, ok, err := h.cache.Lookup(ctx, pctx.Request)
+    if err != nil {
+        return nil, err // fail open — logged & skipped, pipeline continues normally
+    }
+    if !ok {
+        return nil, nil // cache miss — carry on with planning
+    }
+    return &core.PipelineShortCircuit{Response: hit, Source: "semantic_cache"}, nil
+}
+```
+
+---
+
+## 7. Writing Your Own Hook
+
+A hook is any struct with a `Name()` method plus at least one stage method. Nothing else is required — no registration interface, no base class to embed.
+
+### 7.1 The smallest possible hook
+
+This is the minimal shape — a `BeforePlanning` hook that injects a static enrichment. (It mirrors the `enrichmentHook` test helper in `pipeline_hooks_test.go:87-97`.)
+
+```go
+package hooks
+
+import (
+    "context"
+
+    "github.com/truvaagents/truva-g3/core"
+)
+
+type StaticEnrichmentHook struct {
+    key   string
+    value interface{}
+}
+
+func (h *StaticEnrichmentHook) Name() string { return "static-" + h.key }
+
+func (h *StaticEnrichmentHook) BeforePlanning(ctx context.Context, pctx *core.PipelineContext) (*core.PipelineShortCircuit, error) {
+    pctx.Enrichments[h.key] = h.value
+    return nil, nil
+}
+```
+
+### 7.2 A realistic RAG hook
+
+A `BeforePlanning` hook that queries a vector store and injects the results under the well-known RAG key, so the default prompt builder renders them as `<agent_memory>`:
+
+```go
+// rag_hook.go
+package hooks
+
+import (
+    "context"
+    "fmt"
+    "strings"
+
+    "github.com/truvaagents/truva-g3/core"
+)
+
+type RAGHook struct {
+    retriever VectorRetriever // your interface: Search(ctx, query) ([]Doc, error)
+    topK      int
+    logger    core.Logger
+}
+
+func NewRAGHook(retriever VectorRetriever, topK int) *RAGHook {
+    return &RAGHook{retriever: retriever, topK: topK}
+}
+
+func (h *RAGHook) Name() string { return "rag-retriever" }
+
+func (h *RAGHook) BeforePlanning(ctx context.Context, pctx *core.PipelineContext) (*core.PipelineShortCircuit, error) {
+    docs, err := h.retriever.Search(ctx, pctx.Request)
+    if err != nil {
+        return nil, fmt.Errorf("rag search: %w", err) // fail open
+    }
+    if len(docs) == 0 {
+        return nil, nil
+    }
+
+    var b strings.Builder
+    for i, d := range docs {
+        if i >= h.topK {
+            break
+        }
+        fmt.Fprintf(&b, "- %s\n", d.Text)
+    }
+    // Well-known key → rendered as <agent_memory> in the planning prompt.
+    pctx.Enrichments[core.EnrichmentRAGContext] = b.String()
+    return nil, nil
+}
+
+// SetLogger is optional — the factory injects the framework logger if present.
+func (h *RAGHook) SetLogger(l core.Logger) { h.logger = l }
+```
+
+### 7.3 A guardrail hook
+
+An `AfterSynthesis` hook that redacts the response. Remember the streaming caveat — on streaming paths this is post-hoc.
+
+```go
+func (h *RedactionHook) Name() string { return "pii-redaction" }
+
+func (h *RedactionHook) AfterSynthesis(ctx context.Context, pctx *core.PipelineContext, response string) (string, error) {
+    return h.redactor.Scrub(response), nil
+}
+```
+
+> **Optional setter interfaces**
+>
+> If your hook implements any of `SetLogger(core.Logger)`, `SetTelemetry(core.Telemetry)`, or `SetLLMDebugStore(LLMDebugStore)`, the factory detects them by type assertion and injects the framework's instances after registration (`factory.go:364-384`). These are entirely optional — implement them only if your hook needs to log, trace, or record LLM calls.
+
+> **Tip: assert the contract at compile time**
+>
+> Because stages are discovered by type assertion, a typo in a method signature fails silently — your hook compiles, registers, and is simply skipped at runtime. Add a compile-time assertion so the mismatch becomes a build error instead. Several built-in hooks do this (e.g. `ConversationHistoryHook`, `UserMemoryEnrichmentHook`):
+>
+> ```go
+> var _ core.BeforePlanningHook = (*RAGHook)(nil)
+> ```
+
+---
+
+## 8. Registering Hooks
+
+> **Registration is factory-only.** There is no framework-level `WithHooks` option. Hooks are attached through `OrchestratorDependencies.PipelineHooks` when you create the orchestrator. (`framework.go` exposes config options but nothing about pipeline hooks.)
+
+### 8.1 The direct path
+
+```go
+deps := orchestration.OrchestratorDependencies{
+    Discovery:           discovery,
+    AIClient:            agent.AI,
+    Logger:              agent.Logger,
+    Telemetry:           telemetry.GetTelemetryProvider(),
+    PipelineHooks:       []core.PipelineHook{ // ← registration order = execution order
+        NewSemanticCacheHook(cache), // BeforePlanning (may short-circuit)
+        NewRAGHook(retriever, 5),     // BeforePlanning (enrich)
+        &RedactionHook{redactor: r},  // AfterSynthesis
+    },
+}
+
+orch, err := orchestration.CreateOrchestrator(config, deps)
+```
+
+The factory assigns the slice to the orchestrator and runs the optional-setter injection described in §7 (`factory.go:354-385`). This is exactly what [`examples/qa-agent/qa_agent.go:220-230`](https://github.com/truvaagents/truva-g3/blob/main/examples/qa-agent/qa_agent.go) does.
+
+### 8.2 The builder path (memory)
+
+You rarely assemble memory hooks by hand. The `BuildMemoryHooks` builder returns a ready-ordered `[]core.PipelineHook` (announcement → enrichment → record → knowledge-extraction → cleanup) plus an `ActivityCoordinator`, gated on which backends you configured:
+
+```go
+// examples/qa-agent/main.go
+memHooks, activityCoord := orchestration.BuildMemoryHooks(
+    memBackends.ToDeps(), agent.AI, agent.Logger,
+)
+// …then later…
+deps.PipelineHooks = memHooks
+deps.ActivityCoordinator = activityCoord
+```
+
+For per-user memory, `BuildUserMemoryHooks` plays the same role — see [`examples/travel-chat-agent/chat_agent.go`](https://github.com/truvaagents/truva-g3/blob/main/examples/travel-chat-agent/chat_agent.go). Behavioral knobs (lookback window, retrieval weights, entity extractor) are passed as options to the builder; see [Adding Context to Your Agent](../building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md) and the [Agent Memory User Guide](../memory-and-chat/AGENT_MEMORY_USER_GUIDE.md).
+
+> **Mixing custom and built-in hooks**
+>
+> `PipelineHooks` is a flat slice, and slice order is execution order. **Append** enrichment hooks to the builder's output — your RAG hook and `MemoryEnrichmentHook` both run at `BeforePlanning`, each accumulating into `Enrichments`. But **prepend** a short-circuiting cache hook if you want it to pre-empt the builder's (expensive) enrichment hooks: the first `BeforePlanning` hook to short-circuit wins (§9).
+
+---
+
+## 9. Execution Semantics and Guarantees
+
+The runners in `orchestration/pipeline_hooks.go` all share one shape: iterate `pipelineHooks` in order, type-assert to the stage interface (skip hooks that don't implement it), open a telemetry span named `pipeline.hook.<stage>.<Name()>`, call the hook.
+
+**Ordering.** Hooks fire in registration (slice) order within a stage. A hook that implements multiple stages is invoked once per stage, at the appropriate point in the lifecycle.
+
+**Type filtering.** Implementing `BeforePlanningHook` does not obligate you to implement the others. At each stage the runner does `h, ok := hook.(core.AfterSynthesisHook)` and silently skips non-matching hooks. This is why partial hooks are idiomatic.
+
+**Fail-open resilience.** Every runner handles a hook error identically: log `"Pipeline hook failed, skipping"` with the hook name and `continue`. One bad hook never aborts the request and never prevents later hooks from running. If your hook's work is *mandatory* (e.g. a hard compliance gate), a hook is the wrong place — enforce it at a layer that can reject the request.
+
+**Mutation chaining.** `AfterSynthesis` (and the not-yet-wired `AfterPlanning`) chain: the output of hook *N* is the input to hook *N+1*. Order matters. `AfterExecution` is observe-only and `BeforePlanning` accumulates into the shared `Enrichments` map, so neither "chains" a return value.
+
+**Short-circuit precedence.** The first `BeforePlanning` hook to return a non-nil short-circuit wins; subsequent `BeforePlanning` hooks are not called. Put your cache hook early if you want it to pre-empt expensive enrichment hooks.
+
+**Telemetry.** Each hook invocation is wrapped in its own span (when a telemetry provider is configured), so you can see in a trace exactly which hooks ran and how long each took — e.g. `pipeline.hook.before_planning.rag-retriever`. Errors are recorded on the span. See the [Distributed Tracing Guide](../observability/DISTRIBUTED_TRACING_GUIDE.md).
+
+**Concurrency.** Hooks for a single request run sequentially with no concurrent access to `PipelineContext` (`core/interfaces.go:250`), so you don't need locks around reads/writes of `Enrichments`. Hooks across *different* requests run on different `PipelineContext` instances; any shared state *your* hook holds (a cache client, a retriever) must be safe for concurrent use.
+
+---
+
+## 10. Built-in Hooks Reference
+
+These ship in the `orchestration` module and are the best worked examples to read. Most are assembled for you by `BuildMemoryHooks` / `BuildUserMemoryHooks` (§8.2) — the exception is `ConversationHistoryHook`, which you construct directly via `NewConversationHistoryHook` and add to the slice yourself (the builders do not wire conversation history). None of them short-circuit.
+
+| Type | File | Stage | What it does |
+|---|---|---|---|
+| `MemoryEnrichmentHook` | `orchestration/memory_hooks.go:176` | `BeforePlanning` | Extracts entities from the request, queries shared episodic memory, and **appends** recent/related domain events into `Enrichments[EnrichmentRAGContext]`. Read/enrich. |
+| `MemoryRecordHook` | `orchestration/memory_hooks.go:718` | `AfterExecution` | Records the completed execution (entities, outcome, importance) into episodic memory. Write/record. |
+| `UserMemoryEnrichmentHook` | `orchestration/user_memory_hooks.go:27` | `BeforePlanning` | Reads `Metadata["user_id"]`; recalls per-user identity and query-relevant facts into `Enrichments[EnrichmentUserProfile]`. No-ops without a user ID. |
+| `UserMemoryExtractionHook` | `orchestration/user_memory_extraction.go:59` | `AfterSynthesis` | Extracts durable user facts from request+response via LLM and stores them per-user. Returns the response unchanged. Async or sync. |
+| `KnowledgeExtractionHook` | `orchestration/knowledge_extraction_hook.go:24` | `AfterSynthesis` | Asks an LLM for 0–3 reusable knowledge fragments, embeds and stores them. Runs in a goroutine; never mutates the response. |
+| `ConversationHistoryHook` | `orchestration/conversation_history_hook.go:15` | `BeforePlanning` | Adapter that injects memory-backed conversation history into `Enrichments[EnrichmentConversationHistory]`. Constructed manually via `NewConversationHistoryHook` — not wired by the builders. (For raw turns, prefer the metadata path in §5.4.) |
+| `ActivityAnnouncementHook` | `orchestration/activity_hooks.go:52` | `BeforePlanning` | Announces this agent's activity to the coordinator and injects concurrent activities into `Enrichments[EnrichmentActivityCoordination]`. |
+| `ActivityCleanupHook` | `orchestration/activity_hooks.go:228` | `AfterSynthesis` | Clears this agent's announced activity signal after the response. Pass-through. |
+
+Notice the symmetry: the `BeforePlanning` hooks **read/enrich**, the `AfterExecution`/`AfterSynthesis` hooks **write/record**. Several also declare the compile-time conformance assertion recommended in [§7](#7-writing-your-own-hook) — a habit worth adopting in your own hooks.
+
+---
+
+## 11. Testing Hooks
+
+This section covers unit-testing a hook in isolation. For diagnosing a hook that misbehaves inside a *running* agent (didn't fire, fired but didn't reach the LLM), jump to [§13 Troubleshooting](#13-troubleshooting).
+
+Hooks are plain structs, so they're trivial to unit-test in isolation: construct a `*core.PipelineContext`, call the stage method, assert on the returned value and the mutated `Enrichments`.
+
+```go
+func TestRAGHook_InjectsContext(t *testing.T) {
+    h := NewRAGHook(stubRetriever{docs: []Doc{{Text: "Paris is the capital of France."}}}, 5)
+    pctx := &core.PipelineContext{
+        Request:     "What is the capital of France?",
+        Metadata:    map[string]interface{}{},
+        Enrichments: map[string]interface{}{},
+    }
+
+    sc, err := h.BeforePlanning(context.Background(), pctx)
+    require.NoError(t, err)
+    require.Nil(t, sc) // no short-circuit
+    require.Contains(t, pctx.Enrichments[core.EnrichmentRAGContext], "Paris")
+}
+```
+
+The framework's own contract tests are worth reading as a reference for expected behavior — `orchestration/pipeline_hooks_test.go` proves type filtering (only matching hooks fire), short-circuit precedence (first wins, rest skipped), and fail-open error handling (an erroring hook is logged and skipped). The file also contains compact exemplar hooks:
+
+- `enrichmentHook` (`:87-97`) — the minimal one-stage hook shown in §7.
+- `allStagesHook` (`:33-84`) — implements all four stages with call counters and injectable errors/mutations; a good template for an exhaustive test double.
+- `beforeOnlyHook` (`:100-109`) — demonstrates the partial-implementation pattern.
+
+There is no exported NoOp hook in non-test code; if you want one for tests, the `enrichmentHook` shape above is the smallest thing that compiles. To stub a hook's *dependencies* (an embedding client, a memory backend), the `core` module ships `NoOp*` and `Mock*` doubles — see [Adding Context to Your Agent §11](../building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md) for the conventions.
+
+---
+
+## 12. Design Decisions and Trade-offs
+
+**Why per-stage interfaces instead of one big callback?** Type assertion lets a hook declare exactly the stages it cares about. A guardrail hook implements only `AfterSynthesis`; the orchestrator skips it everywhere else with no boilerplate on your side. It also keeps each method signature honest about what data is available and what can change at that point.
+
+**Why do hooks fail open?** Context injection is an enhancement. A vector store being briefly unreachable should degrade the answer's quality, not turn the request into a 500. If you need hard enforcement, the hook layer is the wrong layer — reject at the API boundary instead.
+
+**Why can only `BeforePlanning` short-circuit?** Short-circuiting means "I already have the answer, skip the work." That only makes sense before any work has happened. After planning or execution, you've already paid the cost, so there's nothing to save.
+
+**Why is `AfterExecution` observe-only?** Letting a hook rewrite raw tool results mid-pipeline invites subtle, hard-to-trace corruption of the data the synthesizer reasons over. Recording and metrics are safe; mutation is intentionally withheld. Shape the *response* in `AfterSynthesis` instead.
+
+**Why metadata auto-promotion *and* hooks?** Two audiences. Simple agents that already hold the context (chat turns, a precomputed snippet) shouldn't have to write a hook — they pass metadata. Agents that must *compute* context (a vector query, a cache lookup) need code, and that's a hook. The two compose: auto-promotion runs first, hooks can override.
+
+---
+
+## 13. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Hook never runs | Not in `deps.PipelineHooks`, or doesn't implement the stage interface you expect | Confirm it's in the slice and that the method signature exactly matches the interface (pointer vs value receiver matters for the type assertion) |
+| `AfterPlanning` hook never fires | `AfterPlanning` is not wired into the live path (§4.2) | Use a different stage; don't depend on `AfterPlanning` today |
+| Enrichment set but LLM ignores it | Wrong key, or a custom `PromptBuilder` that doesn't read enrichments | Use a well-known key (§5) with the default builder, or have your custom builder call `core.GetPipelineEnrichments(ctx)` |
+| Guardrail didn't block streamed text | `AfterSynthesis` runs after tokens stream | Move the check to `BeforePlanning`, a guarded prompt builder, or the non-streaming path |
+| Hook error silently swallowed | Fail-open by design — errors are logged at WARN and skipped | Check logs for `"Pipeline hook failed, skipping"`; enforce mandatory logic outside the hook layer |
+| Hook ran but its work was overwritten | Another hook later in the slice mutated the same enrichment key or chained response | Reorder the slice; remember `AfterSynthesis` chains and `BeforePlanning` shares one `Enrichments` map |
+| Can't find the hook in a trace | Telemetry provider not configured, or hook never matched its stage | Verify telemetry is initialized; look for span `pipeline.hook.<stage>.<name>` |
+
+To verify a hook fired, look in Jaeger for its span (`pipeline.hook.before_planning.<name>`) or grep agent logs for the hook name. The DAG/registry-viewer debug UI surfaces `BeforePlanning` activity under its **Pre-Execution** tab and `AfterSynthesis` activity under **Post-Execution** — see the [Dev Tools Guide](../operations/DEV_TOOLS_GUIDE.md).
+
+That's the whole surface: four stages, one shared context, fail-open semantics. Wire a hook, confirm its span shows up in a trace, and build out from there. Happy hooking!
+
+---
+
+## 14. Further Reading
+
+- [Adding Context to Your Agent](../building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md) — the scenario cookbook (RAG, semantic cache, conversation history, guardrails) built on these hooks
+- [Agent Memory User Guide](../memory-and-chat/AGENT_MEMORY_USER_GUIDE.md) — how the built-in memory hooks read and write shared episodic memory
+- [Conversation History Guide](../memory-and-chat/CONVERSATION_HISTORY_GUIDE.md) — the metadata path and `ConversationHistoryPreparer` referenced in §5
+- [Orchestration Modes Guide](ORCHESTRATION_MODES_GUIDE.md) — how planning, execution, and synthesis fit together
+- [Error Handling Guide](ERROR_HANDLING_GUIDE.md) — how hook errors flow through the resilient error-handling system
+- [Distributed Tracing Guide](../observability/DISTRIBUTED_TRACING_GUIDE.md) — each hook gets its own span (e.g. `pipeline.hook.before_planning.rag-retriever`)
+- [Dev Tools Guide](../operations/DEV_TOOLS_GUIDE.md) — Pre-Execution / Post-Execution tabs in the execution DAG viewer
+- [API Reference](../reference/API_REFERENCE.md) — `OrchestratorDependencies`, `CreateOrchestrator`, and the `PromptBuilder` contract

--- a/www/assets/css/landing.css
+++ b/www/assets/css/landing.css
@@ -700,6 +700,68 @@ section .lede {
   line-height: 1.5;
 }
 
+.read-group-heading {
+  margin: 28px 0 14px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.read-group-heading:first-of-type { margin-top: 24px; }
+
+.read-expand {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  interpolate-size: allow-keywords;
+}
+.read-expand > summary {
+  cursor: pointer;
+  list-style: none;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--brand-g3);
+  padding: 8px 14px;
+  border: 1px solid rgba(255, 160, 64, 0.35);
+  border-radius: 999px;
+  background: var(--bg-2);
+  transition: border-color .15s ease, filter .15s ease, background .15s ease;
+  order: 2;
+  align-self: flex-start;
+}
+.read-expand[open] > summary { margin-top: 14px; }
+.read-expand > summary::-webkit-details-marker { display: none; }
+.read-expand > summary:hover {
+  border-color: var(--brand-g3);
+  filter: brightness(1.1);
+}
+.read-expand .when-closed::before {
+  content: "▸";
+  display: inline-block;
+  margin-right: 6px;
+}
+.read-expand .when-open::before {
+  content: "▴";
+  display: inline-block;
+  margin-right: 6px;
+}
+.read-expand .when-open { display: none; }
+.read-expand[open] .when-closed { display: none; }
+.read-expand[open] .when-open { display: inline; }
+/* Fallback for browsers without ::details-content support */
+.read-expand[open] > .read-list { order: 1; margin-top: 0; }
+/* Modern browsers: animate the disclosure region via ::details-content */
+.read-expand::details-content {
+  order: 1;
+  block-size: 0;
+  overflow: hidden;
+  transition:
+    block-size 510ms cubic-bezier(0.65, 0, 0.35, 1),
+    content-visibility 510ms cubic-bezier(0.65, 0, 0.35, 1) allow-discrete;
+}
+.read-expand[open]::details-content { block-size: auto; }
+
 /* -------------------------------------------------------------------------
  * Footer
  * ------------------------------------------------------------------------- */

--- a/www/blogs/index.html
+++ b/www/blogs/index.html
@@ -132,6 +132,19 @@
 <section class="index-list">
   <div class="container">
 
+    <a class="index-entry" href="/blogs/truvag3-agentic-memory.html">
+      <p class="meta">Neelabh Tripathi · May 27, 2026</p>
+      <h2>Agentic Memory in TruvaG3: A Team With a Shared Notebook</h2>
+      <p class="dek">
+        A guided tour of TruvaG3's four-tier shared memory system — the
+        academic research it came from, the five pipeline hooks that wire
+        it into the orchestrator, how a fleet of agents stops repeating each
+        other's work, and how a single chat agent finally remembers what a
+        user said last week.
+      </p>
+      <span class="read-arrow">Read article →</span>
+    </a>
+
     <a class="index-entry" href="/blogs/truvag3-introduction.html">
       <p class="meta">Neelabh Tripathi · May 16, 2026</p>
       <h2>TruvaG3: An Introduction to the Microagents Framework</h2>

--- a/www/blogs/truvag3-agentic-memory.html
+++ b/www/blogs/truvag3-agentic-memory.html
@@ -1,0 +1,1526 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Agentic Memory in TruvaG3: A Team With a Shared Notebook</title>
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="stylesheet" href="/assets/css/site-nav.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css">
+<meta name="description" content="A guided tour of TruvaG3's four-tier agentic memory system — the research it came from, the five pipeline hooks that wire it in, and how a fleet of agents stops repeating each other's work.">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="TruvaG3">
+<meta property="og:title" content="Agentic Memory in TruvaG3: A Team With a Shared Notebook">
+<meta property="og:description" content="A guided tour of TruvaG3's four-tier agentic memory system — the research it came from, the five pipeline hooks that wire it in, and how a fleet of agents stops repeating each other's work.">
+<meta property="og:url" content="https://truvag3.dev/blogs/truvag3-agentic-memory">
+<meta property="og:image" content="https://truvag3.dev/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="TruvaG3 — Microagents Framework for Go">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Agentic Memory in TruvaG3: A Team With a Shared Notebook">
+<meta name="twitter:description" content="A guided tour of TruvaG3's four-tier agentic memory system — the research it came from, the five pipeline hooks that wire it in, and how a fleet of agents stops repeating each other's work.">
+<meta name="twitter:image" content="https://truvag3.dev/og-image.png">
+<style>
+  :root {
+    /* Dark theme — mirrored from truvag3-introduction so this article
+     * visually continues from the rest of truvag3.dev. */
+    --fg: #9aa6bd;
+    --muted: #9aa6bd;
+    --accent: #7cc4ff;
+    --rule: #2a3550;
+    --code-bg: #1a2236;
+    --aside-bg: #121826;
+    --aside-border: #C56710;
+    /* Per-memory-type accent palette used in the SVG figures.
+     * Each of the four shared-memory tiers + user memory gets its own
+     * hue so the reader can track a tier across multiple diagrams. */
+    --m-episodic: #f59e0b;      /* amber — events, recorded actions */
+    --m-coord:    #fbbf24;      /* yellow — transient locks */
+    --m-knowledge: #a78bfa;     /* purple — learned, semantic */
+    --m-reflect:  #34d399;      /* green — synthesis, distillation */
+    --m-user:     #7cc4ff;      /* blue — per-user, private */
+    --m-bad:      #f87171;      /* failure / duplicated work */
+  }
+  html {
+    background: radial-gradient(1200px 800px at 50% -10%, #1c2541 0%, #0b0f17 60%);
+    background-attachment: fixed;
+    min-height: 100vh;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    color: var(--fg);
+    line-height: 1.55;
+    font-weight: 400;
+    margin: 0;
+    background: transparent;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  article {
+    max-width: 760px;
+    margin: 2rem auto;
+    padding: 0 1.25rem;
+    font-size: 17px;
+  }
+  header.article-header {
+    border-bottom: 1px solid var(--rule);
+    padding-bottom: 1.25rem;
+    margin-bottom: 2rem;
+  }
+  header.article-header h1 {
+    font-size: 1.85rem;
+    line-height: 1.25;
+    margin: 0 0 0.6rem 0;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    width: fit-content;
+    max-width: 100%;
+    background: linear-gradient(90deg, #ffffff 0%, #7dd3fc 45%, #c4b5fd 90%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  header.article-header p.dek {
+    color: var(--muted);
+    font-size: 1.1rem;
+    margin: 0 0 0.8rem 0;
+    line-height: 1.45;
+  }
+  header.article-header .meta {
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+  h2 {
+    font-size: 1.35rem;
+    margin-top: 2.4rem;
+    margin-bottom: 0.6rem;
+    line-height: 1.3;
+    width: fit-content;
+    max-width: 100%;
+    background: linear-gradient(90deg, #ffffff 0%, #7dd3fc 60%, #c4b5fd 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  h3 {
+    font-size: 1.25rem;
+    margin-top: 1.8rem;
+    margin-bottom: 0.4rem;
+    color: #e6edf7;
+  }
+  p { margin: 0.7rem 0; }
+  p > strong:first-child,
+  li > strong:first-child {
+    font-weight: 600;
+    font-size: 0.95em;
+    color: var(--accent);
+  }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  /* ── Code blocks · IDE-style chrome ─────────────────────────────────
+   * Code blocks are styled to feel like a dark-theme editor pane:
+   *  - a faux titlebar at the top with three macOS-style traffic-light
+   *    dots, drawn with two pseudo-elements (no extra HTML required);
+   *  - a deeper near-black background that contrasts strongly with the
+   *    page's slate-blue body;
+   *  - VS Code Dark+ inspired token colors overriding Prism Tomorrow's
+   *    defaults so keywords, strings, comments, and types each show in
+   *    distinct, vibrant hues.
+   * Inline <code> remains subtle — a softly-tinted pill on the running
+   * prose, not chrome'd.
+   */
+  pre {
+    background: #0d1117;
+    color: #d4d4d4;
+    padding: 42px 18px 18px 18px;
+    overflow-x: auto;
+    border-radius: 10px;
+    font-size: 13px;
+    line-height: 1.6;
+    border: 1px solid #1f2937;
+    box-shadow: 0 1px 0 rgba(255,255,255,0.04) inset,
+                0 6px 20px rgba(0,0,0,0.35);
+    position: relative;
+    margin: 1.5rem 0;
+  }
+  /* Titlebar (gradient strip across the top of every code block) */
+  pre::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 30px;
+    background: linear-gradient(180deg, #21262d 0%, #161b22 100%);
+    border-bottom: 1px solid #1f2937;
+    border-radius: 10px 10px 0 0;
+  }
+  /* Three traffic-light dots inside the titlebar */
+  pre::after {
+    content: '';
+    position: absolute;
+    top: 10px; left: 14px;
+    width: 12px; height: 12px;
+    border-radius: 50%;
+    background: #ff5f57;
+    box-shadow:
+      18px 0 0 #febc2e,
+      36px 0 0 #28c840;
+  }
+  pre[class*="language-"] {
+    background: #0d1117;
+    border: 1px solid #1f2937;
+    border-radius: 10px;
+    padding: 42px 18px 18px 18px;
+    font-size: 13px;
+    line-height: 1.6;
+    text-shadow: none;
+  }
+  code[class*="language-"] {
+    text-shadow: none;
+    font-family: "JetBrains Mono", "SF Mono", Menlo, Monaco, "Courier New", monospace;
+    color: #d4d4d4;
+  }
+  code {
+    font-family: "JetBrains Mono", "SF Mono", Menlo, Monaco, "Courier New", monospace;
+    background: var(--code-bg);
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    font-size: 0.9em;
+    color: #cfe1ff;
+  }
+  pre code {
+    background: transparent;
+    padding: 0;
+    border-radius: 0;
+    font-size: inherit;
+    color: inherit;
+  }
+  /* VS Code Dark+ inspired token palette — overrides Prism Tomorrow's
+   * defaults to give every block the same editor-like color scheme.
+   * !important is used because Prism Tomorrow's own token rules ship with
+   * roughly equal specificity; without !important, whichever stylesheet
+   * loads later wins, which is fragile. With !important here, the palette
+   * is deterministic regardless of stylesheet load order. */
+  pre[class*="language-"] .token.comment,
+  pre[class*="language-"] .token.prolog,
+  pre[class*="language-"] .token.doctype,
+  pre[class*="language-"] .token.cdata        { color: #6a9955 !important; font-style: italic; }
+  pre[class*="language-"] .token.punctuation  { color: #d4d4d4 !important; }
+  pre[class*="language-"] .token.property,
+  pre[class*="language-"] .token.boolean,
+  pre[class*="language-"] .token.number,
+  pre[class*="language-"] .token.constant,
+  pre[class*="language-"] .token.symbol,
+  pre[class*="language-"] .token.deleted      { color: #b5cea8 !important; }
+  pre[class*="language-"] .token.selector,
+  pre[class*="language-"] .token.string,
+  pre[class*="language-"] .token.char,
+  pre[class*="language-"] .token.builtin,
+  pre[class*="language-"] .token.inserted     { color: #ce9178 !important; }
+  pre[class*="language-"] .token.operator,
+  pre[class*="language-"] .token.entity,
+  pre[class*="language-"] .token.url          { color: #d4d4d4 !important; }
+  pre[class*="language-"] .token.atrule,
+  pre[class*="language-"] .token.keyword      { color: #569cd6 !important; }
+  pre[class*="language-"] .token.function,
+  pre[class*="language-"] .token.class-name   { color: #dcdcaa !important; }
+  pre[class*="language-"] .token.regex,
+  pre[class*="language-"] .token.important,
+  pre[class*="language-"] .token.variable     { color: #9cdcfe !important; }
+  /* XML/HTML tag names and attribute names get their own treatment
+   * because Prism nests these tokens (e.g. <span class="token tag"><span
+   * class="token punctuation">&lt;</span><span class="token tag">name</span></span>).
+   * Targeting the leaf .tag and .attr-name is what colors them correctly. */
+  pre[class*="language-"] .token.tag,
+  pre[class*="language-"] .token.tag > .token.tag,
+  pre[class*="language-"] .token.tag .token.punctuation { color: #569cd6 !important; }
+  pre[class*="language-"] .token.attr-name              { color: #9cdcfe !important; }
+  pre[class*="language-"] .token.attr-value,
+  pre[class*="language-"] .token.attr-value .token.punctuation { color: #ce9178 !important; }
+  pre[class*="language-"] .token.namespace               { color: #4ec9b0 !important; opacity: 1; }
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1rem 0;
+    font-size: 0.95rem;
+  }
+  th, td {
+    border-bottom: 1px solid var(--rule);
+    padding: 0.55rem 0.7rem;
+    text-align: left;
+    vertical-align: top;
+  }
+  th {
+    background: var(--code-bg);
+    font-weight: 600;
+    color: #e6edf7;
+  }
+  aside.callout {
+    background: var(--aside-bg);
+    border-left: 3px solid var(--aside-border);
+    padding: 0.85rem 1.1rem;
+    margin: 1.4rem 0;
+    font-size: 0.95rem;
+    border-radius: 3px;
+  }
+  aside.callout strong { color: #e6edf7; }
+  ul, ol { padding-left: 1.4rem; }
+  li { margin: 0.3rem 0; }
+  /* Highlight inline emphasis with amber, like the intro blog. */
+  .highlight-amber { color: #FFA040; }
+
+  /* Figures use the whitepaper diagram convention: dark-on-dark cards
+   * with per-tier accent colors and animated dashed flow lines. */
+  figure { margin: 1.6rem 0; }
+  figure svg {
+    width: 100%;
+    height: auto;
+    display: block;
+    background: var(--code-bg);
+    border: 1px solid var(--rule);
+    border-radius: 10px;
+  }
+  figcaption {
+    color: var(--muted);
+    font-size: 0.85rem;
+    text-align: center;
+    margin-top: 0.4rem;
+    line-height: 1.5;
+  }
+  figcaption strong { color: var(--accent); font-weight: 600; }
+
+  /* Collapsible TOC — native <details>/<summary>; no JS. */
+  details.toc {
+    margin: 1.5rem 0 2.5rem;
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: 0.75rem 1.25rem;
+    background: var(--code-bg);
+  }
+  details.toc summary {
+    font-weight: 700;
+    font-size: 0.95rem;
+    cursor: pointer;
+    color: var(--accent);
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0;
+  }
+  details.toc summary::-webkit-details-marker { display: none; }
+  details.toc summary::before {
+    content: '▸';
+    display: inline-block;
+    transition: transform 0.15s ease;
+    color: var(--accent);
+    font-size: 0.85em;
+  }
+  details.toc[open] summary::before { transform: rotate(90deg); }
+  details.toc ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0.85rem 0 0.25rem;
+  }
+  details.toc > ul > li { margin: 0.5rem 0; }
+  details.toc > ul > li > a {
+    font-weight: 600;
+    font-size: 0.93rem;
+    color: var(--accent);
+    text-decoration: none;
+  }
+  details.toc ul ul {
+    margin: 0.35rem 0 0.6rem;
+    padding-left: 1.25rem;
+    border-left: 1px solid var(--rule);
+  }
+  details.toc ul ul li { margin: 0.25rem 0 0.25rem 0.5rem; }
+  details.toc ul ul a {
+    color: var(--muted);
+    font-size: 0.88rem;
+    font-weight: 400;
+    text-decoration: none;
+  }
+  details.toc a:hover { text-decoration: underline; color: #e6edf7; }
+
+  /* Tier-tag pills — used inline to label which memory tier a passage
+   * is about, color-coded to match the SVGs. */
+  .tier {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 1px 8px;
+    border-radius: 999px;
+    background: #19243d;
+    border: 1px solid var(--rule);
+    margin-right: 4px;
+    vertical-align: middle;
+  }
+  .tier.episodic  { color: var(--m-episodic);  border-color: rgba(245,158,11,.4); }
+  .tier.coord     { color: var(--m-coord);     border-color: rgba(251,191,36,.4); }
+  .tier.knowledge { color: var(--m-knowledge); border-color: rgba(167,139,250,.4); }
+  .tier.reflect   { color: var(--m-reflect);   border-color: rgba(52,211,153,.4); }
+  .tier.user      { color: var(--m-user);      border-color: rgba(124,196,255,.4); }
+
+  /* Cheat-sheet grid — small dark cards, mirrors whitepaper takeaways. */
+  .takeaways {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 14px;
+    margin: 1.4rem 0;
+  }
+  @media (max-width: 600px) { .takeaways { grid-template-columns: 1fr; } }
+  .ta {
+    background: var(--code-bg);
+    border: 1px solid var(--rule);
+    border-radius: 10px;
+    padding: 14px 16px;
+  }
+  .ta h4 { margin: 6px 0 6px; font-size: 14.5px; color: #e6edf7; }
+  .ta p { margin: 0; font-size: 13.5px; color: var(--fg); }
+  .ta .tag {
+    display: inline-block;
+    font-size: 10.5px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: #19243d;
+    color: #9fc2ff;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .footer-note {
+    margin-top: 3rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--rule);
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+  .copyright {
+    color: var(--muted);
+    font-size: 0.85rem;
+    text-align: center;
+    margin-top: 1.5rem;
+    margin-bottom: 0;
+  }
+
+  /* Animated dashed flow lines (whitepaper convention). */
+  @keyframes dash { to { stroke-dashoffset: -40; } }
+  .flow-line { stroke-dasharray: 6 6; animation: dash 4s linear infinite; }
+</style>
+</head>
+<body>
+<nav class="site-nav">
+  <div class="container">
+    <a class="nav-brand" href="/"><span class="brand-truva">Truva</span><span class="brand-g3">G3</span></a>
+    <div class="nav-links">
+      <a href="/blogs/">Blog</a>
+      <a href="/whitepapers/">Whitepapers</a>
+      <a href="https://docs.truvag3.dev/docs/intro/">Docs</a>
+      <a href="https://github.com/truvaagents/truva-g3">GitHub</a>
+    </div>
+  </div>
+</nav>
+
+
+<article>
+
+<header class="article-header">
+  <h1>Agentic Memory in TruvaG3: A Team With a Shared Notebook</h1>
+  <p class="dek">A guided tour of <a href="https://github.com/truvaagents/truva-g3">TruvaG3's</a> four-tier shared memory system — the academic research it came from, the five pipeline hooks that wire it into the orchestrator, how a fleet of agents stops repeating each other's work, and how a single chat agent finally remembers what a user said last week.</p>
+  <p class="meta">Neelabh Tripathi · May 27, 2026</p>
+</header>
+
+<details class="toc">
+  <summary>Contents</summary>
+  <ul>
+    <li><a href="#amnesia">The amnesia problem</a></li>
+    <li><a href="#research">Where the design came from</a>
+      <ul>
+        <li><a href="#research-survey">A survey, not a vector DB bolt-on</a></li>
+        <li><a href="#research-findings">Three findings that shaped everything</a></li>
+      </ul>
+    </li>
+    <li><a href="#four-tiers">Four interfaces, swappable backends</a></li>
+    <li><a href="#pipeline">How memory plugs into the pipeline</a>
+      <ul>
+        <li><a href="#five-hooks">Five hooks, three stages</a></li>
+        <li><a href="#what-llm-sees">What the LLM actually sees</a></li>
+      </ul>
+    </li>
+    <li><a href="#compaction">Activity compaction: surviving thousands of events</a></li>
+    <li><a href="#coordination">Real-time coordination signals</a></li>
+    <li><a href="#knowledge">Knowledge extraction and the reflection job</a></li>
+    <li><a href="#user-memory">User memory: per-user personalization</a>
+      <ul>
+        <li><a href="#reconciliation">Fact reconciliation in four operations</a></li>
+        <li><a href="#recall">Five parallel recall paths</a></li>
+      </ul>
+    </li>
+    <li><a href="#scoping">Domain scoping and physical isolation</a></li>
+    <li><a href="#wiring">What the wiring looks like</a>
+      <ul>
+        <li><a href="#swapping-a-backend">Swapping a backend</a></li>
+      </ul>
+    </li>
+    <li><a href="#cheat">Architect's cheat sheet</a></li>
+    <li><a href="#further">Where to go next</a></li>
+  </ul>
+</details>
+
+<!-- ===================== AMNESIA ===================== -->
+<section>
+<h2 id="amnesia">The amnesia problem</h2>
+
+<p>In TruvaG3, every <code>ProcessRequest</code> call starts with a blank slate. The orchestrator plans against the registry, executes the DAG, synthesizes a response, and forgets everything. The next call — even one made one second later, by the same agent, against the same entity — begins again from zero.</p>
+
+<p>That is fine for a single tool. It is a problem the moment you have <em>two agents that can act on the same entity</em>. Without shared memory, agents fail in three concrete ways. <strong>Duplicated work</strong> — two agents independently investigate the same root cause, burning LLM tokens and tool invocations on the same five-step plan. <strong>Missing context</strong> — Agent B makes a decision without knowing Agent A's recent action on the same entity, leading to conflicting remediations or contradictory customer messages. <strong>No institutional learning</strong> — the same class of incident gets resolved fifty times, and the fifty-first still runs the full investigation, because the system has accumulated nothing.</p>
+
+<p><span class="highlight-amber">The picture below is what this looks like in a typical TruvaG3 deployment.</span> An event-driven agent reacts to an OOMKilled alert and creates a JIRA ticket. Five minutes later, a chat agent receives a related question about the same pod. Without shared memory, the second agent has no idea the first one ran.</p>
+
+<figure id="fig-amnesia">
+<svg viewBox="0 0 760 470" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Without memory vs With memory. Two side-by-side timelines showing how two agents fail without shared memory and succeed with it. The 'With memory' column has a shared-memory store between the two agents — the first agent writes to it, the second agent reads from it before planning.">
+  <defs>
+    <marker id="am-arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#9ec5ff"/>
+    </marker>
+    <marker id="am-arr-amber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#f59e0b"/>
+    </marker>
+    <marker id="am-arr-purple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#a78bfa"/>
+    </marker>
+    <linearGradient id="am-mem" x1="0" x2="1">
+      <stop offset="0" stop-color="#f59e0b"/><stop offset="1" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+
+  <!-- column titles -->
+  <text x="190" y="28" text-anchor="middle" fill="#f87171" font-size="14" font-weight="700">Without memory</text>
+  <text x="570" y="28" text-anchor="middle" fill="#34d399" font-size="14" font-weight="700">With memory</text>
+  <line x1="380" y1="46" x2="380" y2="455" stroke="#2a3550" stroke-dasharray="4 4"/>
+
+  <!-- ─────────── LEFT COLUMN · Without memory ─────────── -->
+
+  <!-- Agent A -->
+  <rect x="40" y="60" width="300" height="62" rx="10" fill="#1a2236" stroke="#3a4a72"/>
+  <text x="56" y="82" fill="#e6edf7" font-size="13" font-weight="700">event-driven-agent</text>
+  <text x="56" y="100" fill="#9aa6bd" font-size="11">Pod X is OOMKilled · alert received</text>
+  <text x="56" y="114" fill="#9aa6bd" font-size="11">5-step investigation · creates JIRA DEVOPS-42</text>
+
+  <!-- "5 min later, no shared memory" — long arrow spanning the full
+       vertical gap that the right column uses for the shared-memory box -->
+  <path d="M190,128 L190,247" stroke="#9ec5ff" stroke-width="1.5" marker-end="url(#am-arr)" fill="none"/>
+  <text x="205" y="170" fill="#9aa6bd" font-size="11" font-style="italic">5 min later</text>
+  <text x="205" y="186" fill="#9aa6bd" font-size="11" font-style="italic">— no record</text>
+  <text x="205" y="202" fill="#9aa6bd" font-size="11" font-style="italic">— no signal</text>
+  <text x="205" y="218" fill="#9aa6bd" font-size="11" font-style="italic">— no knowledge</text>
+
+  <!-- Agent B -->
+  <rect x="40" y="252" width="300" height="62" rx="10" fill="#1a2236" stroke="#3a4a72"/>
+  <text x="56" y="274" fill="#e6edf7" font-size="13" font-weight="700">devops-chat-agent</text>
+  <text x="56" y="292" fill="#9aa6bd" font-size="11">"Why is pod X slow?"</text>
+  <text x="56" y="306" fill="#9aa6bd" font-size="11">Investigates from scratch — no idea A ran</text>
+
+  <!-- Outcome -->
+  <rect x="40" y="332" width="300" height="115" rx="10" fill="#2a1a1f" stroke="#f87171"/>
+  <text x="56" y="354" fill="#f87171" font-size="12" font-weight="700">OUTCOME</text>
+  <text x="56" y="377" fill="#fca5a5" font-size="11.5">• DUPLICATE 5-step investigation</text>
+  <text x="56" y="396" fill="#fca5a5" font-size="11.5">• DUPLICATE JIRA ticket created</text>
+  <text x="56" y="415" fill="#fca5a5" font-size="11.5">• DUPLICATE Slack notification</text>
+  <text x="56" y="434" fill="#fca5a5" font-size="11.5">• Conflicting remediations · tokens wasted</text>
+
+  <!-- ─────────── RIGHT COLUMN · With memory ─────────── -->
+
+  <!-- Agent A -->
+  <rect x="420" y="60" width="300" height="62" rx="10" fill="#1a2236" stroke="#3a4a72"/>
+  <text x="436" y="82" fill="#e6edf7" font-size="13" font-weight="700">event-driven-agent</text>
+  <text x="436" y="100" fill="#9aa6bd" font-size="11">Pod X OOMKilled · creates DEVOPS-42</text>
+  <text x="436" y="114" fill="#9aa6bd" font-size="11">Writes AgentEvent → episodic memory</text>
+
+  <!-- Write arrows — two diagonals from the bottom of EDA flowing into
+       the top of the shared-memory blob. Animated dashed (flow-line)
+       to suggest data movement. -->
+  <path d="M500,124 Q 510,148 530,168" stroke="#f59e0b" stroke-width="1.6" stroke-dasharray="5 3" marker-end="url(#am-arr-amber)" fill="none" class="flow-line"/>
+  <path d="M640,124 Q 630,148 610,168" stroke="#f59e0b" stroke-width="1.6" stroke-dasharray="5 3" marker-end="url(#am-arr-amber)" fill="none" class="flow-line"/>
+  <text x="486" y="148" fill="#f59e0b" font-size="11" font-style="italic">writes</text>
+
+  <!-- Shared memory blob — bigger, centered, with a sub-label so the
+       reader knows what's inside it. -->
+  <rect x="460" y="172" width="220" height="50" rx="10" fill="url(#am-mem)" opacity="0.94"/>
+  <text x="570" y="194" text-anchor="middle" fill="#1a0f0a" font-size="13" font-weight="700">shared memory</text>
+  <text x="570" y="211" text-anchor="middle" fill="#1a0f0a" font-size="10.5" font-style="italic">events · coordination · knowledge</text>
+
+  <!-- Read arrow — straight down from blob bottom to DCA top, with a
+       clear label so the read direction is unambiguous. -->
+  <path d="M570,224 L570,247" stroke="#a78bfa" stroke-width="1.8" marker-end="url(#am-arr-purple)" fill="none"/>
+  <text x="586" y="240" fill="#a78bfa" font-size="11" font-style="italic">reads</text>
+
+  <!-- Agent B (aligned with the left column's Agent B at y=252) -->
+  <rect x="420" y="252" width="300" height="62" rx="10" fill="#1a2236" stroke="#3a4a72"/>
+  <text x="436" y="274" fill="#e6edf7" font-size="13" font-weight="700">devops-chat-agent</text>
+  <text x="436" y="292" fill="#9aa6bd" font-size="11">"Why is pod X slow?"</text>
+  <text x="436" y="306" fill="#a78bfa" font-size="11">Reads memory: A restarted pod X · DEVOPS-42</text>
+
+  <!-- Outcome (aligned with the left column's outcome at y=332) -->
+  <rect x="420" y="332" width="300" height="115" rx="10" fill="#0d2a1d" stroke="#34d399"/>
+  <text x="436" y="354" fill="#34d399" font-size="12" font-weight="700">OUTCOME</text>
+  <text x="436" y="377" fill="#a7f3d0" font-size="11.5">• 2-step plan: check status, add comment</text>
+  <text x="436" y="396" fill="#a7f3d0" font-size="11.5">• No duplicate ticket</text>
+  <text x="436" y="415" fill="#a7f3d0" font-size="11.5">• Consistent action across agents</text>
+  <text x="436" y="434" fill="#a7f3d0" font-size="11.5">• Fewer tokens spent · faster turnaround</text>
+</svg>
+<figcaption><strong>Figure 1.</strong> <strong>The amnesia problem and the shared-notebook fix.</strong> Two agents, same entity, two sequential requests. On the left, each agent investigates independently — duplicated tools, duplicated tickets, duplicated notifications. On the right, the first agent's actions are written into shared memory; the second agent reads them before planning and produces a different, smaller plan. The shared memory does not change <em>what</em> an agent can do — it changes what the agent <em>knows</em> when it starts.</figcaption>
+</figure>
+
+<p>Everything in the rest of this article is an answer to the same question asked at different timescales: <em>how does Agent B see what Agent A just did?</em> Five seconds ago. Five minutes ago. Five weeks ago. And how does that visibility survive a backend restart, scale to thousands of events, and not block the request path when it fails?</p>
+</section>
+
+<!-- ===================== RESEARCH ===================== -->
+<section>
+<h2 id="research">Where the design came from</h2>
+
+<h3 id="research-survey">A survey, not a vector DB bolt-on</h3>
+
+<p>The temptation when adding "memory" to an agent framework is to attach a vector database and call it done. Every paper that took that route — store everything, retrieve by similarity — found the same failure mode: as memory grows, signal-to-noise collapses and decision quality degrades. TruvaG3's memory system was designed against a literature survey first, then implemented. The relevant lineage:</p>
+
+<table>
+<thead>
+<tr><th>Source</th><th>What it gave us</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td><strong><a href="https://arxiv.org/abs/2304.03442">Stanford Generative Agents (2023)</a></strong><br><span style="color:var(--muted);font-size:11.5px;font-family:'SF Mono',monospace">Park et al., arXiv <a href="https://arxiv.org/abs/2304.03442">2304.03442</a></span></td>
+  <td>The three-tier model — memory stream, reflection, planning — and the now-standard <em>recency · importance · relevance</em> retrieval triad. Their hard finding: without a periodic reflection pass, agents became incoherent within a few hundred turns.</td>
+</tr>
+<tr>
+  <td><strong><a href="https://arxiv.org/abs/2310.08560">MemGPT (2023)</a></strong><br><span style="color:var(--muted);font-size:11.5px;font-family:'SF Mono',monospace">Packer et al., arXiv <a href="https://arxiv.org/abs/2310.08560">2310.08560</a></span></td>
+  <td>The LLM as its own memory manager — paging information in and out of the context window via explicit function calls. TruvaG3's enrichment hook is the "page in" mechanism.</td>
+</tr>
+<tr>
+  <td><strong><a href="https://arxiv.org/abs/2502.12110">A-MEM (2025)</a></strong><br><span style="color:var(--muted);font-size:11.5px;font-family:'SF Mono',monospace">Xu et al., arXiv <a href="https://arxiv.org/abs/2502.12110">2502.12110</a></span></td>
+  <td>Agentic memory — the store actively organizes, connects, and evolves its contents instead of passively accumulating them. Source of the ADD / UPDATE / CONTRADICT / DUPLICATE reconciliation pattern.</td>
+</tr>
+<tr>
+  <td><strong><a href="https://arxiv.org/abs/2502.05453">DAMCS (2025)</a></strong><br><span style="color:var(--muted);font-size:11.5px;font-family:'SF Mono',monospace">arXiv <a href="https://arxiv.org/abs/2502.05453">2502.05453</a></span></td>
+  <td>The cognitive-science three-tier model — sensory (raw tool output), episodic (events), procedural (learned how-to). Maps cleanly onto TruvaG3's <code>ExecutionStore</code> → <code>AgentEvent</code> → <code>KnowledgeFragment</code> progression.</td>
+</tr>
+<tr>
+  <td><strong><a href="https://arxiv.org/abs/2506.07398">G-Memory (2025)</a></strong><br><span style="color:var(--muted);font-size:11.5px;font-family:'SF Mono',monospace">arXiv <a href="https://arxiv.org/abs/2506.07398">2506.07398</a></span></td>
+  <td>Provenance — every fragment tracks who created it, what evidence it was based on, and the derivation chain. Critical for enterprise audit trails. Lives in <code>KnowledgeFragment.SourceEvents</code> (which events produced the fragment) and <code>AgentEvent.ParentEvent</code> (which request derived from which).</td>
+</tr>
+<tr>
+  <td><strong><a href="https://arxiv.org/abs/2603.10062">Multi-Agent Memory from CompArch (2026)</a></strong><br><span style="color:var(--muted);font-size:11.5px;font-family:'SF Mono',monospace">arXiv <a href="https://arxiv.org/abs/2603.10062">2603.10062</a></span></td>
+  <td>The L1/L2/RAM/Disk analogy and the consistency-model benchmark. Strong consistency cost 3-5× latency; eventual consistency caused decision conflicts in ~12% of scenarios. Causal consistency — what Redis Streams give you for free — was the sweet spot.</td>
+</tr>
+<tr>
+  <td><strong><a href="https://arxiv.org/abs/2603.13110">AgentRM (2026)</a></strong><br><span style="color:var(--muted);font-size:11.5px;font-family:'SF Mono',monospace">arXiv <a href="https://arxiv.org/abs/2603.13110">2603.13110</a></span></td>
+  <td>The number that motivated the entire compaction layer: with no memory management, effective context degrades to noise within ~50 turns. With simple compression, agents retain ~37% of entity information across sessions.</td>
+</tr>
+</tbody>
+</table>
+
+<h3 id="research-findings">Three findings that shaped everything</h3>
+
+<p>Three results recurred across the literature, and shaped the design directly.</p>
+
+<p><strong>Raw event logging is necessary but insufficient.</strong> Every "store everything" approach degraded under load; a reflection or distillation layer is required. <strong>Retrieval must be multi-signal.</strong> Pure embedding similarity misses temporally relevant information, and the recency-importance-relevance triad has held up across every follow-on paper. <strong>Consistency model matters.</strong> Stale reads cause measurable decision quality loss, but strong consistency is too expensive — causal consistency is the right floor.</p>
+
+</section>
+
+<!-- ===================== FOUR TIERS ===================== -->
+<section>
+<h2 id="four-tiers">Four interfaces, swappable backends</h2>
+
+<p>The memory system decomposes into four independent <strong>interfaces defined in <code>core</code></strong> — each solves a distinct problem, each can be implemented and scaled separately, each degrades gracefully when missing. The interfaces are the framework's contract; the backends that implement them are the framework's defaults — opinionated but replaceable. A separate fifth interface, user memory, handles per-user private facts and is covered in <a href="#user-memory">§7</a>.</p>
+
+<table>
+<thead>
+<tr><th>Memory type</th><th>Interface (in <code>core</code>)</th><th>What it stores</th><th>Default backend (in <code>memory</code>)</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td><span class="tier episodic">Episodic</span></td>
+  <td><a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#how-it-works"><code>EpisodicMemory</code></a></td>
+  <td>Structured events: "Agent X did Y to entity Z at time T with outcome W"</td>
+  <td><a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#how-it-works"><code>StreamEpisodicMemory</code></a> · Redis Streams (or <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#how-it-works">in-memory</a> for tests)</td>
+</tr>
+<tr>
+  <td><span class="tier coord">Coordinator</span></td>
+  <td><a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#how-it-works"><code>InvestigationCoordinator</code></a></td>
+  <td>Who currently holds the claim on which entity (with TTL)</td>
+  <td><a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#how-it-works"><code>AtomicLockCoordinator</code></a> · Redis SETNX</td>
+</tr>
+<tr>
+  <td><span class="tier knowledge">Knowledge</span></td>
+  <td><a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#how-it-works"><code>SharedKnowledge</code></a></td>
+  <td>Embedded knowledge fragments — learned patterns, resolution strategies</td>
+  <td><a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#knowledge-extraction-learning-from-experience"><code>VectorSharedKnowledge</code></a> · Qdrant (vector DB, gRPC)</td>
+</tr>
+<tr>
+  <td><span class="tier reflect">Reflector</span></td>
+  <td><a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#how-it-works"><code>MemoryReflector</code></a></td>
+  <td>Higher-level synthesized insights from many episodic events</td>
+  <td><a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#long-term-knowledge-retention-the-reflection-job"><code>LLMMemoryReflector</code></a> · uses the configured <code>AIClient</code> + episodic backend</td>
+</tr>
+</tbody>
+</table>
+
+<p>Each interface lives in the <code>core</code> kernel; concrete backends live in the separate <code>memory</code> module, which absorbs the heavy client dependencies (Redis client, Qdrant gRPC + protobuf) so <code>core</code> stays lightweight. A Phase-1 deployment that needs only episodic memory and coordination compiles with <em>none of</em> the vector-DB dependencies. A Phase-2 deployment that wants knowledge search opts in by passing an embedding client.</p>
+
+<aside class="callout">
+<strong>The backends are defaults, not requirements.</strong> <a href="https://redis.io/">Redis</a> is the default backend for episodic events, the investigation coordinator, the activity coordinator, and the digest cache because it is already on most platforms' bill of materials (it backs the framework's discovery layer too — see the <a href="microagents-architecture.html">architecture article</a>) and <a href="https://redis.io/docs/latest/develop/data-types/streams/">Redis Streams</a> provide causal consistency for free. <a href="https://qdrant.tech/">Qdrant</a> is the default for the knowledge store because it is purpose-built for vector search, <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2.0</a>, and ships an official Go gRPC client. <span class="highlight-amber">Neither is wired into the framework — both sit behind <code>core</code> interfaces.</span> An application that prefers <a href="https://github.com/pgvector/pgvector">pgvector</a>, <a href="https://docs.nats.io/nats-concepts/jetstream">NATS JetStream</a>, <a href="https://github.com/valkey-io/valkey-search">valkey-search</a>, <a href="https://weaviate.io/">Weaviate</a>, or <a href="https://milvus.io/">Milvus</a> writes (or pulls in) a backend that satisfies the same interface and passes it through <code>ToDeps()</code>. Backends targeting the same interface are interchangeable with zero application code change beyond the constructor line in <code>main.go</code>. This is the same pattern the framework uses for AI providers: contracts in <code>core</code>, implementations elsewhere, applications pick at import time.
+</aside>
+
+<figure id="fig-tiers">
+<svg viewBox="0 0 760 410" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Four memory backends over the core micro-kernel. Episodic, Coordinator, Knowledge, and Reflector each implement a core interface; the application wires them via NewSharedBackends.">
+  <defs>
+    <marker id="ft-arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#9ec5ff"/>
+    </marker>
+    <linearGradient id="ft-core" x1="0" x2="1">
+      <stop offset="0" stop-color="#3a6df0"/><stop offset="1" stop-color="#7a3df0"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Whole figure is shifted left by 20px (boxes originally started at
+       x=40 and the rightmost touched x=760, giving 40/0 margins).
+       New layout uses 20/20 margins so neither column hugs the perimeter. -->
+
+  <text x="20" y="28" fill="#9aa6bd" font-size="11" letter-spacing="0.06em">FOUR INTERFACES (core) · DEFAULT BACKENDS (memory module, swappable)</text>
+
+  <!-- Episodic -->
+  <rect x="20" y="50" width="170" height="110" rx="12" fill="#2a1f0c" stroke="#f59e0b"/>
+  <text x="105" y="75" text-anchor="middle" fill="#fde68a" font-size="13" font-weight="700">core.EpisodicMemory</text>
+  <text x="105" y="93" text-anchor="middle" fill="#fcd34d" font-size="11" font-style="italic">interface</text>
+  <text x="105" y="115" text-anchor="middle" fill="#9aa6bd" font-size="10.5">default: StreamEpisodicMemory</text>
+  <text x="105" y="129" text-anchor="middle" fill="#9aa6bd" font-size="10.5">backend: Redis Streams</text>
+  <text x="105" y="147" text-anchor="middle" fill="#9aa6bd" font-size="10.5">alt: pgvector · NATS · in-mem</text>
+
+  <!-- Coordinator -->
+  <rect x="205" y="50" width="170" height="110" rx="12" fill="#2a240c" stroke="#fbbf24"/>
+  <text x="290" y="75" text-anchor="middle" fill="#fde68a" font-size="13" font-weight="700">core.Investigation</text>
+  <text x="290" y="91" text-anchor="middle" fill="#fde68a" font-size="13" font-weight="700">Coordinator</text>
+  <text x="290" y="109" text-anchor="middle" fill="#fcd34d" font-size="11" font-style="italic">interface</text>
+  <text x="290" y="129" text-anchor="middle" fill="#9aa6bd" font-size="10.5">default: AtomicLockCoordinator</text>
+  <text x="290" y="147" text-anchor="middle" fill="#9aa6bd" font-size="10.5">backend: Redis SETNX</text>
+
+  <!-- Knowledge -->
+  <rect x="390" y="50" width="170" height="110" rx="12" fill="#1f1a30" stroke="#a78bfa"/>
+  <text x="475" y="75" text-anchor="middle" fill="#ddd6fe" font-size="13" font-weight="700">core.SharedKnowledge</text>
+  <text x="475" y="93" text-anchor="middle" fill="#c4b5fd" font-size="11" font-style="italic">interface</text>
+  <text x="475" y="115" text-anchor="middle" fill="#9aa6bd" font-size="10.5">default: VectorSharedKnowledge</text>
+  <text x="475" y="129" text-anchor="middle" fill="#9aa6bd" font-size="10.5">backend: Qdrant (vector DB)</text>
+  <text x="475" y="147" text-anchor="middle" fill="#9aa6bd" font-size="10.5">alt: pgvector · Weaviate · Milvus</text>
+
+  <!-- Reflector -->
+  <rect x="575" y="50" width="165" height="110" rx="12" fill="#0d2a1d" stroke="#34d399"/>
+  <text x="657" y="75" text-anchor="middle" fill="#a7f3d0" font-size="13" font-weight="700">core.MemoryReflector</text>
+  <text x="657" y="93" text-anchor="middle" fill="#a7f3d0" font-size="11" font-style="italic">interface</text>
+  <text x="657" y="115" text-anchor="middle" fill="#9aa6bd" font-size="10.5">default: LLMMemoryReflector</text>
+  <text x="657" y="129" text-anchor="middle" fill="#9aa6bd" font-size="10.5">uses configured AIClient</text>
+  <text x="657" y="147" text-anchor="middle" fill="#9aa6bd" font-size="10.5">distills events → fragments</text>
+
+  <!-- arrows down to core (one per interface, dropping straight into it) -->
+  <path d="M105,162 L105,200" stroke="#9ec5ff" stroke-width="1.5" stroke-dasharray="3 3" fill="none"/>
+  <path d="M290,162 L290,200" stroke="#9ec5ff" stroke-width="1.5" stroke-dasharray="3 3" fill="none"/>
+  <path d="M475,162 L475,200" stroke="#9ec5ff" stroke-width="1.5" stroke-dasharray="3 3" fill="none"/>
+  <path d="M657,162 L657,200" stroke="#9ec5ff" stroke-width="1.5" stroke-dasharray="3 3" fill="none"/>
+
+  <!-- core micro-kernel — spans the full width of the four interface
+       boxes above (x=20..740) so every interface drops cleanly into it
+       without the leftmost and rightmost boxes looking disconnected. -->
+  <rect x="20" y="205" width="720" height="80" rx="14" fill="url(#ft-core)" opacity="0.9"/>
+  <text x="380" y="232" text-anchor="middle" fill="#fff" font-size="14" font-weight="700">core (micro-kernel)</text>
+  <text x="380" y="254" text-anchor="middle" fill="#dbeafe" font-size="11.5">interfaces · types · NoOp defaults</text>
+  <text x="380" y="272" text-anchor="middle" fill="#dbeafe" font-size="11.5">deps: go-redis · uuid · testify only</text>
+
+  <!-- arrow down to app -->
+  <path d="M380,290 L380,320" stroke="#9ec5ff" stroke-width="1.5" marker-end="url(#ft-arr)" fill="none"/>
+
+  <!-- application — slightly narrower than core, so the layering reads
+       as "the application sits on top of the kernel, which underpins
+       all four interfaces above". -->
+  <rect x="60" y="325" width="640" height="60" rx="12" fill="#1a2236" stroke="#3a4a72"/>
+  <text x="380" y="349" text-anchor="middle" fill="#e6edf7" font-size="13" font-weight="700">application · main.go</text>
+  <text x="380" y="368" text-anchor="middle" fill="#9aa6bd" font-size="11.5">memory.NewSharedBackends(...) · orchestration.BuildMemoryHooks(...) · framework.RegisterRunnable(...)</text>
+
+  <text x="20" y="403" fill="#9aa6bd" font-size="10.5" font-style="italic">Phase 1 (episodic + coordinator) always created. Phase 2 (knowledge + reflector) opt-in via TRUVAG3_VECTOR_DB_URL + embedding client.</text>
+</svg>
+<figcaption><strong>Figure 2.</strong> <strong>Four <code>core</code> interfaces, swappable backends.</strong> Every tier lives behind a Go interface defined in <code>core</code>. The boxes name the interface first and the default backend second — Redis Streams and Qdrant ship as the production defaults because most platforms already operate Redis and Qdrant is purpose-built for vector search, but they are replaceable. Any backend that satisfies the same <code>core</code> interface is a drop-in alternative; the rest of the framework never knows the difference. The application's <code>main.go</code> is the only place that wires backends to hooks; the orchestrator itself never imports <code>memory</code>, only the <code>core</code> interfaces.</figcaption>
+</figure>
+
+<p>One detail in Figure 2 deserves its own paragraph, because it is the design choice that makes the rest of the system safe to deploy. <strong>Every backend is fail-open</strong>, regardless of which implementation is wired in. Runtime errors return <code>(nil, nil)</code>, not <code>(nil, error)</code>. If the knowledge backend is unreachable, search returns empty; the LLM plans without enrichment. If the episodic backend is unreachable, the activity coordinator returns empty signals; the planner proceeds without coordination. If the LLM-driven compaction times out, the cached digest is used; if there is no cached digest, the raw last-N events are sent through. Memory is an enhancement, never a prerequisite — the orchestration pipeline cannot fail because of a memory backend, whichever one you have plugged in.</p>
+</section>
+
+<!-- ===================== PIPELINE ===================== -->
+<section>
+<h2 id="pipeline">How memory plugs into the pipeline</h2>
+
+<h3 id="five-hooks">Five hooks, three stages</h3>
+
+<p>Memory is not invoked imperatively — agent code does not call <code>memory.Recall()</code> or <code>memory.Record()</code>. Everything happens through TruvaG3's existing pipeline-hook mechanism: middleware that runs at well-defined stages of <code>ProcessRequest</code>, registered once at startup. There are five hooks; they run in a fixed order on every request; they are fail-open individually so a failure in one does not break the others.</p>
+
+<figure id="fig-pipeline">
+<svg viewBox="0 0 760 470" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Five pipeline hooks across three stages — before planning, after execution, after synthesis.">
+  <defs>
+    <marker id="pp-arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#9ec5ff"/>
+    </marker>
+    <marker id="pp-arr-y" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#fbbf24"/>
+    </marker>
+    <linearGradient id="pp-llm" x1="0" x2="1">
+      <stop offset="0" stop-color="#3a6df0"/><stop offset="1" stop-color="#7a3df0"/>
+    </linearGradient>
+  </defs>
+
+  <!-- User request -->
+  <rect x="320" y="14" width="120" height="32" rx="8" fill="#0e1a2e" stroke="#3a8aff"/>
+  <text x="380" y="35" text-anchor="middle" fill="#9ec5ff" font-size="12" font-weight="700">User request</text>
+  <path d="M380,46 L380,64" stroke="#9ec5ff" stroke-width="1.5" marker-end="url(#pp-arr)" fill="none"/>
+
+  <!-- STAGE 1: BEFORE PLANNING -->
+  <rect x="30" y="70" width="700" height="140" rx="12" fill="#171f33" stroke="#3a4a72"/>
+  <text x="48" y="92" fill="#9aa6bd" font-size="11" letter-spacing="0.06em">STAGE 1 · BEFORE PLANNING</text>
+
+  <rect x="50" y="100" width="320" height="96" rx="10" fill="#2a240c" stroke="#fbbf24"/>
+  <text x="64" y="122" fill="#fde68a" font-size="13" font-weight="700">1 · ActivityAnnouncementHook</text>
+  <text x="64" y="142" fill="#9aa6bd" font-size="11.5">writes "I'm working on entity X" signal</text>
+  <text x="64" y="160" fill="#9aa6bd" font-size="11.5">reads other agents' live signals</text>
+  <text x="64" y="184" fill="#fbbf24" font-size="11" font-style="italic">→ injects &lt;agent_coordination&gt;</text>
+
+  <rect x="390" y="100" width="320" height="96" rx="10" fill="#1f1a30" stroke="#a78bfa"/>
+  <text x="404" y="122" fill="#ddd6fe" font-size="13" font-weight="700">2 · MemoryEnrichmentHook</text>
+  <text x="404" y="142" fill="#9aa6bd" font-size="11.5">queries episodic + compacts digest</text>
+  <text x="404" y="160" fill="#9aa6bd" font-size="11.5">searches shared knowledge (vector)</text>
+  <text x="404" y="184" fill="#a78bfa" font-size="11" font-style="italic">→ injects &lt;agent_memory&gt;</text>
+
+  <path d="M380,212 L380,232" stroke="#9ec5ff" stroke-width="1.5" marker-end="url(#pp-arr)" fill="none"/>
+
+  <!-- Plan / Execute / Synthesize band -->
+  <rect x="120" y="234" width="520" height="78" rx="12" fill="url(#pp-llm)" opacity="0.92"/>
+  <text x="380" y="258" text-anchor="middle" fill="#fff" font-size="14" font-weight="700">Plan → Execute → Synthesize</text>
+  <text x="380" y="278" text-anchor="middle" fill="#dbeafe" font-size="11.5">LLM sees &lt;agent_coordination&gt; and &lt;agent_memory&gt; in the planning prompt</text>
+  <text x="380" y="296" text-anchor="middle" fill="#dbeafe" font-size="11.5">DAG executes with parallelism · synthesis composes the response</text>
+
+  <!-- Two branches down -->
+  <path d="M250,312 L250,332" stroke="#9ec5ff" stroke-width="1.5" marker-end="url(#pp-arr)" fill="none"/>
+  <path d="M510,312 L510,332" stroke="#9ec5ff" stroke-width="1.5" marker-end="url(#pp-arr)" fill="none"/>
+
+  <!-- STAGE 2: AFTER EXECUTION -->
+  <rect x="30" y="335" width="350" height="125" rx="12" fill="#171f33" stroke="#3a4a72"/>
+  <text x="48" y="357" fill="#9aa6bd" font-size="11" letter-spacing="0.06em">STAGE 2 · AFTER EXECUTION</text>
+
+  <rect x="50" y="365" width="310" height="40" rx="8" fill="#2a1f0c" stroke="#f59e0b"/>
+  <text x="64" y="384" fill="#fde68a" font-size="12" font-weight="700">3 · MemoryRecordHook</text>
+  <text x="64" y="399" fill="#9aa6bd" font-size="11">records AgentEvent per step (LLM summarizes)</text>
+
+  <rect x="50" y="410" width="310" height="40" rx="8" fill="#2a240c" stroke="#fbbf24"/>
+  <text x="64" y="429" fill="#fde68a" font-size="12" font-weight="700">5 · ActivityCleanupHook</text>
+  <text x="64" y="444" fill="#9aa6bd" font-size="11">removes "working on X" signal · async</text>
+
+  <!-- STAGE 3: AFTER SYNTHESIS -->
+  <rect x="395" y="335" width="335" height="125" rx="12" fill="#171f33" stroke="#3a4a72"/>
+  <text x="413" y="357" fill="#9aa6bd" font-size="11" letter-spacing="0.06em">STAGE 3 · AFTER SYNTHESIS</text>
+
+  <rect x="415" y="365" width="295" height="85" rx="8" fill="#0d2a1d" stroke="#34d399"/>
+  <text x="429" y="385" fill="#a7f3d0" font-size="12" font-weight="700">4 · KnowledgeExtractionHook</text>
+  <text x="429" y="403" fill="#9aa6bd" font-size="11">LLM extracts reusable knowledge fragments</text>
+  <text x="429" y="421" fill="#9aa6bd" font-size="11">embeds → stores via core.SharedKnowledge</text>
+  <text x="429" y="439" fill="#34d399" font-size="11" font-style="italic">async · fail-open · doesn't block response</text>
+</svg>
+<figcaption><strong>Figure 3.</strong> <strong>Five memory hooks across three pipeline stages.</strong> Two hooks fire <em>before planning</em> — one announces and reads activity signals, one queries episodic and knowledge and writes the digest into the prompt. After the DAG finishes, the record hook writes events for every step and the cleanup hook removes the "working on this" signal. After synthesis, the knowledge-extraction hook distills the response into a reusable fragment, asynchronously. Every hook is fail-open; a failure logs a warning and the pipeline continues without that hook's contribution.</figcaption>
+</figure>
+
+<h3 id="what-llm-sees">What the LLM actually sees</h3>
+
+<p>The hooks contribute two new XML sections to the planning prompt. The first is <span class="tier coord">Coordination</span> — real-time signals from agents currently active in the same domain:</p>
+
+<pre><code class="language-xml">&lt;agent_coordination&gt;
+Other agents currently active in domain 'infrastructure':
+- event-driven-agent: investigating "TruvaG3HighLatency on product-catalog-api"
+  (status: executing, started 3s ago)
+&lt;/agent_coordination&gt;</code></pre>
+
+<p>The second is <span class="tier episodic">Episodic</span> + <span class="tier knowledge">Knowledge</span> — a compacted digest of recent domain activity plus the most recent events at full detail, plus any vector-retrieved knowledge fragments:</p>
+
+<pre><code class="language-xml">&lt;agent_memory&gt;
+Domain activity summary (last 2 hours, 106 events):
+- Deployment restart: agent-with-human-approval restarted via rollout (200ms)
+- JIRA: ticket DEVOPS-49 created for the restart, comment added with details
+- Slack: notification sent to #notifications with JIRA reference
+- Monitoring: 4 Prometheus queries run by event-driven-agent
+
+Most recent events (detail):
+- [2026-05-26 23:31] devops-chat-agent: Queried logs for orch-1774... (success)
+- [2026-05-26 23:30] devops-chat-agent: Created JIRA ticket DEVOPS-52 (success)
+
+Prior knowledge relevant to this request:
+- OOMKilled on pods with &lt;256Mi memory is typically resolved by doubling
+  the memory limit. Check resource quotas first. (importance: 0.82)
+&lt;/agent_memory&gt;</code></pre>
+
+<p>This is what the LLM sees when it generates its plan. <span class="highlight-amber">It is not asked to "consider memory" — the memory is already in the prompt</span>, and the LLM treats it like any other context. The behaviour change is emergent: the planner naturally writes shorter plans when the digest tells it the work was already done, and it naturally references existing tickets when the digest names them.</p>
+</section>
+
+<!-- ===================== COMPACTION ===================== -->
+<section>
+<h2 id="compaction">Activity compaction: surviving thousands of events</h2>
+
+<p>The naive version of the enrichment hook sends every recent event through to the LLM on every request. At 200 events per planning prompt, that is 5,000-10,000 tokens of context overhead — every request, every agent. It will work, and it will be expensive.</p>
+
+<p><span class="tier episodic">Episodic</span> compaction solves this with an LLM-summarized digest that lives in the digest cache (<a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#how-it-works"><code>core.DigestCache</code></a> — <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#activity-compaction-scaling-to-thousands-of-events">default backend is Redis</a>, <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#activity-compaction-scaling-to-thousands-of-events">in-memory</a> ships for tests, anything else can be plugged in) and is shared across every agent in the domain. The hook's behaviour depends on what is in the cache and how many new events have arrived since the last compaction:</p>
+
+<figure id="fig-compaction">
+<svg viewBox="0 0 760 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Activity compaction state machine. Four outcomes depending on cache state and new event count.">
+  <defs>
+    <marker id="cm-arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#9ec5ff"/>
+    </marker>
+    <marker id="cm-arr-amber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#f59e0b"/>
+    </marker>
+  </defs>
+
+  <!-- Trigger -->
+  <rect x="30" y="140" width="140" height="60" rx="10" fill="#1a2236" stroke="#3a4a72"/>
+  <text x="100" y="166" text-anchor="middle" fill="#e6edf7" font-size="13" font-weight="700">Request arrives</text>
+  <text x="100" y="184" text-anchor="middle" fill="#9aa6bd" font-size="11">BeforePlanning</text>
+
+  <!-- Decision diamond -->
+  <polygon points="280,140 350,170 280,200 210,170" fill="#1a2236" stroke="#f59e0b"/>
+  <text x="280" y="166" text-anchor="middle" fill="#f59e0b" font-size="11" font-weight="700">cache state?</text>
+  <text x="280" y="182" text-anchor="middle" fill="#9aa6bd" font-size="10">how many new?</text>
+
+  <path d="M170,170 L210,170" stroke="#9ec5ff" stroke-width="1.5" marker-end="url(#cm-arr)" fill="none"/>
+
+  <!-- Four outcomes -->
+  <rect x="410" y="40" width="320" height="50" rx="10" fill="#2a1a1f" stroke="#f87171"/>
+  <text x="424" y="60" fill="#fca5a5" font-size="12" font-weight="700">A · Cache miss (cold start)</text>
+  <text x="424" y="78" fill="#fecaca" font-size="11">200 events → full LLM compaction (5-10s) → cache</text>
+
+  <rect x="410" y="100" width="320" height="50" rx="10" fill="#0d2a1d" stroke="#34d399"/>
+  <text x="424" y="120" fill="#a7f3d0" font-size="12" font-weight="700">B · Cache hit · 0 new events</text>
+  <text x="424" y="138" fill="#bbf7d0" font-size="11">cached digest reused · 0 ms · no LLM call</text>
+
+  <rect x="410" y="160" width="320" height="50" rx="10" fill="#1f1a30" stroke="#a78bfa"/>
+  <text x="424" y="180" fill="#ddd6fe" font-size="12" font-weight="700">C · Cache hit · few new events (&lt; 20)</text>
+  <text x="424" y="198" fill="#e9d5ff" font-size="11">incremental update · prev digest + delta (0.5-1s)</text>
+
+  <rect x="410" y="220" width="320" height="50" rx="10" fill="#2a1f0c" stroke="#f59e0b"/>
+  <text x="424" y="240" fill="#fde68a" font-size="12" font-weight="700">D · Burst · 20+ new events</text>
+  <text x="424" y="258" fill="#fcd34d" font-size="11">full recompaction · LLM (5-10s) · new cache</text>
+
+  <path d="M350,160 L410,65" stroke="#f87171" stroke-width="1.5" stroke-dasharray="3 3" fill="none"/>
+  <path d="M350,170 L410,125" stroke="#34d399" stroke-width="1.5" fill="none"/>
+  <path d="M350,175 L410,185" stroke="#a78bfa" stroke-width="1.5" fill="none"/>
+  <path d="M350,185 L410,245" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="3 3" fill="none" class="flow-line"/>
+
+  <!-- Steady state band -->
+  <rect x="30" y="300" width="700" height="42" rx="10" fill="#171f33" stroke="#3a4a72"/>
+  <text x="380" y="322" text-anchor="middle" fill="#9aa6bd" font-size="12">
+    Typical steady state · 80% cached (0ms) + 15% incremental (0.5s) + 5% full (5s) =
+    <tspan fill="#34d399" font-weight="700">~0.3s average</tspan>
+  </text>
+  <text x="380" y="336" text-anchor="middle" fill="#9aa6bd" font-size="10.5">
+    cache is shared across every agent in the domain — first agent pays the cost, all peers read it back
+  </text>
+</svg>
+<figcaption><strong>Figure 4.</strong> <strong>Activity compaction is a four-state cache.</strong> Cold start is rare. Most requests hit a warm cache that is either reused as-is or incrementally updated with a handful of new events. Burst recompaction kicks in when more than <code>TRUVAG3_SHARED_MEMORY_DIGEST_INCREMENTAL_THRESHOLD</code> events have arrived (default 20). The digest cache is shared across every agent in the same domain — when one agent pays the cost of recompaction, all peers benefit on their next request.</figcaption>
+</figure>
+
+<p>The cache key is the domain, not the agent. When <code>event-driven-agent</code> compacts the digest, <code>devops-chat-agent</code> reads it back as a cache hit on the next request. <strong>This is what makes the compaction pattern affordable in a fleet</strong> — the LLM cost is amortized across every agent in the domain, not paid per agent.</p>
+
+<p>The span event <code>activity.compaction.cache_decision</code> labels the path taken on each request — <code>cached</code>, <code>incremental</code>, <code>full</code>, or <code>full_recompact</code>. If a production deployment shows <code>path=full</code> on every request, the cache is broken — the configured digest-cache backend is unreachable, the TTL is too short, or the digest cache wasn't wired into the enrichment hook. The condition is visible without reading a single application log.</p>
+</section>
+
+<!-- ===================== COORDINATION ===================== -->
+<section>
+<h2 id="coordination">Real-time coordination signals</h2>
+
+<p><span class="tier episodic">Episodic</span> memory has a built-in latency: events are visible after execution completes, which is typically 2-4 seconds. For most workloads that is fine. For <em>concurrent</em> requests — an alert that fires while a chat session is already mid-investigation against the same pod — 2-4 seconds is too slow. The two agents can both start a five-step plan before either of them sees the other's event.</p>
+
+<p>This is what the <span class="tier coord">Coordinator</span> solves. It is a separate, lightweight store implementing <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#how-it-works"><code>core.ActivityCoordinator</code></a>: transient keys with TTL, no JSON payloads, no LLM calls. The default backend writes through <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#real-time-coordination-what-are-other-agents-doing-right-now">Redis</a> (with an <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#real-time-coordination-what-are-other-agents-doing-right-now">in-memory fallback</a> for tests); any KV store with atomic SETNX + TTL semantics can be substituted. An agent writes a signal the moment it starts processing a request and removes it the moment the response is synthesized:</p>
+
+<figure id="fig-coordination">
+<svg viewBox="0 0 760 410" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Real-time coordination timeline. Two agents, one entity. The first agent writes a signal that the second reads before planning.">
+  <defs>
+    <marker id="co-arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#fbbf24"/>
+    </marker>
+  </defs>
+
+  <text x="20" y="28" fill="#e6edf7" font-size="14" font-weight="700">Two agents, one pod, no duplicated work</text>
+
+  <!-- ── event-driven-agent track (y=50..130) — outer perimeter widened
+       to x=40..720 so the inner signal box has visible padding (20px on
+       the left, 60px on the right) instead of hugging the rim. ── -->
+  <rect x="40" y="50" width="680" height="80" rx="10" fill="#171f33" stroke="#3a4a72"/>
+  <text x="58" y="68" fill="#9aa6bd" font-size="11" letter-spacing="0.04em">event-driven-agent</text>
+  <rect x="60" y="80" width="600" height="42" rx="8" fill="#2a240c" stroke="#fbbf24"/>
+  <text x="74" y="100" fill="#fde68a" font-size="12" font-weight="700">signal: "investigating Pod X" (TTL 5min)</text>
+  <text x="74" y="116" fill="#fcd34d" font-size="11">KV with TTL — no JSON payload, no LLM call</text>
+
+  <circle cx="60" cy="101" r="6" fill="#fbbf24"/>
+  <text x="40" y="42" fill="#9aa6bd" font-size="11">alert fires</text>
+  <circle cx="660" cy="101" r="6" fill="#fbbf24"/>
+  <text x="624" y="42" fill="#9aa6bd" font-size="11">signal removed</text>
+
+  <!-- ── devops-chat-agent track — taller (height 145, was 115) and now
+       widened to x=40..720 to match the EDA track above. The extra
+       width gives the rightmost inner box ("responds to user") room to
+       hold the full quoted string without clipping. ── -->
+  <rect x="40" y="192" width="680" height="145" rx="10" fill="#171f33" stroke="#3a4a72"/>
+  <text x="58" y="210" fill="#9aa6bd" font-size="11" letter-spacing="0.04em">devops-chat-agent (second request, same pod)</text>
+
+  <!-- ── signal arrow — fully in the gap between the two tracks, lands
+       at the top of the "reads signal" inner box (y=242). Drawn AFTER
+       the DCA outer rect so the arrowhead is not occluded by its fill. ── -->
+  <path d="M180,122 L180,237" stroke="#fbbf24" stroke-width="1.8" stroke-dasharray="5 4" marker-end="url(#co-arr)" fill="none" class="flow-line"/>
+  <text x="190" y="172" fill="#fbbf24" font-size="11" font-style="italic">1s later — same domain · signal visible</text>
+
+  <!-- Inner action row — pushed down to y=242 (was y=222) so the
+       arrowhead has room above it and below the header label. -->
+  <rect x="180" y="242" width="135" height="40" rx="6" fill="#2a1f0c" stroke="#f59e0b"/>
+  <text x="188" y="260" fill="#fde68a" font-size="11" font-weight="700">reads signal</text>
+  <text x="188" y="274" fill="#fcd34d" font-size="10">sees E-D-A is on it</text>
+
+  <rect x="320" y="242" width="170" height="40" rx="6" fill="#0d2a1d" stroke="#34d399"/>
+  <text x="328" y="260" fill="#a7f3d0" font-size="11" font-weight="700">signal in prompt</text>
+  <text x="328" y="274" fill="#bbf7d0" font-size="10">planner can defer or adapt</text>
+
+  <!-- "responds to user" box widened 160 → 200 so the quoted ETA string
+       fits inside without the trailing quote clipping the right edge. -->
+  <rect x="500" y="242" width="200" height="40" rx="6" fill="#1a2236" stroke="#3a4a72"/>
+  <text x="508" y="260" fill="#e6edf7" font-size="11" font-weight="700">responds to user</text>
+  <text x="508" y="274" fill="#9aa6bd" font-size="10">"investigation in flight, ETA 30s"</text>
+
+  <circle cx="180" cy="297" r="5" fill="#e6edf7"/>
+  <text x="180" y="319" text-anchor="middle" fill="#9aa6bd" font-size="10">same alert arrives</text>
+
+  <!-- ── Timeline axis (moved to y=360 to follow the taller layout) ── -->
+  <line x1="60" y1="360" x2="700" y2="360" stroke="#3a4a72" stroke-width="1.2"/>
+  <line x1="60"  y1="355" x2="60"  y2="365" stroke="#3a4a72" stroke-width="1.2"/>
+  <line x1="180" y1="355" x2="180" y2="365" stroke="#3a4a72" stroke-width="1.2"/>
+  <line x1="320" y1="355" x2="320" y2="365" stroke="#3a4a72" stroke-width="1.2"/>
+  <line x1="500" y1="355" x2="500" y2="365" stroke="#3a4a72" stroke-width="1.2"/>
+  <line x1="660" y1="355" x2="660" y2="365" stroke="#3a4a72" stroke-width="1.2"/>
+  <text x="60"  y="380" text-anchor="middle" fill="#9aa6bd" font-size="11">T = 0s</text>
+  <text x="180" y="380" text-anchor="middle" fill="#9aa6bd" font-size="11">T = 1s</text>
+  <text x="320" y="380" text-anchor="middle" fill="#9aa6bd" font-size="11">T = 3s</text>
+  <text x="500" y="380" text-anchor="middle" fill="#9aa6bd" font-size="11">T = 28s</text>
+  <text x="660" y="380" text-anchor="middle" fill="#9aa6bd" font-size="11">T = 30s</text>
+</svg>
+<figcaption><strong>Figure 5.</strong> <strong>Real-time signals close the 2-4 second gap.</strong> The event-driven agent writes a signal to the activity coordinator's KV store (default backend: Redis) the moment it starts processing the alert (T = 0). One second later, the chat agent reads the same domain's signals and the planner sees E-D-A's activity in its <code>&lt;agent_coordination&gt;</code> prompt block — giving it the option to defer, coordinate, or adapt rather than blindly starting a parallel investigation. The signal is removed when the originating agent finishes; if it crashes, the TTL expires automatically. No cleanup process, no leaked locks.</figcaption>
+</figure>
+
+<p>Two design choices keep this affordable. <strong>The signal is a KV entry with a TTL</strong> — on the default Redis backend that is one <code>SET … EX 300</code>, but the interface only assumes "put, get, expire," so the same hook works against any KV-with-TTL backend. No JSON, no large payloads, no LLM call to write or read. The TTL is longer than the longest expected request (default 5 minutes), so a crash never leaves a permanent claim. <strong>The signal is plain text written in natural language</strong> — "investigating TruvaG3HighLatency on product-catalog-api" — and the LLM reads it the same way it reads the rest of the prompt. The decision of whether to defer is made by the planner, not by a hardcoded rule, so agents can coordinate even when their work overlaps in ways the framework cannot anticipate.</p>
+</section>
+
+<!-- ===================== KNOWLEDGE + REFLECTION ===================== -->
+<section>
+<h2 id="knowledge">Knowledge extraction and the reflection job</h2>
+
+<p><span class="tier episodic">Episodic</span> events answer "what did Agent X just do?" <span class="tier knowledge">Knowledge</span> fragments answer the harder question: "what have we, collectively, learned about this class of problem?" These two questions need different storage. Episodic events expire after 60 days (the default <code>EpisodicMemory</code> backend honours <code>TRUVAG3_SHARED_MEMORY_STREAM_MAXLEN</code> and TTL); knowledge fragments live in the <code>SharedKnowledge</code> backend with no TTL, surfaced through semantic search. The default <code>SharedKnowledge</code> implementation is vector-DB-backed (Qdrant out of the box), but any backend that satisfies the interface works — pgvector for teams already running Postgres, valkey-search once it matures, or a custom implementation for an internal system.</p>
+
+<p>TruvaG3 produces knowledge fragments through <em>two complementary paths</em>, running on different timescales. The first is the <strong>KnowledgeExtractionHook</strong> — it runs after every synthesis, distills the current request's findings into a 1-2 sentence fragment, embeds it, and stores it. Fast, immediate, high-volume. The second is the <span class="tier reflect">Reflector</span> — a background job that runs every 24 hours, scans episodic events older than seven days, and asks the LLM to identify patterns <em>across many past events for the same entity</em>. Slower, distilled, pattern-aware.</p>
+
+<figure id="fig-lifecycle">
+<svg viewBox="0 0 760 410" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="The life of one event, from recording to permanent knowledge fragment.">
+  <defs>
+    <marker id="lc-arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#9ec5ff"/>
+    </marker>
+    <marker id="lc-arr-p" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#a78bfa"/>
+    </marker>
+  </defs>
+
+  <text x="20" y="26" fill="#e6edf7" font-size="14" font-weight="700">The life of one event, from recording to durable knowledge</text>
+
+  <!-- Long timeline -->
+  <line x1="30" y1="200" x2="740" y2="200" stroke="#3a4a72" stroke-width="1.4"/>
+  <line x1="60"  y1="194" x2="60"  y2="206" stroke="#3a4a72" stroke-width="1.4"/>
+  <line x1="170" y1="194" x2="170" y2="206" stroke="#3a4a72" stroke-width="1.4"/>
+  <line x1="320" y1="194" x2="320" y2="206" stroke="#3a4a72" stroke-width="1.4"/>
+  <line x1="500" y1="194" x2="500" y2="206" stroke="#3a4a72" stroke-width="1.4"/>
+  <line x1="650" y1="194" x2="650" y2="206" stroke="#3a4a72" stroke-width="1.4"/>
+
+  <text x="60"  y="222" text-anchor="middle" fill="#9aa6bd" font-size="11">T = 0</text>
+  <text x="170" y="222" text-anchor="middle" fill="#9aa6bd" font-size="11">≤ 24h</text>
+  <text x="320" y="222" text-anchor="middle" fill="#9aa6bd" font-size="11">7 days</text>
+  <text x="500" y="222" text-anchor="middle" fill="#9aa6bd" font-size="11">60 days</text>
+  <text x="650" y="222" text-anchor="middle" fill="#9aa6bd" font-size="11">6 months</text>
+
+  <!-- Stages —
+       Box 1 (recorded) was 105px wide; "MemoryRecordHook" and
+       "EpisodicMemory · 60d" both clipped the right edge. Widened to
+       130px by extending leftward (was x=30, now x=5) so the longer
+       internal labels fit. Right edge stays at x=135 so the gap to
+       Box 2 at x=140 is preserved. -->
+  <rect x="5" y="60" width="130" height="105" rx="10" fill="#2a1f0c" stroke="#f59e0b"/>
+  <text x="70" y="82" text-anchor="middle" fill="#fde68a" font-size="12" font-weight="700">recorded</text>
+  <text x="70" y="100" text-anchor="middle" fill="#9aa6bd" font-size="11">tool runs</text>
+  <text x="70" y="116" text-anchor="middle" fill="#9aa6bd" font-size="11">MemoryRecordHook</text>
+  <text x="70" y="132" text-anchor="middle" fill="#9aa6bd" font-size="11">writes event</text>
+  <text x="70" y="150" text-anchor="middle" fill="#fbbf24" font-size="10">EpisodicMemory · 60d</text>
+
+  <rect x="140" y="60" width="125" height="105" rx="10" fill="#2a1f0c" stroke="#f59e0b"/>
+  <text x="202" y="82" text-anchor="middle" fill="#fde68a" font-size="12" font-weight="700">in digest</text>
+  <text x="202" y="100" text-anchor="middle" fill="#9aa6bd" font-size="11">compactor sees</text>
+  <text x="202" y="116" text-anchor="middle" fill="#9aa6bd" font-size="11">event in 24h window</text>
+  <text x="202" y="132" text-anchor="middle" fill="#9aa6bd" font-size="11">surfaced to LLM</text>
+  <text x="202" y="150" text-anchor="middle" fill="#fbbf24" font-size="10">via &lt;agent_memory&gt;</text>
+
+  <rect x="270" y="60" width="175" height="105" rx="10" fill="#0d2a1d" stroke="#34d399"/>
+  <text x="357" y="82" text-anchor="middle" fill="#a7f3d0" font-size="12" font-weight="700">reflection-eligible</text>
+  <text x="357" y="100" text-anchor="middle" fill="#9aa6bd" font-size="11">≥ AGE_THRESHOLD old</text>
+  <text x="357" y="116" text-anchor="middle" fill="#9aa6bd" font-size="11">paired with peer events</text>
+  <text x="357" y="132" text-anchor="middle" fill="#9aa6bd" font-size="11">for the same entity</text>
+  <text x="357" y="150" text-anchor="middle" fill="#34d399" font-size="10">background job picks up</text>
+
+  <rect x="450" y="60" width="165" height="105" rx="10" fill="#1f1a30" stroke="#a78bfa"/>
+  <text x="532" y="82" text-anchor="middle" fill="#ddd6fe" font-size="12" font-weight="700">distilled to fragment</text>
+  <text x="532" y="100" text-anchor="middle" fill="#9aa6bd" font-size="11">reflector LLM extracts</text>
+  <text x="532" y="116" text-anchor="middle" fill="#9aa6bd" font-size="11">1-3 fragments</text>
+  <text x="532" y="132" text-anchor="middle" fill="#9aa6bd" font-size="11">embed → SharedKnowledge</text>
+  <text x="532" y="150" text-anchor="middle" fill="#a78bfa" font-size="10">no TTL — permanent</text>
+
+  <!-- Box 5 (event expires) was 120px wide; "EpisodicMemory · 60d" and
+       "in SharedKnowledge" both ran close to the right edge. Widened to
+       135px by extending rightward (was w=120, now w=135) so the labels
+       have comfortable padding. Right edge now at x=755, still inside
+       the 760-unit viewBox. -->
+  <rect x="620" y="60" width="135" height="105" rx="10" fill="#171f33" stroke="#3a4a72"/>
+  <text x="687" y="82" text-anchor="middle" fill="#e6edf7" font-size="12" font-weight="700">event expires</text>
+  <text x="687" y="100" text-anchor="middle" fill="#9aa6bd" font-size="11">EpisodicMemory · 60d</text>
+  <text x="687" y="116" text-anchor="middle" fill="#9aa6bd" font-size="11">original gone</text>
+  <text x="687" y="132" text-anchor="middle" fill="#9aa6bd" font-size="11">fragments survive</text>
+  <text x="687" y="150" text-anchor="middle" fill="#a78bfa" font-size="10">in SharedKnowledge</text>
+
+  <!-- arrows down — each anchored to its box's centre. Box 1 and Box 5
+       centres moved (70 and 687 respectively) after the widening above;
+       Boxes 2-4 unchanged. -->
+  <path d="M70,170  L70,194"  stroke="#9ec5ff" stroke-width="1.4" marker-end="url(#lc-arr)" fill="none"/>
+  <path d="M202,170 L202,194" stroke="#9ec5ff" stroke-width="1.4" marker-end="url(#lc-arr)" fill="none"/>
+  <path d="M357,170 L357,194" stroke="#9ec5ff" stroke-width="1.4" marker-end="url(#lc-arr)" fill="none"/>
+  <path d="M532,170 L532,194" stroke="#a78bfa" stroke-width="1.4" marker-end="url(#lc-arr-p)" fill="none"/>
+  <path d="M687,170 L687,194" stroke="#9ec5ff" stroke-width="1.4" marker-end="url(#lc-arr)" fill="none"/>
+
+  <!-- Future query band -->
+  <rect x="50" y="252" width="660" height="135" rx="12" fill="#1f1a30" stroke="#a78bfa"/>
+  <text x="68" y="278" fill="#ddd6fe" font-size="13" font-weight="700">T = 6 months later · a new but related incident arrives</text>
+  <text x="68" y="304" fill="#9aa6bd" font-size="12">→ Semantic search retrieves the reflected fragment from SharedKnowledge</text>
+  <text x="68" y="324" fill="#9aa6bd" font-size="12">→ Planner sees "Prior knowledge: OOMKilled on &lt;256Mi pods is resolved by doubling memory"</text>
+  <text x="68" y="344" fill="#9aa6bd" font-size="12">→ 2-step plan applied directly — even though the original event has aged out of the episodic store</text>
+  <text x="68" y="370" fill="#a78bfa" font-style="italic" font-size="11.5">Knowledge outlives the events it was distilled from.</text>
+</svg>
+<figcaption><strong>Figure 6.</strong> <strong>Knowledge outlives the events it was distilled from.</strong> An event is visible to the compactor for the first 24 hours, eligible for reflection once it crosses the age threshold (default 7 days), and expires from the episodic store at 60 days. By that point, the reflector has already extracted any durable patterns into <code>SharedKnowledge</code> fragments. A new incident months later, semantically related to those patterns, gets a 2-step plan instead of a 5-step investigation — using knowledge derived from events that no longer exist in the episodic store.</figcaption>
+</figure>
+
+<p>The reflection job is the part of the system that most directly maps onto the Stanford Generative Agents finding — agents without a reflection layer became incoherent within a few hundred turns. TruvaG3's version (<a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#long-term-knowledge-retention-the-reflection-job"><code>memory/reflection_job.go</code></a>) runs as a framework <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#how-it-works"><code>Runnable</code></a> with one line of wiring:</p>
+
+<pre><code class="language-go">// Reflection job: long-term knowledge retention via background distillation.
+// Returns nil silently if Phase 2 backends aren't available.
+if reflectionJob, _ := memory.BuildReflectionJob(memBackends.ToDeps(), agent.AI, agent.Logger); reflectionJob != nil {
+    framework.RegisterRunnable(reflectionJob)
+}</code></pre>
+
+<p>Two operational properties matter. <strong>It is multi-replica safe.</strong> The job acquires a distributed lock keyed by domain before each pass (<a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#long-term-knowledge-retention-the-reflection-job">default backend: Redis</a>; the lock is a <code>core.DistributedLock</code> abstraction so any KV with atomic check-and-set will do). Other replicas log "lock held by another replica, skipping" and return. <strong>Model choice matters more than for any other LLM call in the system.</strong> Reflection writes durable knowledge that influences every future request — a bad fragment lingers in the knowledge store and surfaces as confident "prior knowledge" for as long as it remains. The default model is the agent's main AI client; <code>TRUVAG3_REFLECTION_MODEL=fast</code> trades fragment quality for cost, which is acceptable for high-volume cost-sensitive deployments but not the right default.</p>
+
+<aside class="callout">
+<strong>Why we don't just keep all events forever.</strong> The default episodic backend ages events out at 60 days (any backend implementation is free to retain longer, but the cost grows with volume). The activity compactor only looks back 24 hours. Without reflection, every event older than that window becomes invisible to the LLM and eventually expires unread. The 50th OOMKill incident is just as forgotten as the 1st. Reflection is what closes that gap — it converts <em>ephemeral activity into durable patterns</em> before the activity disappears.
+</aside>
+</section>
+
+<!-- ===================== USER MEMORY ===================== -->
+<section>
+<h2 id="user-memory">User memory: per-user personalization</h2>
+
+<p>Everything covered so far is <em>shared agent memory</em> — cross-agent visibility within a domain. TruvaG3 also ships a separate, complementary system for per-user private facts: <span class="tier user">user memory</span>. Different store, different hooks, different privacy boundary, different lifecycle. The mental model is a personal assistant's notebook versus a team's shared notebook.</p>
+
+<table>
+<thead>
+<tr><th></th><th>Shared memory</th><th>User memory</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Scope</strong></td><td>All agents in a domain</td><td>One user only</td></tr>
+<tr><td><strong>Content</strong></td><td>"Agent X restarted pod Y"</td><td>"User prefers DFW airport"</td></tr>
+<tr><td><strong>Visibility</strong></td><td>Domain-wide</td><td>Private to user</td></tr>
+<tr><td><strong>Lifetime</strong></td><td>24h lookback + knowledge persists</td><td>Months / years; evolves with user</td></tr>
+<tr><td><strong>GDPR delete</strong></td><td>Not per-user</td><td><code>Forget("user-42")</code> → one call</td></tr>
+<tr><td><strong>Enrichment tag</strong></td><td><code>&lt;agent_memory&gt;</code></td><td><code>&lt;user_profile&gt;</code></td></tr>
+<tr><td><strong>Interface</strong></td><td><code>core.EpisodicMemory</code> + <code>core.SharedKnowledge</code></td><td><a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#how-it-works"><code>core.UserMemory</code></a></td></tr>
+<tr><td><strong>Default backend</strong></td><td>Redis Streams + Qdrant <span style="color:var(--muted);font-size:11px">(swappable)</span></td><td><a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#user-memory-per-user-personalization"><code>VectorUserMemory</code></a> (Qdrant) or <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#user-memory-per-user-personalization"><code>InMemoryUserMemory</code></a> <span style="color:var(--muted);font-size:11px">(swappable)</span></td></tr>
+</tbody>
+</table>
+
+<h3 id="reconciliation">Fact reconciliation in four operations</h3>
+
+<p>The interesting part of user memory is not the storage — it is what happens when a new fact contradicts an existing one. A user who says "I am vegetarian" on Monday and "I'm not vegetarian anymore" on Friday should not have both facts in their profile. The system needs to recognize the relationship and update accordingly.</p>
+
+<figure id="fig-reconciliation">
+<svg viewBox="0 0 760 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Fact reconciliation. New candidate facts pass through vector similarity; below threshold they ADD directly, above threshold the LLM classifies the relationship into ADD, UPDATE, CONTRADICT, or DUPLICATE.">
+  <defs>
+    <marker id="rc-arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#7cc4ff"/>
+    </marker>
+    <marker id="rc-arr-g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#34d399"/>
+    </marker>
+    <marker id="rc-arr-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#f59e0b"/>
+    </marker>
+  </defs>
+
+  <text x="20" y="26" fill="#e6edf7" font-size="14" font-weight="700">Fact reconciliation: classifying a new candidate against what's known</text>
+
+  <!-- Candidate -->
+  <rect x="30" y="60" width="170" height="60" rx="10" fill="#0e2236" stroke="#7cc4ff"/>
+  <text x="44" y="82" fill="#bae6fd" font-size="12" font-weight="700">Candidate fact</text>
+  <text x="44" y="100" fill="#9aa6bd" font-size="11">extracted from</text>
+  <text x="44" y="114" fill="#9aa6bd" font-size="11">latest conversation</text>
+
+  <path d="M200,90 L230,90" stroke="#7cc4ff" stroke-width="1.5" marker-end="url(#rc-arr)" fill="none"/>
+
+  <!-- Similarity -->
+  <rect x="230" y="60" width="190" height="60" rx="10" fill="#171f33" stroke="#3a4a72"/>
+  <text x="244" y="82" fill="#e6edf7" font-size="12" font-weight="700">Vector similarity</text>
+  <text x="244" y="100" fill="#9aa6bd" font-size="11">cosine against existing</text>
+  <text x="244" y="114" fill="#9aa6bd" font-size="11">facts (vector search)</text>
+
+  <path d="M420,90 L450,90" stroke="#7cc4ff" stroke-width="1.5" marker-end="url(#rc-arr)" fill="none"/>
+
+  <!-- Below / Above threshold paths -->
+  <rect x="450" y="45" width="280" height="36" rx="8" fill="#0d2a1d" stroke="#34d399"/>
+  <text x="464" y="68" fill="#a7f3d0" font-size="12" font-weight="700">below 0.75 → ADD directly (no LLM)</text>
+
+  <rect x="450" y="100" width="280" height="36" rx="8" fill="#2a1f0c" stroke="#f59e0b"/>
+  <text x="464" y="123" fill="#fde68a" font-size="12" font-weight="700">above 0.75 → LLM reconciliation</text>
+
+  <text x="20" y="170" fill="#9aa6bd" font-size="11" letter-spacing="0.06em">LLM CLASSIFIES THE RELATIONSHIP INTO ONE OF FOUR OPERATIONS</text>
+
+  <rect x="30" y="185" width="170" height="135" rx="10" fill="#0d2a1d" stroke="#34d399"/>
+  <text x="44" y="207" fill="#a7f3d0" font-size="13" font-weight="700">ADD</text>
+  <text x="44" y="225" fill="#9aa6bd" font-size="11">no similar fact exists</text>
+  <text x="44" y="245" fill="#9aa6bd" font-size="11">"User likes hiking"</text>
+  <text x="44" y="261" fill="#9aa6bd" font-size="11">→ stored as-is</text>
+  <text x="44" y="297" fill="#34d399" font-size="10.5" font-style="italic">most common path</text>
+  <text x="44" y="311" fill="#34d399" font-size="10.5" font-style="italic">for new users</text>
+
+  <rect x="210" y="185" width="170" height="135" rx="10" fill="#1f1a30" stroke="#a78bfa"/>
+  <text x="224" y="207" fill="#ddd6fe" font-size="13" font-weight="700">UPDATE</text>
+  <text x="224" y="225" fill="#9aa6bd" font-size="11">refines existing fact</text>
+  <text x="224" y="247" fill="#9aa6bd" font-size="11">"Likes cricket" →</text>
+  <text x="224" y="261" fill="#9aa6bd" font-size="11">"...with friends on</text>
+  <text x="224" y="275" fill="#9aa6bd" font-size="11">weekends"</text>
+
+  <rect x="390" y="185" width="170" height="135" rx="10" fill="#2a1f0c" stroke="#f59e0b"/>
+  <text x="404" y="207" fill="#fde68a" font-size="13" font-weight="700">CONTRADICT</text>
+  <text x="404" y="225" fill="#9aa6bd" font-size="11">new supersedes old</text>
+  <text x="404" y="245" fill="#9aa6bd" font-size="11">"Vegetarian" → "No longer</text>
+  <text x="404" y="261" fill="#9aa6bd" font-size="11">vegetarian"</text>
+  <text x="404" y="281" fill="#fbbf24" font-size="11">→ old deleted,</text>
+  <text x="404" y="295" fill="#fbbf24" font-size="11">→ new stored</text>
+
+  <rect x="570" y="185" width="170" height="135" rx="10" fill="#171f33" stroke="#3a4a72"/>
+  <text x="584" y="207" fill="#e6edf7" font-size="13" font-weight="700">DUPLICATE</text>
+  <text x="584" y="225" fill="#9aa6bd" font-size="11">same info exists</text>
+  <text x="584" y="247" fill="#9aa6bd" font-size="11">→ skip storage</text>
+  <text x="584" y="263" fill="#9aa6bd" font-size="11">→ update last_used</text>
+  <text x="584" y="277" fill="#9aa6bd" font-size="11">→ timestamp</text>
+
+  <text x="20" y="346" fill="#9aa6bd" font-size="10.5" font-style="italic">Cost optimization: when no similar fact exists (cosine &lt; 0.75), reconciliation skips the LLM call entirely. For new users, most facts ADD directly with zero reconciliation cost.</text>
+</svg>
+<figcaption><strong>Figure 7.</strong> <strong>Fact reconciliation — four operations, one LLM call.</strong> Embedding similarity finds candidate matches; the LLM classifies the actual semantic relationship. Pure vector similarity cannot distinguish "prefers window seats" from "prefers aisle seats" — both are high-similarity, both are about seating, and the meanings are opposite. The LLM call is the part that handles the contradiction correctly.</figcaption>
+</figure>
+
+<h3 id="recall">Five parallel recall paths</h3>
+
+<p>Recall is structured around five parallel paths, each contributing different facts to the planning prompt: <strong>identity</strong> (who the user is — always recalled), <strong>stable_namespace</strong> (facts tagged with stable identifiers), <strong>query</strong> (semantic match against the current request), <strong>summary</strong> (rolling session summaries from previous conversations), and <strong>universal</strong> (facts that cross every agent — name, language, timezone). Each path emits its own span in <a href="https://www.jaegertracing.io/">Jaeger</a>, so a developer can see which paths contributed to a given response.</p>
+
+<p>The result, in the planning prompt, is a <code>&lt;user_profile&gt;</code> tag with confidence-banded facts:</p>
+
+<pre><code class="language-xml">&lt;user_profile&gt;
+Identity:
+- User lives in Coppell, TX (explicit, high confidence)
+
+Constraint:
+- User and family are vegetarian, no eggs or gelatin (explicit, high confidence)
+
+Preference:
+- User prefers DFW airport for flights (explicit, high confidence)
+
+Relationship:
+- Family of three: user, wife, and 12-year-old son (explicit, high confidence)
+
+Summary:
+- Planned a week-long family itinerary in Zurich with hotel picks and vegetarian restaurant recommendations near each one (derived, 3 days ago)
+- Asked about Switzerland weather, currency, and travel tips (derived, 3 days ago)
+&lt;/user_profile&gt;</code></pre>
+
+<p>The travel agent now plans around the user's dietary constraints, family size, and airport preference — without the user repeating any of it. Extraction runs <em>after</em> the response is streamed, so the user sees the answer immediately and the new facts are stored asynchronously. GDPR erasure is a single API call: <code>userMemory.Forget(ctx, userID)</code> deletes every vector and payload for that user. The interface is the boundary; swapping Qdrant for PostgreSQL with pgvector is a backend change, not an application change.</p>
+</section>
+
+<!-- ===================== SCOPING ===================== -->
+<section>
+<h2 id="scoping">Domain scoping and physical isolation</h2>
+
+<p>An enterprise deployment has multiple agent types, each with multiple replicas, serving different business domains. A platform team needs to know exactly what is shared, what is isolated, and how compliance boundaries are enforced. TruvaG3 operates at two levels: <span class="highlight-amber">logical isolation by default, physical isolation when regulated.</span></p>
+
+<figure id="fig-scoping">
+<svg viewBox="0 0 760 410" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Two standard domains share centralized memory backend instances with query-time scope filters. A regulated healthcare domain runs its own dedicated backend instances in a separate namespace.">
+  <text x="20" y="26" fill="#e6edf7" font-size="14" font-weight="700">Two scopes: shared backends, regulated backends</text>
+
+  <!-- Standard band -->
+  <rect x="30" y="55" width="500" height="335" rx="12" fill="#171f33" stroke="#3a4a72"/>
+  <text x="48" y="78" fill="#9aa6bd" font-size="11" letter-spacing="0.06em">STANDARD DOMAINS · LOGICAL ISOLATION</text>
+
+  <!-- domain: infrastructure -->
+  <rect x="50" y="95" width="220" height="115" rx="10" fill="#2a1f0c" stroke="#f59e0b"/>
+  <text x="64" y="116" fill="#fde68a" font-size="12" font-weight="700">domain: infrastructure</text>
+  <text x="64" y="138" fill="#9aa6bd" font-size="11">devops-chat-agent</text>
+  <text x="64" y="154" fill="#9aa6bd" font-size="11">event-driven-agent</text>
+  <text x="64" y="170" fill="#9aa6bd" font-size="11">agent-with-human-approval</text>
+  <text x="64" y="194" fill="#fbbf24" font-size="10.5" font-style="italic">share events + knowledge</text>
+
+  <!-- domain: commerce -->
+  <rect x="290" y="95" width="220" height="115" rx="10" fill="#2a1f0c" stroke="#f59e0b"/>
+  <text x="304" y="116" fill="#fde68a" font-size="12" font-weight="700">domain: commerce</text>
+  <text x="304" y="138" fill="#9aa6bd" font-size="11">order-exception-agent</text>
+  <text x="304" y="154" fill="#9aa6bd" font-size="11">refund-agent</text>
+  <text x="304" y="170" fill="#9aa6bd" font-size="11">customer-support-agent</text>
+  <text x="304" y="194" fill="#fbbf24" font-size="10.5" font-style="italic">share events + knowledge</text>
+
+  <!-- Global crosses both -->
+  <rect x="50" y="228" width="460" height="50" rx="10" fill="#1f1a30" stroke="#a78bfa"/>
+  <text x="64" y="250" fill="#ddd6fe" font-size="12" font-weight="700">ScopeGlobal events — visible across both domains</text>
+  <text x="64" y="268" fill="#9aa6bd" font-size="11">"service-X is down" · entity state changes · cross-domain correlations</text>
+
+  <!-- Shared infra -->
+  <rect x="50" y="293" width="460" height="36" rx="8" fill="#0e1a2e" stroke="#3a8aff"/>
+  <text x="280" y="316" text-anchor="middle" fill="#9ec5ff" font-size="12" font-weight="700">EpisodicMemory backend + SharedKnowledge backend</text>
+
+  <rect x="50" y="338" width="460" height="40" rx="8" fill="#171f33" stroke="#3a4a72"/>
+  <text x="280" y="358" text-anchor="middle" fill="#9aa6bd" font-size="11">scope filter on every query — runs inside the backend's index</text>
+  <text x="280" y="372" text-anchor="middle" fill="#9aa6bd" font-size="11">traversal, not as a post-filter</text>
+
+  <!-- Regulated band -->
+  <rect x="550" y="55" width="180" height="335" rx="12" fill="#2a1a1f" stroke="#f87171"/>
+  <text x="568" y="72" fill="#fca5a5" font-size="11" letter-spacing="0.06em">REGULATED ·</text>
+  <text x="568" y="87" fill="#fca5a5" font-size="11" letter-spacing="0.06em">PHYSICAL ISOLATION</text>
+
+  <rect x="570" y="95" width="140" height="115" rx="10" fill="#1a2236" stroke="#3a4a72"/>
+  <text x="584" y="116" fill="#e6edf7" font-size="12" font-weight="700">domain: healthcare</text>
+  <text x="584" y="138" fill="#9aa6bd" font-size="11">clinical-agent</text>
+  <text x="584" y="154" fill="#fca5a5" font-size="11">(HIPAA)</text>
+  <text x="584" y="180" fill="#9aa6bd" font-size="10.5">K8s NetworkPolicy</text>
+  <text x="584" y="195" fill="#9aa6bd" font-size="10.5">denies cross-namespace</text>
+
+  <rect x="570" y="228" width="140" height="50" rx="8" fill="#0e1a2e" stroke="#3a8aff"/>
+  <text x="640" y="251" text-anchor="middle" fill="#9ec5ff" font-size="11.5" font-weight="700">dedicated</text>
+  <text x="640" y="266" text-anchor="middle" fill="#9aa6bd" font-size="10.5">episodic backend</text>
+
+  <rect x="570" y="293" width="140" height="50" rx="8" fill="#0e1a2e" stroke="#3a8aff"/>
+  <text x="640" y="316" text-anchor="middle" fill="#9ec5ff" font-size="11.5" font-weight="700">dedicated</text>
+  <text x="640" y="331" text-anchor="middle" fill="#9aa6bd" font-size="10.5">knowledge backend</text>
+
+  <text x="640" y="370" text-anchor="middle" fill="#fca5a5" font-size="11" font-weight="700">no traffic crosses</text>
+</svg>
+<figcaption><strong>Figure 8.</strong> <strong>Two isolation levels, one piece of application code.</strong> Standard domains share centralized backend instances with logical isolation enforced at query time — every <code>SearchKnowledge</code> call includes a <code>callerDomain</code> filter that runs inside the backend's index traversal, not as a post-filter. Regulated domains (HIPAA, PCI-DSS) get separate backend instances in a different K8s namespace with a NetworkPolicy that denies all ingress. Same code, same interfaces; only the connection address (and, optionally, the backend implementation itself) differs. The framework module does not enforce compliance — infrastructure does, and that boundary is the right place for it.</figcaption>
+</figure>
+
+<p>Every <code>AgentEvent</code> and <code>KnowledgeFragment</code> carries three fields that determine visibility: <code>AgentDomain</code>, <code>AgentName</code>, and <code>Scope</code>. Scope is one of three values:</p>
+
+<table>
+<thead>
+<tr><th>Scope</th><th>Visible to</th><th>Example</th></tr>
+</thead>
+<tbody>
+<tr><td><code>ScopePrivate</code></td><td>Owning agent only</td><td>Internal reasoning trace, intermediate failure state. Never stored in shared knowledge.</td></tr>
+<tr><td><code>ScopeSharedDomain</code></td><td>Agents in the same domain</td><td>DevOps incident details. Visible across the infrastructure fleet, invisible to commerce agents.</td></tr>
+<tr><td><code>ScopeGlobal</code></td><td>All agents, any domain</td><td>"service-X is down" — entity state changes that cross domain boundaries.</td></tr>
+</tbody>
+</table>
+
+<p>The investigation-coordinator claim has one known limitation: the lock key is the entity ID only, not <code>type:id</code>. Two entities of different types that happen to share an ID — <code>pod/foo</code> and <code>service/foo</code> — will collide on the lock. The framework documents this honestly because it has low practical impact in most domains and a fix would require breaking the lock-key format. It is the kind of trade-off worth surfacing rather than hiding.</p>
+</section>
+
+<!-- ===================== WIRING ===================== -->
+<section>
+<h2 id="wiring">What the wiring looks like</h2>
+
+<p>The wiring is shorter than the architecture might suggest. Two function calls — one in the <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md"><code>memory</code></a> module to create backends, one in the <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md"><code>orchestration</code></a> module to create hooks from those backends — and the orchestrator gets memory on every request. The example below shows the <em>default</em> wiring (Redis + Qdrant) from the bundled <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/devops-chat-agent"><code>devops-chat-agent</code></a>; replacing either backend is covered after the snippets.</p>
+
+<pre><code class="language-go">// 1. Memory module creates all backends. The default factory takes a Redis
+//    client because Redis is the default backend; to swap, skip this factory
+//    and construct your own backends against core.EpisodicMemory etc. directly.
+//    Phase 1 (episodic + coordination + activity + digest cache) always created.
+//    Phase 2 (knowledge store) auto-detected from TRUVAG3_VECTOR_DB_URL.
+backends, _ := memory.NewSharedBackends(redisClient, agent.Logger,
+    memory.WithAgentName("my-agent"),
+    memory.WithDomain("infrastructure"),
+    memory.WithEmbeddingClient(embedder),   // enables Phase 2
+)
+defer backends.Close()
+
+// 2. Orchestration module creates the 5 hooks from the backends.
+hooks, activityCoord := orchestration.BuildMemoryHooks(
+    backends.ToDeps(), agent.AI, agent.Logger,
+)
+
+// 3. Pass into the orchestrator.
+deps := orchestration.OrchestratorDependencies{
+    Discovery:           discovery,
+    AIClient:            agent.AI,
+    PipelineHooks:       hooks,
+    ActivityCoordinator: activityCoord,
+}
+
+// 4. Long-term retention: reflection job as a framework Runnable.
+if reflectionJob, _ := memory.BuildReflectionJob(
+    backends.ToDeps(), agent.AI, agent.Logger,
+); reflectionJob != nil {
+    framework.RegisterRunnable(reflectionJob)
+}</code></pre>
+
+<p>For a user-memory-enabled chat agent (the <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent"><code>travel-chat-agent</code></a> pattern), one more block:</p>
+
+<pre><code class="language-go">// 5. User memory: separate backend, separate hooks.
+userMemBackend, _ := memory.NewUserMemoryBackend(agent.Logger,
+    memory.WithUserMemoryNamespace("travel"),
+    memory.WithUserMemoryEmbeddingClient(embedder),
+)
+defer userMemBackend.Close()
+
+userHooks, userHooksCloser := orchestration.BuildUserMemoryHooks(
+    userMemBackend.ToDeps(), agent.AI, agent.Logger,
+)
+defer userHooksCloser.Close()
+
+// Shared + user hooks compose into a single pipeline.
+deps.PipelineHooks = append(hooks, userHooks...)</code></pre>
+
+<p>Both wirings ship as working production code. Behavioural customization — domain-specific entity extraction, importance scoring, custom retrieval weights, longer lookback windows — is opt-in via additional options to <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#customising-memory-behaviour"><code>BuildMemoryHooks</code></a>. Numeric tuning (token budgets, TTLs, summarizer model alias) goes through <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/reference/ENVIRONMENT_VARIABLES_GUIDE.md"><code>TRUVAG3_*</code> environment variables</a>.</p>
+
+<h3 id="swapping-a-backend">Swapping a backend</h3>
+
+<p>Replacing the default Redis or Qdrant backend is a constructor-line change, not a framework change. The application skips <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#step-2-add-memory-to-your-agent"><code>NewSharedBackends</code></a> (the convenience factory that assumes Redis), constructs whichever backend it wants, and assembles its own <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md#how-it-works"><code>core.SharedMemoryDeps</code></a>:</p>
+
+<pre><code class="language-go">// Example: a deployment that prefers pgvector for SharedKnowledge
+// (Postgres is already on the platform's bill of materials).
+import (
+    "github.com/truvaagents/truva-g3/core"
+    "github.com/truvaagents/truva-g3/memory"
+    "acme/pgvectormem"      // user-owned package implementing core.SharedKnowledge
+)
+
+episodic, _ := memory.NewStreamEpisodicMemory(                  // keep Redis here
+    memory.WithEpisodicRedisClient(redisClient),
+    memory.WithEpisodicDomain("infrastructure"),
+)
+coordinator, _ := memory.NewAtomicLockCoordinator(
+    memory.WithCoordinatorRedisClient(redisClient),
+    memory.WithCoordinatorDomain("infrastructure"),
+)
+knowledge := pgvectormem.New(pgPool, ...)                       // ← custom backend
+
+deps := &amp;core.SharedMemoryDeps{
+    AgentName:   "my-agent",
+    AgentDomain: "infrastructure",
+    Episodic:    episodic,
+    Coordinator: coordinator,
+    Knowledge:   knowledge,                                     // any core.SharedKnowledge
+    Embedder:    embedder,
+    // ActivityCoordinator and DigestCache are optional; leave nil
+    // to disable signals/cache, or wire memory.NewRedisActivityCoordinator
+    // and memory.NewRedisDigestCache against the same client.
+}
+hooks, activityCoord := orchestration.BuildMemoryHooks(deps, agent.AI, agent.Logger)</code></pre>
+
+<p>The rest of the framework — the five hooks, the activity compactor, the reflection job, the LLM prompt builders — never knows the backend changed. The same applies to every <code>core</code> memory interface: <code>EpisodicMemory</code> can be swapped for a NATS JetStream implementation, <code>DigestCache</code> for any KV cache, <code>UserMemory</code> for a Postgres-backed implementation. The conformance package (<code>core/conformance</code>) ships a test suite that validates a custom backend against the same contract the bundled defaults pass.</p>
+
+<p>One subtle wiring property is worth pulling out. <span class="highlight-amber">The orchestration module does not import the memory module.</span> The dependency graph is <code>orchestration → core</code> (interfaces only), <code>memory → core + telemetry</code> (default implementations), and <code>main.go → orchestration + memory + ai</code> (wiring). This means a Phase-1 deployment that does not import the memory module's vector backend never pulls in gRPC or protobuf, and a deployment that wires only custom backends does not need to import the bundled <code>memory</code> module at all.</p>
+</section>
+
+<!-- ===================== CHEAT SHEET ===================== -->
+<section>
+<h2 id="cheat">Architect's cheat sheet</h2>
+
+<p>Six things to remember when you walk into a design review with this system on the whiteboard.</p>
+
+<div class="takeaways">
+  <div class="ta">
+    <span class="tag">CONTRACT</span>
+    <h4>1 · The interfaces are the framework; the backends are defaults</h4>
+    <p>Four <code>core</code> interfaces — <code>EpisodicMemory</code>, <code>InvestigationCoordinator</code>, <code>SharedKnowledge</code>, <code>MemoryReflector</code> — are the framework's contract. Redis and Qdrant are the production defaults; pgvector, NATS, Weaviate, or a custom backend each work by satisfying the same interface.</p>
+  </div>
+  <div class="ta">
+    <span class="tag">DESIGN</span>
+    <h4>2 · Memory is an enhancement, not a prerequisite</h4>
+    <p>Every backend is fail-open, whichever one is plugged in. If the episodic backend is unreachable, the planner runs without enrichment. If the knowledge backend is unreachable, search returns empty. The pipeline cannot fail because of a memory backend.</p>
+  </div>
+  <div class="ta">
+    <span class="tag">RESEARCH</span>
+    <h4>3 · Recency · Importance · Relevance — all three</h4>
+    <p>Pure vector similarity misses temporally relevant information. The Stanford triad held up across every follow-on paper. Weights are tunable per agent type; defaults are balanced.</p>
+  </div>
+  <div class="ta">
+    <span class="tag">SCALE</span>
+    <h4>4 · The digest cache is what makes this affordable</h4>
+    <p>The naive version sends 200 events through the LLM per request. The cached digest is shared across every agent in the domain — first agent pays the cost, all peers read the cache. Watch <code>activity.compaction.cache_decision</code>.</p>
+  </div>
+  <div class="ta">
+    <span class="tag">RETENTION</span>
+    <h4>5 · Reflection is what makes memory durable</h4>
+    <p>Episodic events age out on the configured TTL; the activity compactor only looks back 24 hours. Without reflection, every event older than that window is invisible and eventually gone. The background job converts ephemeral activity into permanent <code>SharedKnowledge</code> fragments.</p>
+  </div>
+  <div class="ta">
+    <span class="tag">PRIVACY</span>
+    <h4>6 · Shared and user memory are separate concerns</h4>
+    <p>Different interfaces, different hooks, different lifecycles. Shared memory is domain-wide; user memory is private and per-user. <code>Forget(userID)</code> is a single call that deletes everything for one user — GDPR-shaped from day one.</p>
+  </div>
+</div>
+</section>
+
+<!-- ===================== FURTHER ===================== -->
+<section>
+<h2 id="further">Where to go next</h2>
+
+<p>Recommended reading order, by goal:</p>
+
+<ul>
+  <li><strong>Operate it.</strong> The <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md">Agent Memory User Guide</a> is the user-facing tour — every environment variable, every observability signal, every troubleshooting path.</li>
+  <li><strong>Understand the architecture.</strong> <a href="https://github.com/truvaagents/truva-g3/blob/main/memory/ARCHITECTURE.md">memory/ARCHITECTURE.md</a> covers the storage backend contract, the sharing topology, and why the four interfaces are the way they are.</li>
+  <li><strong>Read the original research.</strong> The literature survey and design log are in <code>orchestration/notes/UNIFIED_AGENT_MEMORY_RESEARCH_AND_PLAN.md</code> in the framework's historical repository. It cites every paper above with arXiv IDs.</li>
+  <li><strong>Read working code.</strong> The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/devops-chat-agent">devops-chat-agent</a> wires shared memory plus reflection. The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent">travel-chat-agent</a> wires shared plus user memory. Both are deployed in the bundled Kind setup.</li>
+</ul>
+</section>
+
+<p class="footer-note">TruvaG3 is open source. The source code, the example deployments, the design notes, and the registry viewer are all public. Feedback, issues, and contributions are welcome.</p>
+
+<p class="copyright">© 2026 <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>. Licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
+
+</article>
+
+<!-- Prism syntax highlighting.
+     IMPORTANT: load core with `data-manual` so it does NOT auto-highlight
+     before the language components have registered. Then load every
+     language component (Go is not built-in; markup/XML is built-in but we
+     load it explicitly for clarity), and finally call highlightAll once
+     every grammar is available. This guarantees Go code blocks actually
+     get tokenized — otherwise they render as plain text in a single color. -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js" data-manual></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-markup.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-clike.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-go.min.js"></script>
+<script>
+  // All grammars are now registered — kick off highlighting once.
+  if (window.Prism) { Prism.highlightAll(); }
+</script>
+</body>
+</html>

--- a/www/index.html
+++ b/www/index.html
@@ -596,6 +596,7 @@ response, _ := orchestrator.ProcessRequest(ctx,
       Long-form pieces about the architecture and the broader research that
       informs it.
     </p>
+    <h3 class="read-group-heading">Blogs</h3>
     <div class="read-list">
       <a class="read-item" href="/blogs/microagents-architecture.html">
         <span class="kind">Reference architecture</span>
@@ -607,32 +608,66 @@ response, _ := orchestrator.ProcessRequest(ctx,
         <span class="title">TruvaG3 — A Guided Tour</span>
         <span class="desc">Why the framework exists, how the architecture works in practice, what ships in the box, and how to decide whether it fits your situation.</span>
       </a>
-      <a class="read-item" href="/whitepapers/agent-to-agent-communication.html">
-        <span class="kind">Whitepaper</span>
-        <span class="title">Agent-to-Agent Communication in AI Agent Frameworks</span>
-        <span class="desc">How LangChain, LangGraph, CrewAI, Google ADK, and Microsoft Semantic Kernel handle discovery, embedding, and distributed calls between agents.</span>
-      </a>
+    </div>
+    <details class="read-expand">
+      <summary><span class="when-closed">Show 1 more blog</span><span class="when-open">Hide</span></summary>
+      <div class="read-list">
+        <a class="read-item" href="/blogs/truvag3-agentic-memory.html">
+          <span class="kind">Memory architecture</span>
+          <span class="title">Agentic Memory in TruvaG3</span>
+          <span class="desc">A guided tour of TruvaG3's four-tier shared memory system — the research it came from, the pipeline hooks that wire it in, and how a fleet of agents stops repeating each other's work.</span>
+        </a>
+      </div>
+    </details>
+
+    <h3 class="read-group-heading">Whitepapers</h3>
+    <div class="read-list">
       <a class="read-item" href="/whitepapers/agent-orchestration.html">
         <span class="kind">Whitepaper</span>
         <span class="title">How AI Agent Frameworks Orchestrate Tool Calls</span>
         <span class="desc">A side-by-side look at how the major frameworks turn a user request into a sequence of tool calls — planning models, executor loops, and re-planning strategies.</span>
       </a>
-      <a class="read-item" href="/whitepapers/agent-human-in-the-loop.html">
+      <a class="read-item" href="/whitepapers/mcp-explained.html">
         <span class="kind">Whitepaper</span>
-        <span class="title">Human-in-the-Loop in AI Agent Frameworks</span>
-        <span class="desc">Approval gates, interrupt-and-resume patterns, and approval-state persistence across the major frameworks — where the human fits, and what each framework expects.</span>
-      </a>
-      <a class="read-item" href="/whitepapers/operational-excellence-index.html">
-        <span class="kind">Whitepaper series</span>
-        <span class="title">Operational Excellence in AI Agent Frameworks</span>
-        <span class="desc">Configuration, deployment, observability, performance, testing — operational practices for running agent systems in production.</span>
-      </a>
-      <a class="read-item" href="/whitepapers/agent-errors-index.html">
-        <span class="kind">Whitepaper series</span>
-        <span class="title">Error Handling in AI Agent Frameworks</span>
-        <span class="desc">Provider errors, multi-agent failure modes, data compliance, and operational error handling across major agent frameworks.</span>
+        <span class="title">Model Context Protocol — How It Works</span>
+        <span class="desc">A protocol-level reference for MCP — the wire model, transports, lifecycle, and OAuth 2.1, on the desktop and in the cloud.</span>
       </a>
     </div>
+    <details class="read-expand">
+      <summary><span class="when-closed">Show 6 more whitepapers</span><span class="when-open">Hide</span></summary>
+      <div class="read-list">
+        <a class="read-item" href="/whitepapers/agent-tool-wiring.html">
+          <span class="kind">Whitepaper</span>
+          <span class="title">How AI Agent Frameworks Wire In Tools and Agents</span>
+          <span class="desc">A code-first reference across ten AI agent frameworks — how each one declares tools, defines their schemas, and composes multiple agents.</span>
+        </a>
+        <a class="read-item" href="/whitepapers/agent-remote-tools.html">
+          <span class="kind">Whitepaper</span>
+          <span class="title">Internal vs Remote Tools — How AI Agent Frameworks Wire In Each</span>
+          <span class="desc">Where tools can live across ten AI agent frameworks — in-process code, MCP servers, OpenAPI specs, A2A, and generic RPC — and the documented declaration and call mechanism for each.</span>
+        </a>
+        <a class="read-item" href="/whitepapers/agent-to-agent-communication.html">
+          <span class="kind">Whitepaper</span>
+          <span class="title">Agent-to-Agent Communication in AI Agent Frameworks</span>
+          <span class="desc">How LangChain, LangGraph, CrewAI, Google ADK, and Microsoft Semantic Kernel handle discovery, embedding, and distributed calls between agents.</span>
+        </a>
+        <a class="read-item" href="/whitepapers/agent-human-in-the-loop.html">
+          <span class="kind">Whitepaper</span>
+          <span class="title">Human-in-the-Loop in AI Agent Frameworks</span>
+          <span class="desc">Approval gates, interrupt-and-resume patterns, and approval-state persistence across the major frameworks — where the human fits, and what each framework expects.</span>
+        </a>
+        <a class="read-item" href="/whitepapers/operational-excellence-index.html">
+          <span class="kind">Whitepaper series</span>
+          <span class="title">Operational Excellence in AI Agent Frameworks</span>
+          <span class="desc">Configuration, deployment, observability, performance, testing — operational practices for running agent systems in production.</span>
+        </a>
+        <a class="read-item" href="/whitepapers/agent-errors-index.html">
+          <span class="kind">Whitepaper series</span>
+          <span class="title">Error Handling in AI Agent Frameworks</span>
+          <span class="desc">Provider errors, multi-agent failure modes, data compliance, and operational error handling across major agent frameworks.</span>
+        </a>
+      </div>
+    </details>
   </div>
 </section>
 

--- a/www/sitemap.xml
+++ b/www/sitemap.xml
@@ -2,11 +2,15 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://truvag3.dev/blogs/</loc>
-    <lastmod>2026-05-22T14:13:39-05:00</lastmod>
+    <lastmod>2026-06-01T00:00:00-05:00</lastmod>
   </url>
   <url>
     <loc>https://truvag3.dev/blogs/microagents-architecture</loc>
     <lastmod>2026-05-22T14:13:39-05:00</lastmod>
+  </url>
+  <url>
+    <loc>https://truvag3.dev/blogs/truvag3-agentic-memory</loc>
+    <lastmod>2026-06-01T00:00:00-05:00</lastmod>
   </url>
   <url>
     <loc>https://truvag3.dev/blogs/truvag3-introduction</loc>
@@ -49,12 +53,24 @@
     <lastmod>2026-05-22T14:13:39-05:00</lastmod>
   </url>
   <url>
+    <loc>https://truvag3.dev/whitepapers/agent-remote-tools</loc>
+    <lastmod>2026-06-01T00:00:00-05:00</lastmod>
+  </url>
+  <url>
     <loc>https://truvag3.dev/whitepapers/agent-to-agent-communication</loc>
     <lastmod>2026-05-22T14:13:39-05:00</lastmod>
   </url>
   <url>
+    <loc>https://truvag3.dev/whitepapers/agent-tool-wiring</loc>
+    <lastmod>2026-06-01T00:00:00-05:00</lastmod>
+  </url>
+  <url>
+    <loc>https://truvag3.dev/whitepapers/mcp-explained</loc>
+    <lastmod>2026-06-01T00:00:00-05:00</lastmod>
+  </url>
+  <url>
     <loc>https://truvag3.dev/whitepapers/</loc>
-    <lastmod>2026-05-22T14:13:39-05:00</lastmod>
+    <lastmod>2026-06-01T00:00:00-05:00</lastmod>
   </url>
   <url>
     <loc>https://truvag3.dev/whitepapers/operational-excellence-configuration</loc>

--- a/www/whitepapers/agent-remote-tools.html
+++ b/www/whitepapers/agent-remote-tools.html
@@ -1,0 +1,1411 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Internal vs Remote Tools — How AI Agent Frameworks Wire In Each</title>
+<meta name="description" content="A reference map of where tools can live across ten AI agent frameworks and the documented declaration and call mechanism for each: in-process code, MCP servers, OpenAPI specs, remote agents over A2A, and generic RPC.">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="TruvaG3">
+<meta property="og:title" content="Internal vs Remote Tools — How AI Agent Frameworks Wire In Each">
+<meta property="og:description" content="A reference map of where tools can live across ten AI agent frameworks and the documented declaration and call mechanism for each: in-process code, MCP servers, OpenAPI specs, remote agents over A2A, and generic RPC.">
+<meta property="og:url" content="https://truvag3.dev/whitepapers/agent-remote-tools">
+<meta property="og:image" content="https://truvag3.dev/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="TruvaG3 — Microagents Framework for Go">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Internal vs Remote Tools — How AI Agent Frameworks Wire In Each">
+<meta name="twitter:description" content="A reference map of where tools can live across ten AI agent frameworks and the documented declaration and call mechanism for each.">
+<meta name="twitter:image" content="https://truvag3.dev/og-image.png">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="stylesheet" href="/assets/css/site-nav.css">
+<style>
+  :root {
+    --bg: #0b0f17;
+    --bg-2: #121826;
+    --bg-3: #1a2236;
+    --ink: #e6edf7;
+    --muted: #9aa6bd;
+    --line: #2a3550;
+    --accent: #7cc4ff;
+    --warn: #fbbf24;
+    --good: #34d399;
+    --brand-truva-light: #DBEEFB;
+    --brand-truva-dark:  #4A8AB8;
+    --brand-g3-light:    #FFD080;
+    --brand-g3-dark:     #C56710;
+    --lc:   #1F6FEB;   --lg:  #14b8a6;   --crew: #7c3aed;
+    --adk:  #EA4335;   --sk:  #2EA5FF;   --ma:   #ec4899;
+    --maf:  #512BD4;   --l4j: #ED8B00;   --gk:   #00ADD8;
+    --rg:   #B7410E;
+    /* Mechanism accent colors */
+    --internal: #6ee7b7;
+    --mcp:      #a78bfa;
+    --openapi:  #fbbf24;
+    --a2a:      #f472b6;
+    --rpc:      #94a3b8;
+    --maxw: 1180px;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: radial-gradient(1200px 800px at 50% -10%, #1c2541 0%, var(--bg) 60%);
+    color: var(--ink);
+    font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  p code, li code, td code, h3 code, h4 code { color: #c9e2ff; background: rgba(124,196,255,.08); padding: 1px 5px; border-radius: 4px; font-size: 0.92em; }
+  pre {
+    background: var(--bg-3);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 14px 16px;
+    overflow: auto;
+    font-size: 12.5px;
+    line-height: 1.55;
+    color: #cfe1ff;
+    margin: 8px 0 12px;
+  }
+  pre code { background: transparent; padding: 0; color: inherit; font-size: inherit; }
+  pre .hi {
+    background: rgba(251, 191, 36, 0.18);
+    color: #fde68a;
+    padding: 0 3px;
+    border-radius: 3px;
+    font-weight: 600;
+    border-bottom: 1px dashed rgba(251, 191, 36, 0.55);
+  }
+  .container { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+
+  /* Header */
+  header.hero {
+    padding: 64px 0 36px;
+    text-align: center;
+    border-bottom: 1px solid var(--line);
+    position: relative;
+  }
+  .research-date {
+    display: inline-block;
+    margin-bottom: 18px;
+    padding: 5px 14px;
+    border-radius: 999px;
+    background: var(--bg-2);
+    border: 1px solid var(--line);
+    color: var(--muted);
+    font-size: 12px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+  }
+  .research-date b { color: var(--ink); font-weight: 600; letter-spacing: 0; text-transform: none; }
+  .ai-capsule {
+    display: inline-block;
+    margin-bottom: 18px;
+    margin-left: 8px;
+    padding: 5px 14px;
+    border-radius: 999px;
+    background: var(--bg-2);
+    border: 1px solid var(--warn);
+    color: var(--warn);
+    font-size: 12px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+  }
+  header.hero h1 {
+    font-size: clamp(28px, 4.4vw, 46px);
+    line-height: 1.1;
+    margin: 0 0 14px;
+    letter-spacing: -0.02em;
+    background: linear-gradient(90deg, #ffffff 0%, #9ec5ff 60%, #c4b5fd 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  header.hero .subtitle {
+    color: var(--muted);
+    font-size: 17px;
+    max-width: 820px;
+    margin: 0 auto 22px;
+  }
+  .pillrow {
+    display: flex; flex-wrap: wrap; justify-content: center; gap: 8px;
+  }
+  .pill {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 7px 13px; border-radius: 999px;
+    background: var(--bg-2); border: 1px solid var(--line);
+    color: var(--ink); font-size: 13px; cursor: pointer;
+    transition: transform .15s ease, background .15s ease, border-color .15s ease;
+  }
+  .pill:hover { transform: translateY(-1px); border-color: #3a4a72; text-decoration: none; }
+  .dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; }
+
+  /* Sections */
+  section { padding: 56px 0; border-bottom: 1px solid var(--line); }
+  section h2 { font-size: clamp(22px, 2.5vw, 30px); letter-spacing: -0.01em; margin: 0 0 8px; }
+  section .lede { color: var(--muted); max-width: 820px; margin: 0 0 28px; }
+
+  /* Universal pattern grid */
+  .universal-grid {
+    display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px;
+  }
+  @media (max-width: 980px) { .universal-grid { grid-template-columns: repeat(2, 1fr); } }
+  @media (max-width: 540px) { .universal-grid { grid-template-columns: 1fr; } }
+  .uni-item {
+    background: var(--bg-2); border: 1px solid var(--line); border-radius: 12px; padding: 14px 14px 16px;
+  }
+  .uni-item b { color: #fff; display: block; margin: 4px 0 4px; font-size: 14px; }
+  .uni-item .tag {
+    display: inline-block; font-size: 10.5px; padding: 2px 8px; border-radius: 999px;
+    background: #19243d; color: #9fc2ff; font-weight: 600; letter-spacing: 0.04em;
+  }
+  .uni-item p { margin: 6px 0 0; color: #cfd9ee; font-size: 13px; line-height: 1.45; }
+
+  /* Framework cards */
+  .frameworks { display: grid; gap: 28px; }
+  .fw-card {
+    background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.005));
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    overflow: hidden;
+  }
+  .fw-head {
+    display: flex; align-items: center; gap: 14px;
+    padding: 18px 22px;
+    border-bottom: 1px solid var(--line);
+    background: rgba(255,255,255,0.015);
+  }
+  .fw-badge {
+    width: 46px; height: 46px; border-radius: 12px;
+    display: grid; place-items: center;
+    color: #fff; font-weight: 700; font-size: 16px;
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,.18);
+    flex-shrink: 0;
+  }
+  .fw-head h3 { margin: 0; font-size: 19px; letter-spacing: -0.01em; }
+  .fw-head .sub { color: var(--muted); font-size: 13px; margin-top: 2px; }
+
+  .lang-pill {
+    display: inline-block;
+    font-size: 11px;
+    padding: 3px 11px;
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    vertical-align: 3px;
+    margin-left: 10px;
+    background: var(--bg-2);
+    border: 1px solid currentColor;
+  }
+  .lang-pill.py     { color: #FFD43B; }
+  .lang-pill.ts     { color: #4cb6ff; }
+  .lang-pill.dotnet { color: #a78bfa; }
+  .lang-pill.java   { color: #ED8B00; }
+  .lang-pill.go     { color: #00ADD8; }
+  .lang-pill.rust   { color: #fb6b3c; }
+
+  .fw-body { padding: 22px 22px 18px; }
+  .metaphor {
+    margin: 0 0 18px; padding: 10px 14px;
+    background: #0e1a2e; border-left: 3px solid var(--accent); border-radius: 8px;
+    color: #cfe1ff; font-style: italic; font-size: 14px;
+  }
+
+  /* Mechanism blocks within a card */
+  .mech {
+    border-top: 1px solid var(--line);
+    padding: 18px 0 4px;
+    margin-top: 6px;
+  }
+  .mech:first-of-type { border-top: none; padding-top: 0; margin-top: 0; }
+  .mech-title {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 12px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+    margin-bottom: 8px;
+    padding: 3px 11px; border-radius: 999px;
+    background: var(--bg-2); border: 1px solid currentColor;
+  }
+  .mech-title.internal { color: var(--internal); }
+  .mech-title.mcp      { color: var(--mcp); }
+  .mech-title.openapi  { color: var(--openapi); }
+  .mech-title.a2a      { color: var(--a2a); }
+  .mech-title.rpc      { color: var(--rpc); }
+  .mech p { margin: 0 0 10px; color: #d4dcef; font-size: 14.5px; }
+  .mech p.note {
+    background: rgba(148, 163, 184, 0.08);
+    border: 1px dashed var(--line);
+    padding: 8px 12px;
+    border-radius: 8px;
+    color: var(--muted);
+    font-size: 13.5px;
+  }
+
+  .twocol-snip {
+    display: grid; grid-template-columns: 1fr; gap: 0;
+  }
+
+  /* Tradeoffs miniblocks */
+  .twocol { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-top: 8px; }
+  @media (max-width: 600px) { .twocol { grid-template-columns: 1fr; } }
+  .miniblock { background: var(--bg-3); border: 1px solid var(--line); border-radius: 10px; padding: 10px 12px; }
+  .miniblock h5 { margin: 0 0 4px; font-size: 12px; color: #a8b6d6; letter-spacing: .05em; text-transform: uppercase; }
+  .miniblock p { margin: 0; font-size: 13px; color: #dbe6ff; }
+
+  .src {
+    margin-top: 14px; padding-top: 12px; border-top: 1px dashed var(--line);
+    font-size: 12.5px; color: var(--muted);
+  }
+  .src a { color: var(--accent); }
+  /* Per-snippet source attribution sits directly under each <pre>. */
+  .snip-src {
+    margin: -6px 0 14px;
+    padding-left: 4px;
+    font-size: 11.5px;
+    color: var(--muted);
+    line-height: 1.45;
+  }
+  .snip-src::before { content: "↳  "; color: #4b6688; }
+  .snip-src a {
+    color: var(--muted);
+    border-bottom: 1px dotted rgba(154,166,189,.4);
+    text-decoration: none;
+  }
+  .snip-src a:hover {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+
+  /* Comparison table */
+  .table-wrap { overflow: auto; border: 1px solid var(--line); border-radius: 12px; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 1000px; }
+  th, td { padding: 12px 14px; border-bottom: 1px solid var(--line); vertical-align: top; text-align: left; }
+  thead th { background: var(--bg-2); position: sticky; top: 0; font-weight: 600; }
+  th.fw, td.fw { white-space: nowrap; }
+  td.row-hd { background: var(--bg-2); font-weight: 600; white-space: nowrap; }
+  .yes { color: var(--good); font-weight: 600; }
+  .no  { color: #94a3b8; }
+  .partial { color: var(--warn); font-weight: 600; }
+
+  /* Takeaways */
+  .takeaways { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+  @media (max-width: 880px) { .takeaways { grid-template-columns: 1fr; } }
+  .ta {
+    background: var(--bg-2); border: 1px solid var(--line); border-radius: 14px; padding: 18px;
+  }
+  .ta h4 { margin: 0 0 8px; font-size: 15px; color: #fff; }
+  .ta p { margin: 0; color: #cfd9ee; font-size: 14px; }
+  .ta .tag {
+    display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 999px;
+    background: #19243d; color: #9fc2ff; margin-bottom: 8px;
+  }
+
+  /* Glossary */
+  .gloss { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px 22px; }
+  @media (max-width: 720px) { .gloss { grid-template-columns: 1fr; } }
+  .gloss div { padding: 8px 0; border-bottom: 1px dashed var(--line); color: #cfd9ee; }
+  .gloss b { color: #fff; }
+
+  footer { padding: 36px 0 64px; text-align: center; color: var(--muted); font-size: 13px; }
+  .copyright { color: var(--muted); font-size: 0.85rem; text-align: center; margin-top: 1.5rem; margin-bottom: 0; }
+</style>
+</head>
+<body>
+
+<nav class="site-nav">
+  <div class="container">
+    <a class="nav-brand" href="/"><span class="brand-truva">Truva</span><span class="brand-g3">G3</span></a>
+    <div class="nav-links">
+      <a href="/blogs/">Blog</a>
+      <a href="/whitepapers/">Whitepapers</a>
+      <a href="https://docs.truvag3.dev/docs/intro/">Docs</a>
+      <a href="https://github.com/truvaagents/truva-g3">GitHub</a>
+    </div>
+  </div>
+</nav>
+
+<header class="hero">
+  <div class="container">
+    <div class="research-date">Research date · <b>May 25, 2026</b></div>
+    <div class="ai-capsule">Generated with AI</div>
+    <h1>Internal vs Remote Tools — How AI Agent Frameworks Wire In Each</h1>
+    <p class="subtitle">
+      A reference map of where tools can live across ten AI agent frameworks &mdash; spanning
+      <b>Python</b>, <b>TypeScript</b>, <b>.NET</b>, <b>Java</b>, <b>Go</b>, and <b>Rust</b> &mdash;
+      and the official declaration and call mechanism for each: in-process code, MCP servers,
+      OpenAPI specs, remote agents over A2A, and generic RPC. Every code snippet is taken from
+      the framework's own documentation.
+    </p>
+    <div class="pillrow">
+      <a class="pill" href="#universal"><span class="dot" style="background:#9ec5ff"></span>The five wiring points</a>
+      <a class="pill" href="#langchain"><span class="dot" style="background:var(--lc)"></span>LangChain</a>
+      <a class="pill" href="#langgraph"><span class="dot" style="background:var(--lg)"></span>LangGraph</a>
+      <a class="pill" href="#crewai"><span class="dot" style="background:var(--crew)"></span>CrewAI</a>
+      <a class="pill" href="#adk"><span class="dot" style="background:var(--adk)"></span>Google ADK</a>
+      <a class="pill" href="#sk"><span class="dot" style="background:var(--sk)"></span>Semantic Kernel</a>
+      <a class="pill" href="#mastra"><span class="dot" style="background:var(--ma)"></span>Mastra</a>
+      <a class="pill" href="#maf"><span class="dot" style="background:var(--maf)"></span>MS Agent Framework</a>
+      <a class="pill" href="#l4j"><span class="dot" style="background:var(--l4j)"></span>LangChain4j</a>
+      <a class="pill" href="#genkit"><span class="dot" style="background:var(--gk)"></span>Genkit Go</a>
+      <a class="pill" href="#rig"><span class="dot" style="background:var(--rg)"></span>Rig</a>
+      <a class="pill" href="#compare"><span class="dot" style="background:#fff"></span>Side-by-side</a>
+      <a class="pill" href="#takeaways"><span class="dot" style="background:var(--good)"></span>Cheat sheet</a>
+    </div>
+  </div>
+</header>
+
+<!-- ================= UNIVERSAL PATTERN ================= -->
+<section id="universal">
+  <div class="container">
+    <h2>The five places a tool can live</h2>
+    <p class="lede">
+      Across the ten frameworks profiled here, tools are sourced from five categories. The
+      framework determines which categories have first-class APIs and which require custom code.
+      Each category is described below; per-framework support is summarised in the
+      <a href="#compare">side-by-side table</a>.
+    </p>
+    <div class="universal-grid">
+      <div class="uni-item">
+        <span class="tag" style="color: var(--internal); border: 1px solid currentColor; background: transparent">INTERNAL</span>
+        <b>In-process code</b>
+        <p>A function, class, or annotated method that runs in the agent's own runtime. Schema is derived from the host language's type system or from explicit metadata.</p>
+      </div>
+      <div class="uni-item">
+        <span class="tag" style="color: var(--mcp); border: 1px solid currentColor; background: transparent">MCP</span>
+        <b>Model Context Protocol</b>
+        <p>An open JSON-RPC protocol for tool servers, defined at <a href="https://modelcontextprotocol.io">modelcontextprotocol.io</a>. Transports include stdio (subprocess), streamable HTTP, and SSE. Tools are discovered at runtime via <code>list_tools</code>.</p>
+      </div>
+      <div class="uni-item">
+        <span class="tag" style="color: var(--openapi); border: 1px solid currentColor; background: transparent">OPENAPI</span>
+        <b>REST / OpenAPI</b>
+        <p>The framework parses an OpenAPI 3.x specification and generates one tool per operation, with parameters typed from the spec.</p>
+      </div>
+      <div class="uni-item">
+        <span class="tag" style="color: var(--a2a); border: 1px solid currentColor; background: transparent">A2A</span>
+        <b>Remote agent (A2A)</b>
+        <p>Another agent running on a different host, described by an <code>agent-card.json</code> at a <code>.well-known/</code> URL, invoked over HTTP per the <a href="https://a2a-protocol.org">A2A protocol</a>.</p>
+      </div>
+      <div class="uni-item">
+        <span class="tag" style="color: var(--rpc); border: 1px solid currentColor; background: transparent">RPC</span>
+        <b>Generic RPC / gRPC</b>
+        <p>No framework on this list provides a first-class generator from a gRPC / Thrift / other RPC schema. The documented pattern is to call the RPC client from within an in-process tool body.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ================= FRAMEWORK CARDS ================= -->
+<section id="frameworks" style="border-bottom: none;">
+  <div class="container">
+    <h2>Ten frameworks, five wiring points</h2>
+    <p class="lede">
+      Each card lists the in-process baseline (recapped from the companion paper
+      <a href="/whitepapers/agent-tool-wiring.html">How AI Agent Frameworks Wire In Tools and Agents</a>),
+      then the framework's documented mechanism for MCP, OpenAPI, A2A, and generic RPC.
+      Highlighted spans mark the line of code where each external tool source is attached to the
+      agent.
+    </p>
+
+    <div class="frameworks">
+
+      <!-- ============ LANGCHAIN ============ -->
+      <article class="fw-card" id="langchain">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--lc)">Lc</div>
+          <div>
+            <h3>LangChain <span class="lang-pill py">Python</span></h3>
+            <div class="sub">Decorator for internal; <code>langchain-mcp-adapters</code> for MCP; community <code>RequestsToolkit</code> for OpenAPI.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="metaphor">All external tool sources are exposed through adapter packages that produce a list of LangChain tools, which is passed to <code>create_agent</code>.</div>
+
+          <div class="mech">
+            <span class="mech-title internal">Internal</span>
+            <p>Recap: the <code>@tool</code> decorator turns a function into a tool; pass the list to <code>create_agent</code>.</p>
+            <pre><code>from langchain.tools import tool
+from langchain.agents import create_agent
+
+@tool
+def search_database(query: str) -&gt; str:
+    """Search the customer database."""
+    return f"results for {query}"
+
+agent = create_agent("openai:gpt-4o", <span class="hi">tools=[search_database]</span>)</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.langchain.com/oss/python/langchain/tools">docs.langchain.com · Tools · @tool decorator + create_agent</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title mcp">MCP</span>
+            <p>The <code>langchain-mcp-adapters</code> package ships <code>MultiServerMCPClient</code>, which connects to one or many MCP servers (stdio, SSE, or streamable HTTP) and returns a list of LangChain tools.</p>
+            <pre><code>from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain.agents import create_agent
+
+client = MultiServerMCPClient({
+    "math": {
+        "transport": "stdio",
+        "command": "python",
+        "args": ["/path/to/math_server.py"],
+    },
+    "weather": {
+        "transport": "streamable_http",
+        "url": "http://localhost:8000/mcp",
+    },
+})
+
+tools = await client.get_tools()
+agent = create_agent("anthropic:claude-sonnet-4-6", <span class="hi">tools=tools</span>)</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.langchain.com/oss/python/langchain/mcp">docs.langchain.com · MCP · MultiServerMCPClient</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title openapi">OpenAPI / REST</span>
+            <p>Use <code>RequestsToolkit</code> from <code>langchain_community</code> to expose generic HTTP verbs, then pair with prompt-based OpenAPI guidance. There is no auto-generator from spec to typed tools in core; the <code>langchain-community</code> openapi planner is the closest first-class option.</p>
+            <pre><code>from langchain_community.agent_toolkits.openapi.toolkit import RequestsToolkit
+from langchain_community.utilities.requests import TextRequestsWrapper
+
+toolkit = RequestsToolkit(
+    requests_wrapper=TextRequestsWrapper(headers={"Authorization": "Bearer …"}),
+    allow_dangerous_requests=True,
+)
+agent = create_agent(model, <span class="hi">tools=toolkit.get_tools()</span>)</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.langchain.com/oss/python/integrations/tools/openapi">docs.langchain.com · OpenAPI integration · RequestsToolkit</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title a2a">Remote agent (A2A)</span>
+            <p class="note">Not first-class in LangChain core. The recommended path is LangGraph's <code>RemoteGraph</code> (see next card) — wrap a deployed graph and embed it as a tool or subgraph.</p>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title rpc">Generic RPC</span>
+            <p class="note">Open the gRPC / Thrift / custom-RPC client inside the body of an <code>@tool</code>-decorated function. LangChain doesn't add anything special; the tool is just a callable.</p>
+          </div>
+
+          <div class="twocol">
+            <div class="miniblock"><h5>Mechanism</h5><p>All external tool sources are converted to LangChain <code>BaseTool</code> instances by adapter packages.</p></div>
+            <div class="miniblock"><h5>Notes</h5><p>Each remote source requires a separate adapter package. Connection lifecycle and authentication are configured per-adapter.</p></div>
+          </div>
+          <div class="src">Source · <a href="https://docs.langchain.com/oss/python/langchain/mcp">LangChain MCP docs</a> · <a href="https://docs.langchain.com/oss/python/integrations/tools/openapi">OpenAPI integration</a></div>
+        </div>
+      </article>
+
+      <!-- ============ LANGGRAPH ============ -->
+      <article class="fw-card" id="langgraph">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--lg)">Lg</div>
+          <div>
+            <h3>LangGraph <span class="lang-pill py">Python</span></h3>
+            <div class="sub">Inherits LangChain's adapters; adds <code>RemoteGraph</code> as the first-class A2A primitive.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="metaphor">A <code>RemoteGraph</code> is invoked or embedded as a subgraph using the same APIs as a local compiled graph.</div>
+
+          <div class="mech">
+            <span class="mech-title internal">Internal</span>
+            <p>Recap: tools are LangChain tools; the <code>ToolNode</code> fans them out in parallel.</p>
+            <pre><code>from langgraph.prebuilt import create_react_agent
+graph = create_react_agent(model, <span class="hi">tools=[check_weather]</span>)</code></pre>
+            <div class="snip-src">Source: <a href="https://reference.langchain.com/python/langgraph.prebuilt/chat_agent_executor/create_react_agent">reference.langchain.com · langgraph.prebuilt · create_react_agent</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title mcp">MCP</span>
+            <p>Inherits from LangChain — drop the <code>MultiServerMCPClient</code> output straight into <code>create_react_agent</code> or a <code>ToolNode</code>.</p>
+            <pre><code>from langgraph.prebuilt import create_react_agent
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+tools = await MultiServerMCPClient({
+    "github": {"transport": "streamable_http", "url": "https://mcp.github.com"},
+}).get_tools()
+
+graph = create_react_agent("openai:gpt-4o", <span class="hi">tools=tools</span>)</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.langchain.com/oss/python/langchain/mcp">docs.langchain.com · MCP · LangGraph integration via LangChain adapters</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title openapi">OpenAPI / REST</span>
+            <p class="note">Same as LangChain — use <code>RequestsToolkit</code> or community OpenAPI planners. There is no LangGraph-specific OpenAPI loader.</p>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title a2a">Remote agent (A2A) — <code>RemoteGraph</code></span>
+            <p><code>RemoteGraph</code> connects to a deployed LangGraph Platform graph at the given <code>url</code> and exposes the same interface as a local compiled graph. It can be invoked directly or embedded as a node in a parent graph.</p>
+            <pre><code>from langgraph.pregel.remote import RemoteGraph
+from langgraph.graph import StateGraph, MessagesState
+
+# Connect to a graph deployed on LangGraph Platform
+remote_graph = RemoteGraph("research_agent", url="https://&lt;deployment&gt;.langgraph.cloud")
+
+# 1. Call it directly
+result = await remote_graph.ainvoke(
+    {"messages": [{"role": "user", "content": "analyse Q1 earnings"}]}
+)
+
+# 2. Or embed it as a subgraph node in a larger orchestrator
+builder = StateGraph(MessagesState)
+builder.add_node(<span class="hi">"researcher", remote_graph</span>)   # remote graph as a local node
+builder.add_edge("researcher", "writer")
+super_graph = builder.compile()</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.langchain.com/langsmith/use-remote-graph">docs.langchain.com · LangSmith · Use RemoteGraph</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title rpc">Generic RPC</span>
+            <p class="note">Wrap the RPC client in any LangChain tool, or inside a custom node function — graph nodes are async Python callables.</p>
+          </div>
+
+          <div class="twocol">
+            <div class="miniblock"><h5>Mechanism</h5><p><code>RemoteGraph</code> uses the LangGraph SDK over HTTP. Checkpointer state is maintained on the remote deployment.</p></div>
+            <div class="miniblock"><h5>Constraints</h5><p>The remote endpoint must implement the LangGraph Platform API; arbitrary HTTP agents are not directly supported.</p></div>
+          </div>
+          <div class="src">Source · <a href="https://docs.langchain.com/langsmith/use-remote-graph"><code>RemoteGraph</code> docs</a> · MCP and OpenAPI inherited from LangChain</div>
+        </div>
+      </article>
+
+      <!-- ============ CREWAI ============ -->
+      <article class="fw-card" id="crewai">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--crew)">Cr</div>
+          <div>
+            <h3>CrewAI <span class="lang-pill py">Python</span></h3>
+            <div class="sub">Declarative <code>mcps=[...]</code> field on the Agent; first-class <code>A2AClientConfig</code> for remote agents.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="metaphor">Internal tools, MCP servers, and remote A2A endpoints are declared via dedicated fields on the <code>Agent</code> constructor: <code>tools=</code>, <code>mcps=</code>, and <code>a2a=</code>.</div>
+
+          <div class="mech">
+            <span class="mech-title internal">Internal</span>
+            <p>Recap: subclass <code>BaseTool</code> or use the <code>@tool</code> decorator; pass instances via <code>tools=</code>.</p>
+            <pre><code>from crewai import Agent
+researcher = Agent(role="Analyst", goal="…", backstory="…", <span class="hi">tools=[MyTool()]</span>)</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.crewai.com/en/concepts/tools">docs.crewai.com · Tools · Agent(tools=[...]) pattern</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title mcp">MCP — the <code>mcps=</code> field</span>
+            <p>The <code>mcps=</code> list on <code>Agent</code> accepts string references (remote HTTPS URLs or catalog slugs) and structured transport objects (<code>MCPServerStdio</code>, <code>MCPServerHTTP</code>, <code>MCPServerSSE</code>) in the same list. Stdio, streamable HTTP, and SSE transports are supported.</p>
+            <pre><code>from crewai import Agent
+from crewai.mcp import MCPServerStdio, MCPServerHTTP, MCPServerSSE
+
+agent = Agent(
+    role="Research Analyst",
+    goal="Research with full control over MCP connections",
+    backstory="Expert researcher",
+    <span class="hi">mcps=[
+        # String reference — remote HTTPS MCP server
+        "https://mcp.exa.ai/mcp?api_key=your_key",
+        # Stdio transport for a local subprocess MCP server
+        MCPServerStdio(
+            command="npx",
+            args=["-y", "@modelcontextprotocol/server-filesystem"],
+        ),
+        # Streamable HTTP for a remote MCP server
+        MCPServerHTTP(
+            url="https://api.example.com/mcp",
+            headers={"Authorization": "Bearer your_token"},
+        ),
+    ]</span>,
+)</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.crewai.com/en/mcp/overview">docs.crewai.com · MCP overview · Structured Configurations (mcps= field)</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title openapi">OpenAPI / REST</span>
+            <p class="note">No first-class OpenAPI loader. REST endpoints are typically wrapped in a custom <code>BaseTool</code> subclass or accessed by fronting the API with an MCP server and declaring it via <code>mcps=</code>.</p>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title a2a">Remote agent (A2A)</span>
+            <p>Installed with the <code>crewai[a2a]</code> extra. The <code>a2a=</code> field on <code>Agent</code> takes an <code>A2AClientConfig</code> pointing at the remote agent's <code>agent-card.json</code> endpoint.</p>
+            <pre><code>from crewai import Agent
+from crewai.a2a import A2AClientConfig
+
+agent = Agent(
+    role="Coordinator",
+    goal="Delegate work to a remote A2A agent",
+    backstory="Expert delegator",
+    <span class="hi">a2a=A2AClientConfig(
+        endpoint="https://remote.example.com/.well-known/agent-card.json",
+        timeout=120,
+        max_turns=10,
+    )</span>,
+)</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.crewai.com/en/learn/a2a-agent-delegation">docs.crewai.com · Agent-to-Agent (A2A) Protocol · A2AClientConfig</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title rpc">Generic RPC</span>
+            <p class="note">Wrap the RPC client call inside a custom <code>BaseTool._run</code> or <code>@tool</code>-decorated function.</p>
+          </div>
+
+          <div class="twocol">
+            <div class="miniblock"><h5>Mechanism</h5><p>Tool sources are declared via dedicated fields on <code>Agent</code>: <code>tools=</code>, <code>mcps=</code>, <code>a2a=</code>.</p></div>
+            <div class="miniblock"><h5>Notes</h5><p>OpenAPI ingestion is not provided as a first-class field; use a custom <code>BaseTool</code> or an MCP fronting server.</p></div>
+          </div>
+          <div class="src">Source · <a href="https://docs.crewai.com/en/mcp/overview">CrewAI MCP docs</a> · <a href="https://docs.crewai.com/en/learn/a2a-agent-delegation">A2A agent delegation</a></div>
+        </div>
+      </article>
+
+      <!-- ============ GOOGLE ADK ============ -->
+      <article class="fw-card" id="adk">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--adk)">Ad</div>
+          <div>
+            <h3>Google ADK <span class="lang-pill py">Python</span></h3>
+            <div class="sub">Built-in <code>MCPToolset</code>, <code>OpenAPIToolset</code>, and <code>RemoteA2aAgent</code> — every remote mechanism is a first-class object.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="metaphor">Each external tool source is represented by a dedicated class (<code>MCPToolset</code>, <code>OpenAPIToolset</code>, <code>RemoteA2aAgent</code>) attached to <code>LlmAgent</code> via <code>tools=</code> or <code>sub_agents=</code>.</div>
+
+          <div class="mech">
+            <span class="mech-title internal">Internal</span>
+            <p>Recap: a plain Python function is auto-wrapped as a <code>FunctionTool</code> when passed to <code>LlmAgent(tools=[…])</code>.</p>
+            <pre><code>from google.adk.agents import LlmAgent
+weather_agent = LlmAgent(model="gemini-2.0-flash", <span class="hi">tools=[get_weather]</span>)</code></pre>
+            <div class="snip-src">Source: <a href="https://google.github.io/adk-docs/tools-custom/function-tools/">google.github.io/adk-docs · Function tools (LlmAgent auto-wrapping)</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title mcp">MCP — <code>MCPToolset</code></span>
+            <p>An <code>MCPToolset</code> instance is added to an agent's <code>tools=</code> list. At runtime it connects to the MCP server (stdio or SSE) and exposes the server's tools to the agent.</p>
+            <pre><code>from google.adk.agents import LlmAgent
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset
+
+mcp_toolset = MCPToolset(
+    name="github_mcp",
+    stdio_command="docker",
+    stdio_args=["run", "-i", "--rm", "-e", "GITHUB_TOKEN",
+                "ghcr.io/github/github-mcp-server"],
+    env={"GITHUB_TOKEN": os.getenv("GITHUB_TOKEN")},
+)
+
+agent = LlmAgent(
+    name="github_agent",
+    model="gemini-2.0-flash",
+    <span class="hi">tools=[mcp_toolset]</span>,
+)</code></pre>
+            <div class="snip-src">Source: <a href="https://google.github.io/adk-docs/tools-custom/mcp-tools/">google.github.io/adk-docs · MCP tools · MCPToolset</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title openapi">OpenAPI — <code>OpenAPIToolset</code></span>
+            <p><code>OpenAPIToolset</code> parses an OpenAPI JSON or YAML specification and generates one tool per operation, with parameter schemas derived from the spec.</p>
+            <pre><code>from google.adk.tools.openapi_tool.openapi_spec_parser.openapi_toolset \
+    import OpenAPIToolset
+
+toolset = OpenAPIToolset(
+    spec_str=open("petstore.openapi.json").read(),
+    spec_str_type="json",
+)
+
+agent = LlmAgent(
+    name="petstore_agent",
+    model="gemini-2.0-flash",
+    <span class="hi">tools=[toolset]</span>,
+)</code></pre>
+            <div class="snip-src">Source: <a href="https://google.github.io/adk-docs/tools-custom/openapi-tools/">google.github.io/adk-docs · OpenAPI tools · OpenAPIToolset</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title a2a">Remote agent — <code>RemoteA2aAgent</code></span>
+            <p><code>RemoteA2aAgent</code> takes an <code>agent_card</code> (URL or local file path) and is attached to a parent agent's <code>sub_agents=</code> list. The runtime handles the A2A protocol exchange.</p>
+            <pre><code>from google.adk.agents import LlmAgent
+from google.adk.agents.remote_a2a_agent import RemoteA2aAgent
+
+prime_agent = RemoteA2aAgent(
+    name="prime_agent",
+    description="Agent that checks if numbers are prime.",
+    agent_card="http://localhost:8001/a2a/check_prime/.well-known/agent.json",
+    timeout=300.0,
+)
+
+root_agent = LlmAgent(
+    model="gemini-2.0-flash",
+    <span class="hi">sub_agents=[prime_agent]</span>,
+)</code></pre>
+            <div class="snip-src">Source: <a href="https://google.github.io/adk-docs/a2a/quickstart-consuming/">google.github.io/adk-docs · A2A · Quickstart consuming a remote agent</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title rpc">Generic RPC</span>
+            <p class="note">No first-class gRPC binding. The documented pattern is to call the gRPC client inside a function tool.</p>
+          </div>
+
+          <div class="twocol">
+            <div class="miniblock"><h5>Mechanism</h5><p>Each remote tool source has a dedicated class (<code>MCPToolset</code>, <code>OpenAPIToolset</code>, <code>RemoteA2aAgent</code>).</p></div>
+            <div class="miniblock"><h5>Notes</h5><p>Per-mechanism classes add API surface compared with a single-field declaration model.</p></div>
+          </div>
+          <div class="src">Source · <a href="https://google.github.io/adk-docs/tools-custom/mcp-tools/">MCP tools</a> · <a href="https://google.github.io/adk-docs/tools-custom/openapi-tools/">OpenAPI tools</a> · <a href="https://google.github.io/adk-docs/a2a/quickstart-consuming/">A2A consuming quickstart</a></div>
+        </div>
+      </article>
+
+      <!-- ============ SEMANTIC KERNEL ============ -->
+      <article class="fw-card" id="sk">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--sk)">Sk</div>
+          <div>
+            <h3>Microsoft Semantic Kernel <span class="lang-pill py">Python</span></h3>
+            <div class="sub">Plugins are the universal abstraction: <code>MCPStdioPlugin</code>, <code>add_plugin_from_openapi</code>, all registered on the Kernel.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="metaphor">All tool sources are represented as plugins registered on the <code>Kernel</code>. With <code>FunctionChoiceBehavior.Auto()</code>, the Kernel resolves and invokes the matching plugin function.</div>
+
+          <div class="mech">
+            <span class="mech-title internal">Internal</span>
+            <p>Recap: a class of <code>@kernel_function</code>-decorated methods, registered on the Kernel.</p>
+            <pre><code>from semantic_kernel import Kernel
+from semantic_kernel.functions import kernel_function
+
+class WeatherPlugin:
+    @kernel_function(description="Gets the weather for a city")
+    def get_weather(self, city: str) -&gt; str: return f"sunny in {city}"
+
+kernel = Kernel()
+<span class="hi">kernel.add_plugin(WeatherPlugin(), plugin_name="weather")</span></code></pre>
+            <div class="snip-src">Source: <a href="https://learn.microsoft.com/en-us/semantic-kernel/concepts/kernel">learn.microsoft.com · Understanding the kernel (Python plugin example)</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title mcp">MCP — <code>MCPStdioPlugin</code> / <code>MCPSsePlugin</code></span>
+            <p>An MCP server is wrapped as a plugin via an async context manager (<code>MCPStdioPlugin</code> for stdio transport, <code>MCPSsePlugin</code> for SSE) and registered on the Kernel via <code>kernel.add_plugin</code>.</p>
+            <pre><code>import os
+from semantic_kernel import Kernel
+from semantic_kernel.connectors.mcp import MCPStdioPlugin
+
+async with MCPStdioPlugin(
+    name="Github",
+    description="Github Plugin",
+    command="docker",
+    args=["run", "-i", "--rm", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+          "ghcr.io/github/github-mcp-server"],
+    env={"GITHUB_PERSONAL_ACCESS_TOKEN":
+         os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN")},
+) as github_plugin:
+    kernel = Kernel()
+    <span class="hi">kernel.add_plugin(github_plugin)</span></code></pre>
+            <div class="snip-src">Source: <a href="https://learn.microsoft.com/en-us/semantic-kernel/concepts/plugins/adding-mcp-plugins">learn.microsoft.com · Adding MCP plugins · MCPStdioPlugin (GitHub example)</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title openapi">OpenAPI — <code>add_plugin_from_openapi</code></span>
+            <p><code>kernel.add_plugin_from_openapi</code> accepts an OpenAPI spec URL or file path and registers one kernel function per operation.</p>
+            <pre><code>from semantic_kernel import Kernel
+from semantic_kernel.connectors.openapi_plugin import \
+    OpenAPIFunctionExecutionParameters
+
+kernel = Kernel()
+<span class="hi">await kernel.add_plugin_from_openapi(
+    plugin_name="lights",
+    openapi_document_path="https://example.com/v1/swagger.json",
+    execution_settings=OpenAPIFunctionExecutionParameters(
+        enable_payload_namespacing=True,
+    ),
+)</span></code></pre>
+            <div class="snip-src">Source: <a href="https://learn.microsoft.com/en-us/semantic-kernel/concepts/plugins/adding-openapi-plugins">learn.microsoft.com · Adding OpenAPI plugins · add_plugin_from_openapi</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title a2a">Remote agent (A2A)</span>
+            <p class="note">No first-class A2A primitive in the Python SDK. The documented pattern is to expose the producing agent's Kernel as an MCP server (via <code>kernel.as_mcp_server</code>) and consume it from the calling agent via <code>MCPStdioPlugin</code> or <code>MCPSsePlugin</code>.</p>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title rpc">Generic RPC</span>
+            <p class="note">No first-class gRPC binding. The documented pattern is to wrap the gRPC client in a kernel function registered via <code>kernel.add_function()</code>.</p>
+          </div>
+
+          <div class="twocol">
+            <div class="miniblock"><h5>Mechanism</h5><p>A single abstraction (plugin) covers internal code, MCP, and OpenAPI sources.</p></div>
+            <div class="miniblock"><h5>Notes</h5><p>A2A is achieved by composing an MCP server on one side with an MCP plugin on the other; no dedicated A2A class exists.</p></div>
+          </div>
+          <div class="src">Source · <a href="https://learn.microsoft.com/en-us/semantic-kernel/concepts/plugins/adding-mcp-plugins">MCP plugins</a> · <a href="https://learn.microsoft.com/en-us/semantic-kernel/concepts/plugins/adding-openapi-plugins">OpenAPI plugins</a></div>
+        </div>
+      </article>
+
+      <!-- ============ MASTRA ============ -->
+      <article class="fw-card" id="mastra">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--ma)">Ma</div>
+          <div>
+            <h3>Mastra <span class="lang-pill ts">TypeScript</span></h3>
+            <div class="sub"><code>MCPClient</code> from <code>@mastra/mcp</code>, plus a first-class <code>A2AAgent</code> for remote agents.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="metaphor">MCP tools are attached via <code>tools: await mcp.listTools()</code>. Remote A2A agents are attached via the <code>agents:</code> map on the <code>Agent</code> constructor.</div>
+
+          <div class="mech">
+            <span class="mech-title internal">Internal</span>
+            <p>Recap: <code>createTool({...})</code> with Zod schemas; attach via the agent's <code>tools</code> map.</p>
+            <pre><code>export const weatherAgent = new Agent({
+  id: 'weather-agent', model: 'openai/gpt-4o',
+  <span class="hi">tools: { weatherTool }</span>,
+})</code></pre>
+            <div class="snip-src">Source: <a href="https://mastra.ai/docs/agents/using-tools">mastra.ai · Agents · Using tools (Agent with tools map)</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title mcp">MCP — <code>MCPClient</code></span>
+            <p>The <code>MCPClient</code> constructor accepts a <code>servers</code> map keyed by server name. Each server is configured with <code>command</code>/<code>args</code> for stdio transport or <code>url</code> for HTTP transport. <code>listTools()</code> returns a tools map suitable for an <code>Agent</code>'s <code>tools</code> field.</p>
+            <pre><code>import { MCPClient } from '@mastra/mcp'
+import { Agent } from '@mastra/core/agent'
+
+export const mcp = new MCPClient({
+  id: 'mcp-client',
+  servers: {
+    wikipedia: { command: 'npx', args: ['-y', 'wikipedia-mcp'] },
+    weather:   { url: new URL(`https://server.smithery.ai/.../mcp?api_key=${KEY}`) },
+  },
+})
+
+export const researchAgent = new Agent({
+  id: 'research-agent',
+  model: 'openai/gpt-4o',
+  instructions: 'Use the Wikipedia and weather MCP servers when needed.',
+  <span class="hi">tools: await mcp.listTools()</span>,
+})</code></pre>
+            <div class="snip-src">Source: <a href="https://mastra.ai/docs/mcp/overview">mastra.ai · MCP overview · MCPClient + listTools</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title openapi">OpenAPI / REST</span>
+            <p class="note">No first-class OpenAPI loader. REST calls are typically made inside the <code>execute</code> function of a <code>createTool</code> definition.</p>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title a2a">Remote agent — <code>A2AAgent</code></span>
+            <p><code>A2AAgent</code> takes an A2A-compliant <code>.well-known</code> agent-card URL and optional headers. It is attached under a supervising agent's <code>agents</code> map, where Mastra auto-exposes it as a tool named <code>agent-&lt;key&gt;</code>.</p>
+            <pre><code>import { Agent } from '@mastra/core/agent'
+import { A2AAgent } from '@mastra/core/a2a'
+
+const a2aWeatherAgent = new A2AAgent({
+  url: 'https://py.acme.com/api/a2a/.well-known/a2a-weather-agent/agent-card.json',
+  headers: { 'x-api-key': process.env.A2A_AGENT_API_KEY! },
+})
+
+export const weatherAgent = new Agent({
+  id: 'weather-agent',
+  model: 'anthropic/claude-opus-4-6',
+  instructions: 'Delegate weather questions to a2aWeatherAgent.',
+  <span class="hi">agents: { a2aWeatherAgent }</span>,
+})</code></pre>
+            <div class="snip-src">Source: <a href="https://mastra.ai/blog/introducing-agent-to-agent-support">mastra.ai · Introducing Agent-to-Agent support · A2AAgent example</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title rpc">Generic RPC</span>
+            <p class="note">No first-class gRPC binding. Node gRPC libraries can be called inside the tool's <code>execute</code> function.</p>
+          </div>
+
+          <div class="twocol">
+            <div class="miniblock"><h5>Mechanism</h5><p>Internal tools, MCP tools, sub-agents, and A2A agents are all attached via constructor fields on <code>Agent</code> (<code>tools</code>, <code>agents</code>).</p></div>
+            <div class="miniblock"><h5>Notes</h5><p>No OpenAPI loader; spec-to-client codegen is sourced from the broader TypeScript ecosystem.</p></div>
+          </div>
+          <div class="src">Source · <a href="https://mastra.ai/docs/mcp/overview">Mastra MCP overview</a> · <a href="https://mastra.ai/blog/introducing-agent-to-agent-support">Mastra A2A announcement</a></div>
+        </div>
+      </article>
+
+      <!-- ============ MS AGENT FRAMEWORK ============ -->
+      <article class="fw-card" id="maf">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--maf)">Mf</div>
+          <div>
+            <h3>Microsoft Agent Framework <span class="lang-pill dotnet">.NET</span></h3>
+            <div class="sub"><code>McpClientFactory</code> for MCP; OpenAPI via the Semantic Kernel plugin pipeline.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="metaphor">All tool sources are exposed as <code>AITool</code> instances. Factories (<code>AIFunctionFactory</code>, <code>McpClientFactory</code>) produce them from method references or remote endpoints.</div>
+
+          <div class="mech">
+            <span class="mech-title internal">Internal</span>
+            <p>Recap: any C# method becomes a tool via <code>AIFunctionFactory.Create</code>.</p>
+            <pre><code>AIAgent agent = client.AsAIAgent(
+    model: "gpt-4o-mini",
+    instructions: "You are a helpful assistant",
+    <span class="hi">tools: [ AIFunctionFactory.Create(GetWeather) ]</span>);</code></pre>
+            <div class="snip-src">Source: <a href="https://learn.microsoft.com/en-us/agent-framework/agents/tools/function-tools">learn.microsoft.com · Function tools (AIFunctionFactory.Create)</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title mcp">MCP — <code>McpClientFactory</code></span>
+            <p>An MCP client is created via <code>McpClientFactory.CreateAsync</code> with a transport (e.g. <code>StdioClientTransport</code>). <code>ListToolsAsync</code> returns the available tools, which are cast to <code>AITool</code> and passed to the agent.</p>
+            <pre><code>await using var mcpClient = await McpClientFactory.CreateAsync(
+    new StdioClientTransport(new() {
+        Name = "MCPServer",
+        Command = "npx",
+        Arguments = ["-y", "@modelcontextprotocol/server-github"],
+    }));
+
+var mcpTools = await mcpClient.ListToolsAsync();
+
+AIAgent agent = new AIProjectClient(endpoint, new DefaultAzureCredential())
+    .AsAIAgent(
+        model: deploymentName,
+        <span class="hi">tools: [.. mcpTools.Cast&lt;AITool&gt;()]</span>);</code></pre>
+            <div class="snip-src">Source: <a href="https://learn.microsoft.com/en-us/agent-framework/agents/tools/local-mcp-tools">learn.microsoft.com · Local MCP tools (McpClientFactory.CreateAsync)</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title openapi">OpenAPI</span>
+            <p>OpenAPI ingestion is provided via the Semantic Kernel pipeline. <code>kernel.ImportPluginFromOpenApi</code> registers a plugin whose functions are passed to the agent as tools.</p>
+            <pre><code>var kernel = new Kernel();
+<span class="hi">kernel.ImportPluginFromOpenApi("GitHubPlugin",
+    new Uri("https://api.github.com/openapi.json"))</span>;
+// Pass kernel.Plugins["GitHubPlugin"] functions to the agent's tools list.</code></pre>
+            <div class="snip-src">Source: <a href="https://learn.microsoft.com/en-us/semantic-kernel/concepts/plugins/adding-openapi-plugins">learn.microsoft.com · Adding OpenAPI plugins · ImportPluginFromOpenApi (inherited by MAF)</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title a2a">Remote agent (A2A)</span>
+            <p class="note">No first-class A2A primitive in the current SDK. The documented patterns are to expose the remote agent as an MCP server and consume it via <code>McpClientFactory</code>, or to host remote agents through workflow primitives on Azure AI Foundry.</p>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title rpc">Generic RPC</span>
+            <p class="note">No first-class gRPC binding. The documented pattern is to call a gRPC client (e.g. <code>Grpc.Net.Client</code>) inside a method exposed via <code>AIFunctionFactory.Create</code>.</p>
+          </div>
+
+          <div class="twocol">
+            <div class="miniblock"><h5>Mechanism</h5><p>OpenAPI support is inherited via the Semantic Kernel plugin pipeline. Hosted under ASP.NET Core with standard DI.</p></div>
+            <div class="miniblock"><h5>Notes</h5><p>Cross-vendor agent collaboration is documented via MCP rather than a dedicated A2A primitive.</p></div>
+          </div>
+          <div class="src">Source · <a href="https://learn.microsoft.com/en-us/agent-framework/agents/tools/local-mcp-tools">MAF MCP tools</a> · <a href="https://learn.microsoft.com/en-us/semantic-kernel/concepts/plugins/adding-openapi-plugins">SK OpenAPI plugins</a></div>
+        </div>
+      </article>
+
+      <!-- ============ LANGCHAIN4J ============ -->
+      <article class="fw-card" id="l4j">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--l4j)">L4j</div>
+          <div>
+            <h3>LangChain4j <span class="lang-pill java">Java</span></h3>
+            <div class="sub">Three-step MCP pattern: <code>McpTransport</code> → <code>McpClient</code> → <code>McpToolProvider</code> → <code>AiServices</code>.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="metaphor">Tools are sourced from a <code>ToolProvider</code> or supplied directly via <code>@Tool</code>-annotated objects. MCP integration is implemented as an <code>McpToolProvider</code>.</div>
+
+          <div class="mech">
+            <span class="mech-title internal">Internal</span>
+            <p>Recap: <code>@Tool</code>-annotated POJO methods, registered with <code>AiServices.builder().tools(...)</code>.</p>
+            <pre><code>Assistant assistant = AiServices.builder(Assistant.class)
+    .chatModel(model)
+    <span class="hi">.tools(new Calculator())</span>
+    .build();</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.langchain4j.dev/tutorials/tools">docs.langchain4j.dev · Tools (Function Calling) · AiServices.builder().tools(...)</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title mcp">MCP — transport → client → provider</span>
+            <p>Construct an <code>McpTransport</code> (stdio, streamable HTTP, WebSocket, or Docker), wrap it in a <code>DefaultMcpClient</code>, register the client with an <code>McpToolProvider</code>, and attach the provider to the AI service via <code>AiServices.builder(...).toolProvider(...)</code>.</p>
+            <pre><code>// 1. Transport — start an MCP server as a subprocess
+McpTransport transport = StdioMcpTransport.builder()
+    .command(List.of("/usr/bin/npm", "exec",
+        "@modelcontextprotocol/server-everything@0.6.2"))
+    .build();
+
+// 2. Client
+McpClient mcpClient = DefaultMcpClient.builder()
+    .key("MyMCPClient")
+    .transport(transport)
+    .build();
+
+// 3. Tool provider — optionally filter which tools to expose
+McpToolProvider toolProvider = McpToolProvider.builder()
+    .mcpClients(mcpClient)
+    .filterToolNames("get_issue", "list_issues")
+    .build();
+
+// 4. Wire into AI service
+Bot bot = AiServices.builder(Bot.class)
+    .chatModel(model)
+    <span class="hi">.toolProvider(toolProvider)</span>
+    .build();</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.langchain4j.dev/tutorials/mcp">docs.langchain4j.dev · MCP · StdioMcpTransport + McpToolProvider pipeline</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title openapi">OpenAPI</span>
+            <p class="note">No first-class OpenAPI loader. REST calls are typically wrapped in <code>@Tool</code>-annotated methods, or accessed via an MCP fronting server.</p>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title a2a">Remote agent (A2A)</span>
+            <p class="note">No first-class A2A primitive. Local agents can be exposed as tools; remote agents are accessed by wrapping them as an MCP server.</p>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title rpc">Generic RPC</span>
+            <p class="note">No first-class gRPC binding. The documented pattern is to call a Java gRPC client inside a <code>@Tool</code>-annotated method.</p>
+          </div>
+
+          <div class="twocol">
+            <div class="miniblock"><h5>Mechanism</h5><p>MCP coverage includes stdio, streamable HTTP, WebSocket, and Docker transports.</p></div>
+            <div class="miniblock"><h5>Notes</h5><p>Tool registration is a four-step pipeline: transport → client → provider → AI service.</p></div>
+          </div>
+          <div class="src">Source · <a href="https://docs.langchain4j.dev/tutorials/mcp">LangChain4j MCP tutorial</a></div>
+        </div>
+      </article>
+
+      <!-- ============ GENKIT GO ============ -->
+      <article class="fw-card" id="genkit">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--gk)">Gk</div>
+          <div>
+            <h3>Genkit <span class="lang-pill go">Go</span></h3>
+            <div class="sub">Dedicated <code>plugins/mcp</code> package; multi-server management via <code>MCPManager</code>.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="metaphor">MCP servers are registered in an <code>MCPManager</code>; the manager holds connections and exposes tools keyed by server name.</div>
+
+          <div class="mech">
+            <span class="mech-title internal">Internal</span>
+            <p>Recap: <code>genkit.DefineTool</code> with a typed input struct; pass via <code>ai.WithTools</code>.</p>
+            <pre><code>getWeatherTool := genkit.DefineTool(g, "getWeather", "Gets the weather",
+    func(ctx *ai.ToolContext, in WeatherInput) (string, error) { /* ... */ })
+
+resp, _ := genkit.Generate(ctx, g, ai.WithPrompt("…"),
+    <span class="hi">ai.WithTools(getWeatherTool)</span>)</code></pre>
+            <div class="snip-src">Source: <a href="https://genkit.dev/docs/go/tool-calling/">genkit.dev · Tool calling (Go) · DefineTool + WithTools</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title mcp">MCP — <code>MCPManager</code></span>
+            <p>The <code>plugins/mcp</code> package provides <code>NewMCPManager</code>, which holds multiple MCP server connections. Servers may be declared up front via <code>MCPManagerOptions.MCPServers</code> or added at runtime via <code>ConnectServer</code>.</p>
+            <pre><code>package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/mcp"
+)
+
+func main() {
+    ctx := context.Background()
+    g, _ := genkit.Init(ctx)
+
+    // Configure one or more MCP servers up front
+    manager, err := mcp.NewMCPManager(mcp.MCPManagerOptions{
+        Name: "my-app",
+        MCPServers: map[string]mcp.MCPClientOptions{
+            "everything": {
+                Name: "everything-server",
+                <span class="hi">Stdio: &mcp.StdioConfig{
+                    Command: "npx",
+                    Args:    []string{"-y", "@modelcontextprotocol/server-everything"},
+                }</span>,
+            },
+        },
+    })
+    if err != nil { log.Fatal(err) }
+
+    // Connect additional servers at runtime
+    _ = manager.ConnectServer(ctx, "weather", mcp.MCPClientOptions{
+        Name: "weather-server",
+        Stdio: &mcp.StdioConfig{Command: "python", Args: []string{"weather_server.py"}},
+    })
+}</code></pre>
+            <div class="snip-src">Source: <a href="https://pkg.go.dev/github.com/firebase/genkit/go/plugins/mcp">pkg.go.dev · firebase/genkit/go/plugins/mcp · NewMCPManager + ConnectServer</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title openapi">OpenAPI</span>
+            <p class="note">No first-class OpenAPI loader. The documented pattern is to generate a Go client from the spec (e.g. with <code>oapi-codegen</code>) and call it inside a <code>genkit.DefineTool</code> handler.</p>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title a2a">Remote agent (A2A)</span>
+            <p class="note">No first-class A2A primitive. The documented pattern is to set <code>WithReturnToolRequests(true)</code> to take over the tool-call loop and proxy requests to remote agents over HTTP.</p>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title rpc">Generic RPC</span>
+            <p class="note">No first-class gRPC binding. The documented pattern is to call a Go gRPC client inside a tool handler.</p>
+          </div>
+
+          <div class="twocol">
+            <div class="miniblock"><h5>Mechanism</h5><p>Compiles to a single Go binary. The MCP manager uses goroutines to multiplex connections to multiple servers.</p></div>
+            <div class="miniblock"><h5>Notes</h5><p>Of the four remote sources, only MCP has first-class support; OpenAPI and A2A require custom code.</p></div>
+          </div>
+          <div class="src">Source · <a href="https://pkg.go.dev/github.com/firebase/genkit/go/plugins/mcp">pkg.go.dev · plugins/mcp</a> · <a href="https://genkit.dev/docs/go/tool-calling/">Genkit Go tool calling</a></div>
+        </div>
+      </article>
+
+      <!-- ============ RIG ============ -->
+      <article class="fw-card" id="rig">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--rg)">Rg</div>
+          <div>
+            <h3>Rig <span class="lang-pill rust">Rust</span></h3>
+            <div class="sub">MCP via the <code>rmcp</code> Cargo feature; tool servers can mix static, dynamic, and MCP tools.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="metaphor">As of Rig 0.16, MCP integration uses the official Rust MCP SDK (<code>rmcp</code>) under the <code>rmcp</code> Cargo feature. The earlier <code>mcp-core</code> integration is deprecated and scheduled for removal in 0.18.</div>
+
+          <div class="mech">
+            <span class="mech-title internal">Internal</span>
+            <p>Recap: implement the <code>Tool</code> trait or use the <code>#[rig_tool]</code> macro; attach via the agent builder's <code>.tool(...)</code>.</p>
+            <pre><code>let agent = client.agent("gpt-4o")
+    .preamble("You are a calculator.")
+    <span class="hi">.tool(Adder)</span>
+    .build();</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.rig.rs/docs/concepts/tools#using-tools-with-agents">docs.rig.rs · Tools · Using Tools with Agents (.tool() builder)</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title mcp">MCP — <code>rmcp</code> integration</span>
+            <p>The <code>rmcp</code> Cargo feature enables the official Rust MCP SDK. The application connects to an MCP server through <code>rmcp</code> transports, lists tools, and attaches each to a Rig agent (or to a shared <code>ToolServer</code> handle) via <code>.rmcp_tool(tool, peer)</code> on the agent builder. The earlier <code>mcp-core</code> integration is deprecated and scheduled for removal in 0.18.</p>
+            <pre><code># Cargo.toml
+rig-core = { version = "0.16", features = ["rmcp"] }
+rmcp     = { version = "0.x", features = ["client", "transport-child-process"] }</code></pre>
+            <div class="snip-src">Source: <a href="https://github.com/0xPlaygrounds/rig/discussions/635">github.com/0xPlaygrounds/rig · Discussion #635 · Rig 0.16.0 release (rmcp Cargo feature)</a></div>
+            <pre><code>use rig::providers::openai;
+use rmcp::{ServiceExt, transport::child_process::TokioChildProcess};
+use tokio::process::Command;
+
+// 1. Connect to the MCP server as a subprocess
+let transport = TokioChildProcess::new(
+    Command::new("npx").args(["-y", "@modelcontextprotocol/server-everything"]),
+)?;
+let mcp_client = ().serve(transport).await?;
+
+// 2. Discover its tools and attach them to a Rig agent
+let tools = mcp_client.list_tools(Default::default()).await?;
+let mut builder = openai::Client::from_env()
+    .agent("gpt-4o")
+    .preamble("Use the available MCP tools.");
+
+for tool in tools.tools {
+    builder = <span class="hi">builder.rmcp_tool(tool, mcp_client.peer().clone())</span>;
+}
+let agent = builder.build();</code></pre>
+            <div class="snip-src">Source: <a href="https://github.com/0xPlaygrounds/rig/discussions/635">github.com/0xPlaygrounds/rig · Discussion #635 · rmcp integration pattern</a> · <a href="https://docs.rig.rs/docs/concepts/tools">docs.rig.rs · Tools (ToolServer + rmcp)</a></div>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title openapi">OpenAPI</span>
+            <p class="note">No first-class OpenAPI loader. The documented pattern is to generate a typed client from the spec (e.g. with <code>progenitor</code> or <code>openapitor</code>) and call it from a Rig <code>Tool</code> implementation.</p>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title a2a">Remote agent (A2A)</span>
+            <p class="note">No first-class A2A primitive. Tool sharing across agents in the same process is supported by the <code>ToolServer</code> handle. For cross-process coordination, the documented pattern is to expose the agent as an MCP server via <code>rmcp</code> and consume it via the MCP pattern above.</p>
+          </div>
+
+          <div class="mech">
+            <span class="mech-title rpc">Generic RPC</span>
+            <p class="note">No first-class gRPC binding. The documented pattern is to call Tonic (or another Rust RPC client) inside a <code>Tool</code> trait implementation.</p>
+          </div>
+
+          <div class="twocol">
+            <div class="miniblock"><h5>Mechanism</h5><p>MCP integration uses the official Rust MCP SDK (<code>rmcp</code>) under the <code>rmcp</code> Cargo feature.</p></div>
+            <div class="miniblock"><h5>Notes</h5><p>The <code>mcp-core</code> → <code>rmcp</code> migration is in progress; the <code>mcp-core</code> integration is scheduled for removal in 0.18.</p></div>
+          </div>
+          <div class="src">Source · <a href="https://github.com/0xPlaygrounds/rig/discussions/635">Rig 0.16.0 release notes (rmcp integration)</a> · <a href="https://docs.rig.rs/docs/concepts/tools">Rig Tools docs</a></div>
+        </div>
+      </article>
+
+    </div>
+  </div>
+</section>
+
+<!-- ================= COMPARISON ================= -->
+<section id="compare">
+  <div class="container">
+    <h2>Side-by-side · first-class remote-tool support</h2>
+    <p class="lede">
+      <span class="yes">●</span> = first-class API ·
+      <span class="partial">◐</span> = supported via wrapper / sibling library ·
+      <span class="no">○</span> = no first-class support; the documented pattern is to call the source from an in-process tool body.
+    </p>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th class="fw"><span class="dot" style="background:var(--lc)"></span> LangChain</th>
+            <th class="fw"><span class="dot" style="background:var(--lg)"></span> LangGraph</th>
+            <th class="fw"><span class="dot" style="background:var(--crew)"></span> CrewAI</th>
+            <th class="fw"><span class="dot" style="background:var(--adk)"></span> ADK</th>
+            <th class="fw"><span class="dot" style="background:var(--sk)"></span> Semantic Kernel</th>
+            <th class="fw"><span class="dot" style="background:var(--ma)"></span> Mastra</th>
+            <th class="fw"><span class="dot" style="background:var(--maf)"></span> MS Agent Fw</th>
+            <th class="fw"><span class="dot" style="background:var(--l4j)"></span> LangChain4j</th>
+            <th class="fw"><span class="dot" style="background:var(--gk)"></span> Genkit Go</th>
+            <th class="fw"><span class="dot" style="background:var(--rg)"></span> Rig</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="row-hd">Internal tools</td>
+            <td class="yes">●</td><td class="yes">●</td><td class="yes">●</td><td class="yes">●</td><td class="yes">●</td>
+            <td class="yes">●</td><td class="yes">●</td><td class="yes">●</td><td class="yes">●</td><td class="yes">●</td>
+          </tr>
+          <tr>
+            <td class="row-hd">MCP (consumer)</td>
+            <td class="yes">●</td><td class="yes">●</td><td class="yes">●</td><td class="yes">●</td><td class="yes">●</td>
+            <td class="yes">●</td><td class="yes">●</td><td class="yes">●</td><td class="yes">●</td><td class="yes">●</td>
+          </tr>
+          <tr>
+            <td class="row-hd">MCP server (exposing your tools)</td>
+            <td class="partial">◐</td><td class="partial">◐</td><td class="partial">◐</td><td class="yes">●</td><td class="yes">●</td>
+            <td class="yes">●</td><td class="partial">◐</td><td class="partial">◐</td><td class="yes">●</td><td class="yes">●</td>
+          </tr>
+          <tr>
+            <td class="row-hd">OpenAPI / REST loader</td>
+            <td class="partial">◐</td><td class="partial">◐</td><td class="no">○</td><td class="yes">●</td><td class="yes">●</td>
+            <td class="no">○</td><td class="yes">●</td><td class="no">○</td><td class="no">○</td><td class="no">○</td>
+          </tr>
+          <tr>
+            <td class="row-hd">Remote agent (A2A)</td>
+            <td class="no">○</td><td class="yes">●</td><td class="yes">●</td><td class="yes">●</td><td class="no">○</td>
+            <td class="yes">●</td><td class="no">○</td><td class="no">○</td><td class="no">○</td><td class="no">○</td>
+          </tr>
+          <tr>
+            <td class="row-hd">A2A primitive name</td>
+            <td><span class="no">—</span></td>
+            <td><code>RemoteGraph</code></td>
+            <td><code>A2AClientConfig</code></td>
+            <td><code>RemoteA2aAgent</code></td>
+            <td><span class="no">via MCP</span></td>
+            <td><code>A2AAgent</code></td>
+            <td><span class="no">via MCP</span></td>
+            <td><span class="no">via MCP</span></td>
+            <td><span class="no">—</span></td>
+            <td><span class="no">via MCP</span></td>
+          </tr>
+          <tr>
+            <td class="row-hd">MCP transports</td>
+            <td>stdio · SSE · HTTP</td>
+            <td>inherits LC</td>
+            <td>stdio · SSE · HTTP</td>
+            <td>stdio · SSE</td>
+            <td>stdio · SSE</td>
+            <td>stdio · HTTP</td>
+            <td>stdio · HTTP</td>
+            <td>stdio · HTTP · WS · Docker</td>
+            <td>stdio · HTTP</td>
+            <td>via <code>rmcp</code></td>
+          </tr>
+          <tr>
+            <td class="row-hd">Canonical doc</td>
+            <td><a href="https://docs.langchain.com/oss/python/langchain/mcp">MCP</a></td>
+            <td><a href="https://docs.langchain.com/langsmith/use-remote-graph">RemoteGraph</a></td>
+            <td><a href="https://docs.crewai.com/en/mcp/overview">MCP</a> · <a href="https://docs.crewai.com/en/learn/a2a-agent-delegation">A2A</a></td>
+            <td><a href="https://google.github.io/adk-docs/tools-custom/mcp-tools/">MCP</a> · <a href="https://google.github.io/adk-docs/a2a/quickstart-consuming/">A2A</a></td>
+            <td><a href="https://learn.microsoft.com/en-us/semantic-kernel/concepts/plugins/adding-mcp-plugins">MCP</a></td>
+            <td><a href="https://mastra.ai/docs/mcp/overview">MCP</a> · <a href="https://mastra.ai/blog/introducing-agent-to-agent-support">A2A</a></td>
+            <td><a href="https://learn.microsoft.com/en-us/agent-framework/agents/tools/local-mcp-tools">MCP</a></td>
+            <td><a href="https://docs.langchain4j.dev/tutorials/mcp">MCP</a></td>
+            <td><a href="https://pkg.go.dev/github.com/firebase/genkit/go/plugins/mcp">mcp pkg</a></td>
+            <td><a href="https://github.com/0xPlaygrounds/rig/discussions/635">rmcp release</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- ================= TAKEAWAYS ================= -->
+<section id="takeaways">
+  <div class="container">
+    <h2>Summary observations</h2>
+    <p class="lede">Six factual observations drawn from the per-framework data above.</p>
+    <div class="takeaways">
+      <div class="ta">
+        <span class="tag">MCP</span>
+        <h4>1 · MCP consumer support is present in all ten frameworks</h4>
+        <p>Every framework profiled here ships first-class MCP consumer support, either in core or via an officially-maintained adapter package. MCP server (producer) support is present in six: ADK, Semantic Kernel, Mastra, Genkit Go, Rig, and via separate packages in the LangChain/LangGraph and CrewAI ecosystems.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">DECLARATION</span>
+        <h4>2 · Declaration patterns fall into three shapes</h4>
+        <p>A single constructor field listing all sources (CrewAI <code>mcps=</code>, Mastra <code>tools:</code> / <code>agents:</code>); a dedicated class per source (ADK <code>MCPToolset</code> / <code>OpenAPIToolset</code> / <code>RemoteA2aAgent</code>); or a builder pipeline (LangChain4j transport → client → provider → AI service).</p>
+      </div>
+      <div class="ta">
+        <span class="tag">A2A</span>
+        <h4>3 · Four frameworks expose a first-class A2A primitive</h4>
+        <p>ADK (<code>RemoteA2aAgent</code>), CrewAI (<code>A2AClientConfig</code>), Mastra (<code>A2AAgent</code>), and LangGraph (<code>RemoteGraph</code>, requires a LangGraph Platform endpoint). In the other six frameworks, remote-agent access is documented via MCP composition.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">OPENAPI</span>
+        <h4>4 · First-class OpenAPI ingestion is present in three frameworks</h4>
+        <p>ADK (<code>OpenAPIToolset</code>), Semantic Kernel (<code>kernel.add_plugin_from_openapi</code>), and Microsoft Agent Framework (via the Semantic Kernel plugin pipeline). In the other seven frameworks, the documented pattern is to wrap an HTTP call in a custom tool body or front the API with an MCP server.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">RPC</span>
+        <h4>5 · No framework provides a first-class gRPC generator</h4>
+        <p>None of the ten frameworks generates tools from a gRPC, Thrift, or other RPC schema. In every case the documented pattern is to call the RPC client from within an in-process tool body.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">PORTABILITY</span>
+        <h4>6 · MCP is the most portable tool-definition surface</h4>
+        <p>An MCP server can be consumed by all ten frameworks via their documented MCP integration. Tool definitions placed inside an MCP server are therefore portable across frameworks without modification; framework-specific tool definitions are not.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ================= GLOSSARY ================= -->
+<section id="glossary">
+  <div class="container">
+    <h2>Mini-glossary</h2>
+    <p class="lede">Terms used above that mean slightly different things in different frameworks.</p>
+    <div class="gloss">
+      <div><b>MCP</b> (Model Context Protocol) — open JSON-RPC protocol for exposing tools, resources, and prompts to LLM agents. See <a href="https://modelcontextprotocol.io">modelcontextprotocol.io</a>.</div>
+      <div><b>MCP transport</b> — how the client talks to the server: <code>stdio</code> (server runs as a subprocess), <code>streamable-http</code> (HTTP POST + optional SSE), <code>sse</code> (legacy server-sent events), or <code>websocket</code> (LangChain4j extension).</div>
+      <div><b>Agent card</b> (A2A) — a <code>.well-known/agent-card.json</code> document at the remote agent's URL describing its capabilities, skills, auth, and supported modes.</div>
+      <div><b>A2A</b> (Agent-to-Agent Protocol) — open standard for one agent calling another over HTTP using the agent-card discovery + JSON-RPC messaging. Cross-framework by design.</div>
+      <div><b>OpenAPI toolset / toolkit</b> — a framework-level converter from an OpenAPI 3.x spec to a set of tools, one per operation (or one generic verb-based tool).</div>
+      <div><b>RemoteGraph</b> (LangGraph) — proxy object that talks to a graph deployed on LangGraph Platform; behaves identically to a local compiled graph for callers.</div>
+      <div><b>RemoteA2aAgent</b> (ADK) — agent class that wraps a remote A2A endpoint; attached to a parent agent's <code>sub_agents=</code> list.</div>
+      <div><b>MCPManager</b> (Genkit Go) — top-level container for multiple MCP server connections, with <code>ConnectServer</code> for dynamic add and per-server tool resolution.</div>
+      <div><b>ToolProvider</b> (LangChain4j) — interface that supplies a list of tools to <code>AiServices</code> at build or invocation time; MCP is one such provider.</div>
+      <div><b>rmcp</b> — the official Rust SDK for MCP; in Rig 0.16+ it's the canonical MCP integration (the older <code>mcp-core</code> is being phased out).</div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    Compiled from the upstream documentation of LangChain, LangGraph, CrewAI, Google ADK,
+    Microsoft Semantic Kernel, Mastra, Microsoft Agent Framework, LangChain4j, Genkit, and Rig.
+    Sibling paper: <a href="/whitepapers/agent-tool-wiring.html">How AI Agent Frameworks Wire In Tools and Agents</a>.
+    <p class="copyright">© 2026 <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>. Licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
+  </div>
+</footer>
+
+<script>
+  document.querySelectorAll('a.pill').forEach(a => {
+    a.addEventListener('click', e => {
+      const id = a.getAttribute('href');
+      if (id && id.startsWith('#')) {
+        const el = document.querySelector(id);
+        if (el) {
+          e.preventDefault();
+          el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          history.replaceState(null, '', id);
+        }
+      }
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/www/whitepapers/agent-tool-wiring.html
+++ b/www/whitepapers/agent-tool-wiring.html
@@ -1,0 +1,1327 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>How AI Agent Frameworks Wire In Tools and Agents</title>
+<meta name="description" content="A code-first reference across ten AI agent frameworks — LangChain, LangGraph, CrewAI, Google ADK, Semantic Kernel, Mastra, Microsoft Agent Framework, LangChain4j, Genkit Go, and Rig — covering the documented mechanisms for declaring tools, defining their schemas, and composing multiple agents.">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="TruvaG3">
+<meta property="og:title" content="How AI Agent Frameworks Wire In Tools and Agents">
+<meta property="og:description" content="A code-first reference across ten AI agent frameworks — LangChain, LangGraph, CrewAI, Google ADK, Semantic Kernel, Mastra, Microsoft Agent Framework, LangChain4j, Genkit Go, and Rig — covering the documented mechanisms for declaring tools, defining their schemas, and composing multiple agents.">
+<meta property="og:url" content="https://truvag3.dev/whitepapers/agent-tool-wiring">
+<meta property="og:image" content="https://truvag3.dev/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="TruvaG3 — Microagents Framework for Go">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="How AI Agent Frameworks Wire In Tools and Agents">
+<meta name="twitter:description" content="A code-first reference covering the documented mechanisms for declaring tools and composing multiple agents across ten AI agent frameworks.">
+<meta name="twitter:image" content="https://truvag3.dev/og-image.png">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="stylesheet" href="/assets/css/site-nav.css">
+<style>
+  :root {
+    --bg: #0b0f17;
+    --bg-2: #121826;
+    --bg-3: #1a2236;
+    --ink: #e6edf7;
+    --muted: #9aa6bd;
+    --line: #2a3550;
+    --accent: #7cc4ff;
+    --warn: #fbbf24;
+    --good: #34d399;
+    /* Brand fallbacks for site-nav.css */
+    --brand-truva-light: #DBEEFB;
+    --brand-truva-dark:  #4A8AB8;
+    --brand-g3-light:    #FFD080;
+    --brand-g3-dark:     #C56710;
+    /* Per-framework accents */
+    --lc:   #1F6FEB;   /* LangChain */
+    --lg:   #14b8a6;   /* LangGraph */
+    --crew: #7c3aed;   /* CrewAI */
+    --adk:  #EA4335;   /* Google ADK */
+    --sk:   #2EA5FF;   /* Semantic Kernel */
+    --ma:   #ec4899;   /* Mastra */
+    --maf:  #512BD4;   /* MS Agent Framework (.NET violet) */
+    --l4j:  #ED8B00;   /* LangChain4j (Java orange) */
+    --gk:   #00ADD8;   /* Genkit Go (Go cyan) */
+    --rg:   #B7410E;   /* Rig (Rust orange) */
+    --maxw: 1180px;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: radial-gradient(1200px 800px at 50% -10%, #1c2541 0%, var(--bg) 60%);
+    color: var(--ink);
+    font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  p code, li code, td code, h3 code, h4 code { color: #c9e2ff; background: rgba(124,196,255,.08); padding: 1px 5px; border-radius: 4px; font-size: 0.92em; }
+  pre {
+    background: var(--bg-3);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 14px 16px;
+    overflow: auto;
+    font-size: 12.5px;
+    line-height: 1.55;
+    color: #cfe1ff;
+    margin: 8px 0 14px;
+  }
+  pre code { background: transparent; padding: 0; color: inherit; font-size: inherit; }
+  /* Highlights the exact spot where a tool or sub-agent is wired into the caller. */
+  pre .hi {
+    background: rgba(251, 191, 36, 0.18);
+    color: #fde68a;
+    padding: 0 3px;
+    border-radius: 3px;
+    font-weight: 600;
+    border-bottom: 1px dashed rgba(251, 191, 36, 0.55);
+  }
+  .hi-legend {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 12.5px; color: var(--muted);
+    background: var(--bg-2); border: 1px solid var(--line);
+    padding: 6px 12px; border-radius: 999px; margin-top: 4px;
+  }
+  .hi-legend .swatch {
+    display: inline-block; width: 12px; height: 12px; border-radius: 3px;
+    background: rgba(251, 191, 36, 0.18);
+    border-bottom: 1px dashed rgba(251, 191, 36, 0.7);
+  }
+  .container { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+
+  /* Header */
+  header.hero {
+    padding: 64px 0 36px;
+    text-align: center;
+    border-bottom: 1px solid var(--line);
+    position: relative;
+  }
+  .research-date {
+    display: inline-block;
+    margin-bottom: 18px;
+    padding: 5px 14px;
+    border-radius: 999px;
+    background: var(--bg-2);
+    border: 1px solid var(--line);
+    color: var(--muted);
+    font-size: 12px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+  }
+  .research-date b { color: var(--ink); font-weight: 600; letter-spacing: 0; text-transform: none; }
+  .ai-capsule {
+    display: inline-block;
+    margin-bottom: 18px;
+    margin-left: 8px;
+    padding: 5px 14px;
+    border-radius: 999px;
+    background: var(--bg-2);
+    border: 1px solid var(--warn);
+    color: var(--warn);
+    font-size: 12px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+  }
+  header.hero h1 {
+    font-size: clamp(28px, 4.4vw, 46px);
+    line-height: 1.1;
+    margin: 0 0 14px;
+    letter-spacing: -0.02em;
+    background: linear-gradient(90deg, #ffffff 0%, #9ec5ff 60%, #c4b5fd 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  header.hero .subtitle {
+    color: var(--muted);
+    font-size: 17px;
+    max-width: 820px;
+    margin: 0 auto 22px;
+  }
+  .pillrow {
+    display: flex; flex-wrap: wrap; justify-content: center; gap: 8px;
+  }
+  .pill {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 7px 13px; border-radius: 999px;
+    background: var(--bg-2); border: 1px solid var(--line);
+    color: var(--ink); font-size: 13px; cursor: pointer;
+    transition: transform .15s ease, background .15s ease, border-color .15s ease;
+  }
+  .pill:hover { transform: translateY(-1px); border-color: #3a4a72; text-decoration: none; }
+  .dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; }
+
+  /* Sections */
+  section { padding: 56px 0; border-bottom: 1px solid var(--line); }
+  section h2 { font-size: clamp(22px, 2.5vw, 30px); letter-spacing: -0.01em; margin: 0 0 8px; }
+  section .lede { color: var(--muted); max-width: 820px; margin: 0 0 28px; }
+
+  /* Universal pattern */
+  .universal-grid {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 18px; align-items: stretch;
+  }
+  @media (max-width: 880px) { .universal-grid { grid-template-columns: 1fr; } }
+  .uni-item {
+    background: var(--bg-2); border: 1px solid var(--line); border-radius: 12px; padding: 16px 18px;
+  }
+  .uni-item b { color: #fff; }
+  .uni-item .tag {
+    display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 999px;
+    background: #19243d; color: #9fc2ff; margin-right: 8px;
+  }
+  .uni-item p { margin: 8px 0 0; color: #cfd9ee; }
+
+  /* Framework cards */
+  .frameworks { display: grid; gap: 28px; }
+  .fw-card {
+    background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.005));
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    overflow: hidden;
+  }
+  .fw-head {
+    display: flex; align-items: center; gap: 14px;
+    padding: 18px 22px;
+    border-bottom: 1px solid var(--line);
+    background: rgba(255,255,255,0.015);
+  }
+  .fw-badge {
+    width: 46px; height: 46px; border-radius: 12px;
+    display: grid; place-items: center;
+    color: #fff; font-weight: 700; font-size: 16px;
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,.18);
+    flex-shrink: 0;
+  }
+  .fw-head h3 { margin: 0; font-size: 19px; letter-spacing: -0.01em; }
+  .fw-head .sub { color: var(--muted); font-size: 13px; margin-top: 2px; }
+  /* Language identifier pill next to each framework heading.
+     Same convention as the hero .pill (dark bg, rounded), but with
+     border AND text in the language's brand color. */
+  .lang-pill {
+    display: inline-block;
+    font-size: 11px;
+    padding: 3px 11px;
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    vertical-align: 3px;
+    margin-left: 10px;
+    background: var(--bg-2);
+    border: 1px solid currentColor;
+  }
+  .lang-pill.py     { color: #FFD43B; }   /* Python  — signature yellow */
+  .lang-pill.ts     { color: #4cb6ff; }   /* TS      — sky blue */
+  .lang-pill.dotnet { color: #a78bfa; }   /* .NET    — violet */
+  .lang-pill.java   { color: #ED8B00; }   /* Java    — Duke orange */
+  .lang-pill.go     { color: #00ADD8; }   /* Go      — Gopher cyan */
+  .lang-pill.rust   { color: #fb6b3c; }   /* Rust    — red-orange */
+  .fw-body { display: grid; grid-template-columns: 1.05fr .95fr; gap: 0; }
+  @media (max-width: 980px) { .fw-body { grid-template-columns: 1fr; } }
+  .fw-code {
+    padding: 22px;
+    border-right: 1px solid var(--line);
+    background:
+      radial-gradient(900px 500px at 20% 10%, rgba(124,196,255,.05), transparent 60%),
+      var(--bg-2);
+  }
+  @media (max-width: 980px) { .fw-code { border-right: none; border-bottom: 1px solid var(--line); } }
+  .fw-text { padding: 22px; }
+  .fw-text h4, .fw-code h4 {
+    margin: 0 0 8px; font-size: 12px; color: var(--accent);
+    letter-spacing: .06em; text-transform: uppercase; font-weight: 600;
+  }
+  .fw-text p, .fw-code p { margin: 0 0 12px; color: #cfd9ee; }
+  .fw-text h4:not(:first-of-type), .fw-code h4:not(:first-of-type) { margin-top: 16px; }
+  .code-label {
+    display: inline-block; font-size: 10.5px; padding: 2px 8px; border-radius: 999px;
+    background: #19243d; color: #9fc2ff; margin-bottom: 6px;
+    letter-spacing: .04em; text-transform: uppercase;
+  }
+  .metaphor {
+    margin: 4px 0 14px; padding: 10px 14px;
+    background: #0e1a2e; border-left: 3px solid var(--accent); border-radius: 8px;
+    color: #cfe1ff; font-style: italic; font-size: 14px;
+  }
+  .twocol { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-top: 6px; }
+  @media (max-width: 600px) { .twocol { grid-template-columns: 1fr; } }
+  .miniblock { background: var(--bg-3); border: 1px solid var(--line); border-radius: 10px; padding: 10px 12px; }
+  .miniblock h5 { margin: 0 0 4px; font-size: 12px; color: #a8b6d6; letter-spacing: .05em; text-transform: uppercase; }
+  .miniblock p { margin: 0; font-size: 13px; color: #dbe6ff; }
+  .src {
+    margin-top: 14px; padding-top: 12px; border-top: 1px dashed var(--line);
+    font-size: 12.5px; color: var(--muted);
+  }
+  .src a { color: var(--accent); }
+  /* Per-snippet source attribution sits directly under each <pre>. */
+  .snip-src {
+    margin: -6px 0 14px;
+    padding-left: 4px;
+    font-size: 11.5px;
+    color: var(--muted);
+    line-height: 1.45;
+  }
+  .snip-src::before { content: "↳  "; color: #4b6688; }
+  .snip-src a {
+    color: var(--muted);
+    border-bottom: 1px dotted rgba(154,166,189,.4);
+    text-decoration: none;
+  }
+  .snip-src a:hover {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+  }
+
+  /* Comparison table */
+  .table-wrap { overflow: auto; border: 1px solid var(--line); border-radius: 12px; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 1000px; }
+  th, td { padding: 12px 14px; border-bottom: 1px solid var(--line); vertical-align: top; text-align: left; }
+  thead th { background: var(--bg-2); position: sticky; top: 0; font-weight: 600; }
+  th.fw, td.fw { white-space: nowrap; }
+  td.row-hd { background: var(--bg-2); font-weight: 600; white-space: nowrap; }
+
+  /* Takeaways */
+  .takeaways { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+  @media (max-width: 880px) { .takeaways { grid-template-columns: 1fr; } }
+  .ta {
+    background: var(--bg-2); border: 1px solid var(--line); border-radius: 14px; padding: 18px;
+  }
+  .ta h4 { margin: 0 0 8px; font-size: 15px; color: #fff; }
+  .ta p { margin: 0; color: #cfd9ee; font-size: 14px; }
+  .ta .tag {
+    display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 999px;
+    background: #19243d; color: #9fc2ff; margin-bottom: 8px;
+  }
+
+  /* Glossary */
+  .gloss { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px 22px; }
+  @media (max-width: 720px) { .gloss { grid-template-columns: 1fr; } }
+  .gloss div { padding: 8px 0; border-bottom: 1px dashed var(--line); color: #cfd9ee; }
+  .gloss b { color: #fff; }
+
+  /* Footer */
+  footer { padding: 36px 0 64px; text-align: center; color: var(--muted); font-size: 13px; }
+  .copyright { color: var(--muted); font-size: 0.85rem; text-align: center; margin-top: 1.5rem; margin-bottom: 0; }
+
+  @media print {
+    body { background: white; color: black; }
+    .pill, nav, footer { display: none; }
+    section { page-break-inside: avoid; }
+    .fw-card { break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+
+<nav class="site-nav">
+  <div class="container">
+    <a class="nav-brand" href="/"><span class="brand-truva">Truva</span><span class="brand-g3">G3</span></a>
+    <div class="nav-links">
+      <a href="/blogs/">Blog</a>
+      <a href="/whitepapers/">Whitepapers</a>
+      <a href="https://docs.truvag3.dev/docs/intro/">Docs</a>
+      <a href="https://github.com/truvaagents/truva-g3">GitHub</a>
+    </div>
+  </div>
+</nav>
+
+<header class="hero">
+  <div class="container">
+    <div class="research-date">Research date · <b>May 25, 2026</b></div>
+    <div class="ai-capsule">Generated with AI</div>
+    <h1>How AI Agent Frameworks Wire In Tools and Agents</h1>
+    <p class="subtitle">
+      A code-first reference across ten AI agent frameworks &mdash; spanning
+      <b>Python</b>, <b>TypeScript</b>, <b>.NET</b>, <b>Java</b>, <b>Go</b>, and <b>Rust</b> &mdash;
+      covering the documented mechanisms for declaring tools, defining their schemas, and
+      composing multiple agents. Every code snippet is taken from the framework's own documentation.
+    </p>
+    <div class="pillrow">
+      <a class="pill" href="#universal"><span class="dot" style="background:#9ec5ff"></span>The universal pattern</a>
+      <a class="pill" href="#langchain"><span class="dot" style="background:var(--lc)"></span>LangChain</a>
+      <a class="pill" href="#langgraph"><span class="dot" style="background:var(--lg)"></span>LangGraph</a>
+      <a class="pill" href="#crewai"><span class="dot" style="background:var(--crew)"></span>CrewAI</a>
+      <a class="pill" href="#adk"><span class="dot" style="background:var(--adk)"></span>Google ADK</a>
+      <a class="pill" href="#sk"><span class="dot" style="background:var(--sk)"></span>Semantic Kernel</a>
+      <a class="pill" href="#mastra"><span class="dot" style="background:var(--ma)"></span>Mastra</a>
+      <a class="pill" href="#maf"><span class="dot" style="background:var(--maf)"></span>MS Agent Framework</a>
+      <a class="pill" href="#l4j"><span class="dot" style="background:var(--l4j)"></span>LangChain4j</a>
+      <a class="pill" href="#genkit"><span class="dot" style="background:var(--gk)"></span>Genkit Go</a>
+      <a class="pill" href="#rig"><span class="dot" style="background:var(--rg)"></span>Rig</a>
+      <a class="pill" href="#compare"><span class="dot" style="background:#fff"></span>Side-by-side</a>
+      <a class="pill" href="#takeaways"><span class="dot" style="background:var(--good)"></span>Summary observations</a>
+    </div>
+  </div>
+</header>
+
+<!-- ================= UNIVERSAL PATTERN ================= -->
+<section id="universal">
+  <div class="container">
+    <h2>The universal wiring pattern</h2>
+    <p class="lede">
+      Underneath the differences in syntax, every framework on this list ships the same three primitives:
+      a way to <b>describe a callable</b> to the model (name, description, JSON schema), a way to
+      <b>bind those callables to an agent</b>, and a way to <b>compose multiple agents</b> — by exposing
+      one agent as a tool to another, by handing off control via a structured action, or by orchestrating
+      them with a parent process.
+    </p>
+    <div class="universal-grid">
+      <div class="uni-item">
+        <span class="tag">1 · Describe</span><b>Tool definition</b>
+        <p>A decorator, a class, a macro, or a builder produces a four-field object: a unique name, a description, a JSON schema for arguments, and the callable itself.</p>
+      </div>
+      <div class="uni-item">
+        <span class="tag">2 · Bind</span><b>Attach to an agent</b>
+        <p>The agent receives a list (or map) of tools at construction time. Some frameworks bind tools to the model directly; others register them on a kernel, a graph node, or a tool server.</p>
+      </div>
+      <div class="uni-item">
+        <span class="tag">3 · Compose</span><b>Multi-agent wiring</b>
+        <p>Three composition patterns appear across the ten frameworks: agent-as-tool, transfer-of-control, and hierarchical composition. Each framework supports at least one; several support more than one.</p>
+      </div>
+      <div class="uni-item">
+        <span class="tag">4 · Loop</span><b>Who runs the call</b>
+        <p>The agent loop is run by the framework (most), by the kernel (Semantic Kernel), or by the application code with a convenience opt-out (Genkit Go, Rig).</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ================= FRAMEWORK CARDS ================= -->
+<section id="frameworks" style="border-bottom: none;">
+  <div class="container">
+    <h2>Ten frameworks, ten dialects</h2>
+    <p class="lede">
+      Same primitives, ten different ways of expressing them. Each card pairs a canonical
+      tool-wiring snippet from the framework's own docs with a prose breakdown and the agent-wiring
+      snippet that goes with it.
+    </p>
+    <div class="hi-legend">
+      <span class="swatch"></span>
+      Highlighted spans mark exactly where a <b style="color:#fde68a">tool or sub-agent is hooked into the caller agent</b>.
+    </div>
+    <br><br>
+
+    <div class="frameworks">
+
+      <!-- ============ LANGCHAIN ============ -->
+      <article class="fw-card" id="langchain">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--lc)">Lc</div>
+          <div>
+            <h3>LangChain · the <code>@tool</code> decorator + <code>create_agent</code> <span class="lang-pill py">Python</span></h3>
+            <div class="sub">Type-hint-driven schemas, looped by the prebuilt agent factory.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="fw-code">
+            <span class="code-label">Tool definition</span>
+            <pre><code>from langchain.tools import tool
+
+@tool
+def search_database(query: str, limit: int = 10) -> str:
+    """Search the customer database for records matching the query.
+
+    Args:
+        query: Search terms to look for
+        limit: Maximum number of results to return
+    """
+    return f"Found {limit} results for '{query}'"</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.langchain.com/oss/python/langchain/tools#basic-tool-definition">docs.langchain.com · Tools · Basic tool definition</a></div>
+
+            <span class="code-label">Bind to an agent</span>
+            <pre><code>from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
+
+agent = create_agent(
+    ChatOpenAI(model="gpt-5.4"),
+    <span class="hi">tools=[search_database]</span>,
+    system_prompt="You are a helpful assistant.",
+)
+agent.invoke({"messages": [
+    {"role": "user", "content": "find acme orders"},
+]})</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.langchain.com/oss/python/langchain/tools#context">docs.langchain.com · Tools · Context example with create_agent</a></div>
+          </div>
+          <div class="fw-text">
+            <div class="metaphor">A Python function decorated with <code>@tool</code> is passed in a list to <code>create_agent</code>, which binds the tools to the model and runs the loop.</div>
+            <h4>How tool wiring works</h4>
+            <p>
+              The <code>@tool</code> decorator turns a Python function into a LangChain tool. Type
+              hints become the JSON schema the model sees; the docstring becomes the description used
+              for selection. For more control, subclass <code>BaseTool</code> or pass a Pydantic
+              <code>args_schema</code>.
+            </p>
+            <h4>How agent wiring works</h4>
+            <p>
+              <code>create_agent</code> (the v1 successor to <code>AgentExecutor</code>) binds the
+              tools to the model and runs the loop. Multi-agent in LangChain is "agent-as-tool" —
+              wrap a sub-agent and add it to the parent's <code>tools</code> list.
+            </p>
+            <div class="twocol">
+              <div class="miniblock"><h5>Mechanism</h5><p>Function-level decorators; the agent factory manages the tool-call loop internally.</p></div>
+              <div class="miniblock"><h5>Notes</h5><p>Multi-agent is not a first-class primitive; the documented path for composition is LangGraph.</p></div>
+            </div>
+            <div class="src">Source · <a href="https://docs.langchain.com/oss/python/langchain/tools">LangChain docs · Tools</a></div>
+          </div>
+        </div>
+      </article>
+
+      <!-- ============ LANGGRAPH ============ -->
+      <article class="fw-card" id="langgraph">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--lg)">Lg</div>
+          <div>
+            <h3>LangGraph · <code>ToolNode</code> in a state graph (or prebuilt <code>create_react_agent</code>) <span class="lang-pill py">Python</span></h3>
+            <div class="sub">Tools become a graph node; multi-agent is graph composition.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="fw-code">
+            <span class="code-label">Prebuilt ReAct agent</span>
+            <pre><code>from langgraph.prebuilt import create_react_agent
+
+def check_weather(location: str) -> str:
+    '''Return the weather forecast for the specified location.'''
+    return f"It's always sunny in {location}"
+
+graph = create_react_agent(
+    "anthropic:claude-3-7-sonnet-latest",
+    <span class="hi">tools=[check_weather]</span>,
+    prompt="You are a helpful assistant",
+)
+for chunk in graph.stream(
+    {"messages": [{"role": "user", "content": "weather in sf"}]},
+    stream_mode="updates",
+):
+    print(chunk)</code></pre>
+            <div class="snip-src">Source: <a href="https://reference.langchain.com/python/langgraph.prebuilt/chat_agent_executor/create_react_agent">reference.langchain.com · langgraph.prebuilt · create_react_agent</a></div>
+
+            <span class="code-label">Custom graph with <code>ToolNode</code></span>
+            <pre><code>from langgraph.graph import StateGraph, MessagesState, START
+from langgraph.prebuilt import ToolNode, tools_condition
+
+builder = StateGraph(MessagesState)
+builder.add_node("llm", call_llm)
+builder.add_node("tools", <span class="hi">ToolNode([check_weather])</span>)
+builder.add_edge(START, "llm")
+builder.add_conditional_edges("llm", tools_condition)
+builder.add_edge("tools", "llm")
+graph = builder.compile()</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.langchain.com/oss/python/langchain/tools#route-with-tools_condition">docs.langchain.com · Tools · Route with tools_condition</a></div>
+          </div>
+          <div class="fw-text">
+            <div class="metaphor">Tools are executed by a graph node. <code>ToolNode</code> fans out every <code>tool_call</code> on the last <code>AIMessage</code> in parallel and writes the results back to the <code>messages</code> channel.</div>
+            <h4>How tool wiring works</h4>
+            <p>
+              LangGraph reuses LangChain's <code>@tool</code> definitions. To dispatch them, you drop
+              a prebuilt <code>ToolNode</code> into a <code>StateGraph</code> — it reads the last
+              <code>AIMessage</code>, executes every <code>tool_call</code> (in parallel), and writes
+              <code>ToolMessage</code>s back into the <code>messages</code> channel.
+            </p>
+            <h4>How agent wiring works</h4>
+            <p>
+              The prebuilt <code>create_react_agent</code> constructs a two-node graph
+              (<code>agent</code> ↔ <code>tools</code>) and terminates when the model returns no
+              <code>tool_calls</code>. Multi-agent composition is expressed by wiring sub-agent
+              graphs as nodes within a supervisor graph.
+            </p>
+            <div class="twocol">
+              <div class="miniblock"><h5>Mechanism</h5><p>A graph node executes every tool call; state is checkpointable and human-in-the-loop interrupts are supported.</p></div>
+              <div class="miniblock"><h5>Notes</h5><p>Logic is expressed as nodes, edges, and reducers rather than as imperative scripts.</p></div>
+            </div>
+            <div class="src">Source · <a href="https://reference.langchain.com/python/langgraph.prebuilt/chat_agent_executor/create_react_agent"><code>create_react_agent</code> reference</a> · <a href="https://docs.langchain.com/oss/python/langchain/tools#toolnode"><code>ToolNode</code> docs</a></div>
+          </div>
+        </div>
+      </article>
+
+      <!-- ============ CREWAI ============ -->
+      <article class="fw-card" id="crewai">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--crew)">Cr</div>
+          <div>
+            <h3>CrewAI · Pydantic-typed <code>BaseTool</code>, agents inside a <code>Crew</code> <span class="lang-pill py">Python</span></h3>
+            <div class="sub">Per-agent toolbelt; outer Crew/Process orchestrates the team.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="fw-code">
+            <span class="code-label">Tool definition</span>
+            <pre><code>from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+from typing import Type
+
+class MyToolInput(BaseModel):
+    """Input schema for MyCustomTool."""
+    argument: str = Field(..., description="Description of the argument.")
+
+class MyCustomTool(BaseTool):
+    name: str = "Name of my tool"
+    description: str = "What this tool does. It's vital for effective utilization."
+    args_schema: Type[BaseModel] = MyToolInput
+
+    def _run(self, argument: str) -> str:
+        return "Tool's result"</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.crewai.com/en/concepts/tools#subclassing-basetool">docs.crewai.com · Tools · Subclassing BaseTool</a></div>
+
+            <span class="code-label">Crew &amp; Agent wiring</span>
+            <pre><code>from crewai import Agent, Task, Crew
+from crewai_tools import SerperDevTool, WebsiteSearchTool
+
+researcher = Agent(
+    role='Market Research Analyst',
+    goal='Provide up-to-date market analysis.',
+    backstory='An expert analyst with a keen eye for trends.',
+    <span class="hi">tools=[SerperDevTool(), WebsiteSearchTool()]</span>,
+)
+
+research = Task(
+    description='Research the latest trends in the AI industry.',
+    expected_output='Top 3 trending developments with significance.',
+    <span class="hi">agent=researcher</span>,
+)
+
+crew = Crew(<span class="hi">agents=[researcher], tasks=[research]</span>, planning=True)
+crew.kickoff()</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.crewai.com/en/concepts/tools#using-crewai-tools">docs.crewai.com · Tools · Using CrewAI Tools example</a></div>
+          </div>
+          <div class="fw-text">
+            <div class="metaphor">Tools are <code>BaseTool</code> subclasses attached to each <code>Agent</code>'s <code>tools=</code> list. A <code>Crew</code> owns multiple agents and tasks; a <code>Process</code> (sequential or hierarchical) determines execution order.</div>
+            <h4>How tool wiring works</h4>
+            <p>
+              A custom tool is a <code>BaseTool</code> subclass with a Pydantic <code>args_schema</code>
+              and a <code>_run</code> method. There's also a lighter <code>@tool</code> decorator and an
+              automatic tool-result cache; you can tune the cache with <code>cache_function</code>.
+            </p>
+            <h4>How agent wiring works</h4>
+            <p>
+              Tools are attached to an <code>Agent</code>'s <code>tools=[...]</code> field. A
+              <code>Crew</code> owns multiple agents and tasks; the <code>Process</code> (sequential
+              or hierarchical) decides who runs when. In hierarchical mode a manager LLM gets
+              <code>DelegateWorkTool</code>s and picks the next worker.
+            </p>
+            <div class="twocol">
+              <div class="miniblock"><h5>Mechanism</h5><p>Each agent has a role, goal, and backstory. An outer crew loop runs the per-agent inner loop.</p></div>
+              <div class="miniblock"><h5>Notes</h5><p>Hierarchical Process mode invokes a manager LLM once per delegation.</p></div>
+            </div>
+            <div class="src">Source · <a href="https://docs.crewai.com/en/concepts/tools">CrewAI docs · Tools</a></div>
+          </div>
+        </div>
+      </article>
+
+      <!-- ============ GOOGLE ADK ============ -->
+      <article class="fw-card" id="adk">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--adk)">Ad</div>
+          <div>
+            <h3>Google ADK · plain functions auto-wrapped as <code>FunctionTool</code>, sub-agents via <code>transfer_to_agent</code> <span class="lang-pill py">Python</span></h3>
+            <div class="sub">Agent algebra (Sequential / Parallel / Loop) + structured transfer of control.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="fw-code">
+            <span class="code-label">Tool definition + LlmAgent</span>
+            <pre><code>from google.adk.agents import LlmAgent
+
+def get_weather(location: str) -> dict:
+    """Return the current weather for a city."""
+    return {"location": location, "tempC": 22, "conditions": "sunny"}
+
+weather_agent = LlmAgent(
+    name="weather_agent",
+    model="gemini-2.0-flash",
+    instruction="Use the get_weather tool to answer weather questions.",
+    <span class="hi">tools=[get_weather]</span>,   # auto-wrapped as FunctionTool
+)</code></pre>
+            <div class="snip-src">Source: <a href="https://google.github.io/adk-docs/tools-custom/function-tools/">google.github.io/adk-docs · Function tools (auto-wrapping pattern)</a></div>
+
+            <span class="code-label">Multi-agent: transfer + composition</span>
+            <pre><code>from google.adk.agents import LlmAgent, SequentialAgent
+from google.adk.tools import ToolContext
+
+def check_and_transfer(query: str, tool_context: ToolContext) -> str:
+    """Inspect the query and delegate to support if urgent."""
+    if "urgent" in query.lower():
+        <span class="hi">tool_context.actions.transfer_to_agent = "support_agent"</span>
+        return "Transferring to support."
+    return "No transfer needed."
+
+coordinator = LlmAgent(
+    name="coordinator",
+    model="gemini-2.0-flash",
+    <span class="hi">tools=[check_and_transfer]</span>,
+    <span class="hi">sub_agents=[support_agent]</span>,
+)
+
+pipeline = SequentialAgent(
+    name="pipeline",
+    <span class="hi">sub_agents=[coordinator, summariser_agent]</span>,
+)</code></pre>
+            <div class="snip-src">Source: <a href="https://google.github.io/adk-docs/tools-custom/">google.github.io/adk-docs · Custom Tools (transfer_to_agent)</a> · <a href="https://google.github.io/adk-docs/agents/workflow-agents/sequential-agents/">SequentialAgent docs</a></div>
+          </div>
+          <div class="fw-text">
+            <div class="metaphor">A native Python function passed to <code>LlmAgent(tools=[…])</code> is auto-wrapped as a <code>FunctionTool</code>. Agents are composed into trees; tools can hand off control to siblings via <code>tool_context.actions.transfer_to_agent</code>.</div>
+            <h4>How tool wiring works</h4>
+            <p>
+              Any native function (or method) passed to <code>LlmAgent(tools=[...])</code> is
+              automatically wrapped as a <code>FunctionTool</code>. The function signature, type
+              hints, and docstring become the schema and description the model sees. ADK also ships
+              prebuilt tools (search, code execution, …) and supports OpenAPI/MCP tool servers.
+            </p>
+            <h4>How agent wiring works</h4>
+            <p>
+              ADK ships an agent algebra: <code>SequentialAgent</code>, <code>ParallelAgent</code>,
+              <code>LoopAgent</code>, and the <code>sub_agents=</code> field on <code>LlmAgent</code>
+              for delegate-on-demand. A tool can transfer control by setting
+              <code>tool_context.actions.transfer_to_agent</code>.
+            </p>
+            <div class="twocol">
+              <div class="miniblock"><h5>Mechanism</h5><p>Agents are composed into a tree; each LLM turn passes through a processor pipeline that emits typed <code>Event</code> records.</p></div>
+              <div class="miniblock"><h5>Notes</h5><p>The processor pipeline has its own lifecycle and ordering rules that callers must follow when extending it.</p></div>
+            </div>
+            <div class="src">Source · <a href="https://google.github.io/adk-docs/tools-custom/">ADK docs · Custom Tools</a> · <a href="https://google.github.io/adk-docs/agents/workflow-agents/sequential-agents/">Sequential workflow</a></div>
+          </div>
+        </div>
+      </article>
+
+      <!-- ============ SEMANTIC KERNEL ============ -->
+      <article class="fw-card" id="sk">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--sk)">Sk</div>
+          <div>
+            <h3>Microsoft Semantic Kernel · <code>@kernel_function</code> on a plugin class <span class="lang-pill py">Python</span></h3>
+            <div class="sub">The Kernel auto-invokes plugin functions; multi-agent via <code>AgentGroupChat</code>.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="fw-code">
+            <span class="code-label">Tool (plugin) definition + Kernel</span>
+            <pre><code>from semantic_kernel import Kernel
+from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+from semantic_kernel.functions import kernel_function
+
+class WeatherPlugin:
+    @kernel_function(name="get_weather", description="Gets the weather for a city")
+    def get_weather(self, city: str) -> str:
+        return f"It is sunny in {city}."
+
+kernel = Kernel()
+kernel.add_service(OpenAIChatCompletion(service_id="default"))
+<span class="hi">kernel.add_plugin(WeatherPlugin(), plugin_name="weather")</span></code></pre>
+            <div class="snip-src">Source: <a href="https://learn.microsoft.com/en-us/semantic-kernel/concepts/kernel">learn.microsoft.com · Understanding the kernel (Python plugin example)</a></div>
+
+            <span class="code-label">Agent with auto function-calling</span>
+            <pre><code>from semantic_kernel.agents import ChatCompletionAgent
+from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior
+
+agent = ChatCompletionAgent(
+    <span class="hi">kernel=kernel</span>,
+    name="WeatherAssistant",
+    instructions="Help the user with weather questions.",
+    function_choice_behavior=FunctionChoiceBehavior.Auto(),
+)</code></pre>
+            <div class="snip-src">Source: <a href="https://learn.microsoft.com/en-us/semantic-kernel/concepts/ai-services/chat-completion/function-calling/function-choice-behaviors">learn.microsoft.com · Function Choice Behavior (Auto)</a></div>
+          </div>
+          <div class="fw-text">
+            <div class="metaphor">Plugins are classes of <code>@kernel_function</code>-decorated methods registered on the Kernel. With <code>FunctionChoiceBehavior.Auto()</code>, the Kernel resolves and invokes the requested function when the model emits a function call.</div>
+            <h4>How tool wiring works</h4>
+            <p>
+              Tools in SK are <code>@kernel_function</code>-decorated methods grouped into a plugin
+              class. Calling <code>kernel.add_plugin(...)</code> exposes every function on that class
+              as a callable the model can request via native function-calling.
+            </p>
+            <h4>How agent wiring works</h4>
+            <p>
+              A <code>ChatCompletionAgent</code> wraps the Kernel; with
+              <code>FunctionChoiceBehavior.Auto()</code>, the Kernel itself runs the function-call
+              loop until no more calls are emitted or <code>maximum_auto_invoke_attempts</code> is hit.
+              Multi-agent uses <code>AgentGroupChat</code> with a <code>SelectionStrategy</code> and a
+              <code>TerminationStrategy</code>.
+            </p>
+            <div class="twocol">
+              <div class="miniblock"><h5>Mechanism</h5><p>The Kernel is a dependency-injection container; plugins register both native and prompt-based functions.</p></div>
+              <div class="miniblock"><h5>Notes</h5><p>Loop control is encapsulated in the Kernel; intervention points are exposed through filters and middleware.</p></div>
+            </div>
+            <div class="src">Source · <a href="https://learn.microsoft.com/en-us/semantic-kernel/concepts/kernel">Understanding the kernel</a> · <a href="https://learn.microsoft.com/en-us/semantic-kernel/concepts/ai-services/chat-completion/function-calling/function-choice-behaviors">Function Choice Behavior</a></div>
+          </div>
+        </div>
+      </article>
+
+      <!-- ============ MASTRA ============ -->
+      <article class="fw-card" id="mastra">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--ma)">Ma</div>
+          <div>
+            <h3>Mastra · <code>createTool</code> with Zod schemas, agents via <code>new Agent({ tools })</code> <span class="lang-pill ts">TypeScript</span></h3>
+            <div class="sub">Subagents auto-exposed as <code>agent-&lt;key&gt;</code> tools.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="fw-code">
+            <span class="code-label">Tool definition</span>
+            <pre><code>import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+export const weatherTool = createTool({
+  id: 'weather-tool',
+  description: 'Fetches weather for a location',
+  inputSchema:  z.object({ location: z.string() }),
+  outputSchema: z.object({ weather:  z.string() }),
+  execute: async (inputData) => {
+    const { location } = inputData
+    const res = await fetch(`https://wttr.in/${location}?format=3`)
+    return { weather: await res.text() }
+  },
+})</code></pre>
+            <div class="snip-src">Source: <a href="https://mastra.ai/docs/agents/using-tools#quickstart">mastra.ai · Using tools · Quickstart (createTool)</a></div>
+
+            <span class="code-label">Supervisor with sub-agent</span>
+            <pre><code>import { Agent } from '@mastra/core/agent'
+import { weatherTool } from '../tools/weather-tool'
+
+const writer = new Agent({
+  id: 'writer', name: 'Writer',
+  description: 'Drafts and edits written content',
+  instructions: 'You are a skilled writer.',
+  model: 'openai/gpt-5.4',
+})
+
+export const supervisor = new Agent({
+  id: 'supervisor', name: 'Supervisor',
+  instructions: 'Coordinate the writer and fetch weather.',
+  model: 'openai/gpt-5.4',
+  <span class="hi">tools:  { weatherTool }</span>,
+  <span class="hi">agents: { writer }</span>,   // auto-exposed as "agent-writer"
+})</code></pre>
+            <div class="snip-src">Source: <a href="https://mastra.ai/docs/agents/using-tools#agents-as-tools">mastra.ai · Using tools · Agents as tools</a></div>
+          </div>
+          <div class="fw-text">
+            <div class="metaphor">Tools are typed object literals produced by <code>createTool</code>. Agents are <code>Agent</code> instances with <code>tools</code> and <code>agents</code> maps; subagents are auto-exposed as tools named <code>agent-&lt;key&gt;</code>.</div>
+            <h4>How tool wiring works</h4>
+            <p>
+              Tools are created with <code>createTool</code> from <code>@mastra/core/tools</code> —
+              an <code>id</code>, <code>description</code>, <code>inputSchema</code>,
+              <code>outputSchema</code>, and an <code>execute</code> function. Schemas come from any
+              Standard JSON Schema library (Zod, Valibot, ArkType).
+            </p>
+            <h4>How agent wiring works</h4>
+            <p>
+              Tools attach via the <code>tools</code> field on an <code>Agent</code>. Sub-agents
+              attach via the <code>agents</code> field — Mastra automatically exposes each as a tool
+              named <code>agent-&lt;key&gt;</code>, giving you a supervisor pattern out of the box.
+              Workflows wire in identically as <code>workflow-&lt;key&gt;</code>.
+            </p>
+            <div class="twocol">
+              <div class="miniblock"><h5>Mechanism</h5><p>Built on the Vercel AI SDK; supports deployment to edge runtimes (Cloudflare Workers, Vercel Edge, Deno Deploy).</p></div>
+              <div class="miniblock"><h5>Notes</h5><p>Tool name in stream responses is derived from the object key, not the tool's <code>id</code> property; refactoring the key changes the name the model sees.</p></div>
+            </div>
+            <div class="src">Source · <a href="https://mastra.ai/docs/agents/using-tools">Mastra docs · Tools</a></div>
+          </div>
+        </div>
+      </article>
+
+      <!-- ============ MS AGENT FRAMEWORK ============ -->
+      <article class="fw-card" id="maf">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--maf)">Mf</div>
+          <div>
+            <h3>Microsoft Agent Framework · <code>AIFunctionFactory.Create</code> + <code>ChatClientAgent</code> <span class="lang-pill dotnet">.NET</span></h3>
+            <div class="sub">Attribute-driven schemas, agent-on-any-<code>IChatClient</code>.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="fw-code">
+            <span class="code-label">Tool definition</span>
+            <pre><code>using System.ComponentModel;
+
+[Description("Get the weather for a given location.")]
+static string GetWeather(
+    [Description("The location to get the weather for.")] string location)
+    =&gt; $"The weather in {location} is cloudy with a high of 15°C.";</code></pre>
+            <div class="snip-src">Source: <a href="https://learn.microsoft.com/en-us/agent-framework/agents/tools/function-tools">learn.microsoft.com · Function tools · GetWeather example</a></div>
+
+            <span class="code-label">Agent wiring</span>
+            <pre><code>using Azure.AI.Projects;
+using Azure.Identity;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+AIAgent agent = new AIProjectClient(
+        new Uri("&lt;your-foundry-project-endpoint&gt;"),
+        new DefaultAzureCredential())
+    .AsAIAgent(
+        model: "gpt-4o-mini",
+        instructions: "You are a helpful assistant",
+        <span class="hi">tools: [ AIFunctionFactory.Create(GetWeather) ]</span>);
+
+Console.WriteLine(
+    await agent.RunAsync("What is the weather like in Amsterdam?"));</code></pre>
+            <div class="snip-src">Source: <a href="https://learn.microsoft.com/en-us/agent-framework/agents/tools/function-tools">learn.microsoft.com · Function tools · Agent creation with AIFunctionFactory.Create</a></div>
+          </div>
+          <div class="fw-text">
+            <div class="metaphor">A C# method is annotated with <code>[Description]</code> and wrapped as an <code>AIFunction</code> via <code>AIFunctionFactory.Create</code>. The resulting list is passed to a <code>ChatClientAgent</code> (or to <code>AsAIAgent</code>) via the <code>tools</code> parameter.</div>
+            <h4>How tool wiring works</h4>
+            <p>
+              Any C# method can be turned into a function tool by wrapping it with
+              <code>AIFunctionFactory.Create</code>. <code>[Description]</code> attributes on the
+              method and its parameters become the schema and the prose the model sees.
+            </p>
+            <h4>How agent wiring works</h4>
+            <p>
+              A <code>ChatClientAgent</code> (or the <code>AsAIAgent</code> convenience on a chat
+              client) takes a <code>tools</code> list of <code>AIFunction</code> instances. The
+              agent handles the function-calling loop and multi-turn history natively, integrating
+              with ASP.NET Core hosting and DI.
+            </p>
+            <div class="twocol">
+              <div class="miniblock"><h5>Mechanism</h5><p>Schemas are derived from <code>[Description]</code> attributes and reflection. Native integration with .NET dependency injection and OpenTelemetry.</p></div>
+              <div class="miniblock"><h5>Notes</h5><p>Function tools are supported by <code>ChatClientAgent</code>; some other agent types only support built-in tools per the current documentation.</p></div>
+            </div>
+            <div class="src">Source · <a href="https://learn.microsoft.com/en-us/agent-framework/agents/tools/function-tools">Microsoft Learn · Function tools</a></div>
+          </div>
+        </div>
+      </article>
+
+      <!-- ============ LANGCHAIN4J ============ -->
+      <article class="fw-card" id="l4j">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--l4j)">L4j</div>
+          <div>
+            <h3>LangChain4j · <code>@Tool</code>-annotated methods, generated by <code>AiServices</code> <span class="lang-pill java">Java</span></h3>
+            <div class="sub">The agent is an interface; the framework supplies the implementation.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="fw-code">
+            <span class="code-label">Tool definition</span>
+            <pre><code>import dev.langchain4j.agent.tool.Tool;
+
+static class Calculator {
+
+    @Tool("Calculates the length of a string")
+    int stringLength(String s) {
+        return s.length();
+    }
+
+    @Tool("Calculates the sum of two numbers")
+    int add(int a, int b) {
+        return a + b;
+    }
+}</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.langchain4j.dev/tutorials/tools">docs.langchain4j.dev · Tools (Function Calling)</a> · <a href="https://github.com/langchain4j/langchain4j-examples/blob/main/other-examples/src/main/java/ServiceWithToolsExample.java">ServiceWithToolsExample.java</a></div>
+
+            <span class="code-label">Agent wiring (interface + AiServices)</span>
+            <pre><code>import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import dev.langchain4j.service.AiServices;
+
+interface Assistant {
+    String chat(String userMessage);
+}
+
+Assistant assistant = AiServices.builder(Assistant.class)
+    .chatModel(model)
+    <span class="hi">.tools(new Calculator())</span>
+    .chatMemory(MessageWindowChatMemory.withMaxMessages(10))
+    .build();
+
+String answer = assistant.chat(
+    "What is the square root of the length of 'hello'?");</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.langchain4j.dev/tutorials/ai-services">docs.langchain4j.dev · AI Services (AiServices.builder().tools(...))</a></div>
+          </div>
+          <div class="fw-text">
+            <div class="metaphor">Tools are Java methods annotated with <code>@Tool</code> on any POJO. The agent is defined as a Java interface; <code>AiServices</code> generates the implementation and wires in the tool-bearing objects.</div>
+            <h4>How tool wiring works</h4>
+            <p>
+              Tools are annotated methods on a regular Java class. The annotation value is the
+              model-facing description; method parameters become the schema (optionally enriched
+              with <code>@P</code> per-parameter descriptions). Tools can also be loaded dynamically
+              via a <code>ToolProvider</code>.
+            </p>
+            <h4>How agent wiring works</h4>
+            <p>
+              Define your agent as a plain Java interface; <code>AiServices</code> generates the
+              implementation, wires in <code>@Tool</code>-annotated objects, and manages chat memory.
+              Agents-as-tools is the canonical multi-agent pattern.
+            </p>
+            <div class="twocol">
+              <div class="miniblock"><h5>Mechanism</h5><p>Ships Spring Boot and Quarkus integration modules; ~80 vendor integration modules.</p></div>
+              <div class="miniblock"><h5>Notes</h5><p>Tool schemas are derived via reflection; mismatches surface at runtime rather than at compile time.</p></div>
+            </div>
+            <div class="src">Source · <a href="https://docs.langchain4j.dev/tutorials/tools/">LangChain4j · Tools</a> · <a href="https://docs.langchain4j.dev/tutorials/ai-services/">AI Services</a></div>
+          </div>
+        </div>
+      </article>
+
+      <!-- ============ GENKIT GO ============ -->
+      <article class="fw-card" id="genkit">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--gk)">Gk</div>
+          <div>
+            <h3>Genkit · <code>genkit.DefineTool</code> with a typed input struct <span class="lang-pill go">Go</span></h3>
+            <div class="sub">Pass the tool reference into <code>ai.WithTools</code>; you can keep or hand back the loop.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="fw-code">
+            <span class="code-label">Tool definition + use</span>
+            <pre><code>package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/firebase/genkit/go/ai"
+    "github.com/firebase/genkit/go/genkit"
+    "github.com/firebase/genkit/go/plugins/googlegenai"
+)
+
+type WeatherInput struct {
+    Location string `json:"location" jsonschema_description:"Location to get weather for"`
+}
+
+func main() {
+    ctx := context.Background()
+    g := genkit.Init(ctx,
+        genkit.WithPlugins(&amp;googlegenai.GoogleAI{}),
+        genkit.WithDefaultModel("googleai/gemini-1.5-flash"),
+    )
+
+    getWeatherTool := genkit.DefineTool(
+        g, "getWeather", "Gets the current weather in a given location",
+        func(ctx *ai.ToolContext, input WeatherInput) (string, error) {
+            return fmt.Sprintf("It is 63°F and sunny in %s.", input.Location), nil
+        },
+    )
+
+    resp, err := genkit.Generate(ctx, g,
+        ai.WithPrompt("What is the weather in San Francisco?"),
+        <span class="hi">ai.WithTools(getWeatherTool)</span>,
+    )
+    if err != nil { log.Fatal(err) }
+    fmt.Println(resp.Text())
+}</code></pre>
+            <div class="snip-src">Source: <a href="https://genkit.dev/docs/go/tool-calling/">genkit.dev · Tool calling (Go) · DefineTool + WithTools example</a></div>
+          </div>
+          <div class="fw-text">
+            <div class="metaphor">Tools are declared with <code>genkit.DefineTool</code> using a typed input struct. The returned tool reference is passed into <code>genkit.Generate</code> via <code>ai.WithTools</code>.</div>
+            <h4>How tool wiring works</h4>
+            <p>
+              Tools are declared with <code>genkit.DefineTool</code> — a name, description, and a
+              handler whose typed input struct provides the JSON schema via
+              <code>jsonschema_description</code> struct tags. <code>.prompt</code> files can
+              declare tool sets statically.
+            </p>
+            <h4>How agent wiring works</h4>
+            <p>
+              Genkit doesn't ship a dedicated "agent" type — agentic patterns are composed from
+              flows, prompts, and tools. <code>WithReturnToolRequests(true)</code> hands the tool-call
+              loop back to your code, which is the standard way to build multi-agent workflows.
+            </p>
+            <div class="twocol">
+              <div class="miniblock"><h5>Mechanism</h5><p>Plain Go runtime; goroutine-based concurrency; native OpenTelemetry and <code>slog</code> structured logging.</p></div>
+              <div class="miniblock"><h5>Notes</h5><p>No dedicated multi-agent primitives; agentic patterns are assembled from flows, prompts, and tools.</p></div>
+            </div>
+            <div class="src">Source · <a href="https://genkit.dev/docs/go/tool-calling/">Genkit docs · Tool calling (Go)</a></div>
+          </div>
+        </div>
+      </article>
+
+      <!-- ============ RIG ============ -->
+      <article class="fw-card" id="rig">
+        <div class="fw-head">
+          <div class="fw-badge" style="background: var(--rg)">Rg</div>
+          <div>
+            <h3>Rig · the <code>Tool</code> trait or <code>#[rig_tool]</code> macro, attached via the agent builder <span class="lang-pill rust">Rust</span></h3>
+            <div class="sub">Share a <code>ToolServer</code> handle across multiple agents.</div>
+          </div>
+        </div>
+        <div class="fw-body">
+          <div class="fw-code">
+            <span class="code-label">Tool definition (macro)</span>
+            <pre><code>use rig_derive::rig_tool;
+
+#[rig_tool(
+    description = "Perform basic arithmetic operations",
+    required(x, y, operation)
+)]
+fn calculator(
+    x: i32, y: i32, operation: String,
+) -&gt; Result&lt;i32, rig::tool::ToolError&gt; {
+    match operation.as_str() {
+        "add"      =&gt; Ok(x + y),
+        "subtract" =&gt; Ok(x - y),
+        "multiply" =&gt; Ok(x * y),
+        "divide" if y != 0 =&gt; Ok(x / y),
+        "divide"   =&gt; Err(rig::tool::ToolError::ToolCallError(
+            "Division by zero".into())),
+        _ =&gt; Err(rig::tool::ToolError::ToolCallError(
+            format!("Unknown operation: {operation}").into())),
+    }
+}</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.rig.rs/docs/concepts/tools#tool-macros">docs.rig.rs · Rig Tools · Tool Macros (#[rig_tool])</a></div>
+
+            <span class="code-label">Agent wiring + shared ToolServer</span>
+            <pre><code>let agent = client
+    .agent("gpt-5.2")
+    .preamble("You are a calculator.")
+    <span class="hi">.tool(Adder)</span>
+    <span class="hi">.tool(Subtract)</span>
+    .build();
+
+// Share a tool server between multiple agents
+use rig::tool::server::{ToolServer, ToolServerHandle};
+
+let tool_server: ToolServerHandle = ToolServer::new()
+    <span class="hi">.tool(Adder)</span>
+    .run();</code></pre>
+            <div class="snip-src">Source: <a href="https://docs.rig.rs/docs/concepts/tools#using-tools-with-agents">docs.rig.rs · Rig Tools · Using Tools with Agents</a> · <a href="https://docs.rig.rs/docs/concepts/tools#tool-servers">Tool Servers</a></div>
+          </div>
+          <div class="fw-text">
+            <div class="metaphor">Tools either implement the <code>Tool</code> trait directly or are generated by the <code>#[rig_tool]</code> macro. They are attached to an agent via <code>.tool(...)</code> on the agent builder, or shared across agents through a <code>ToolServer</code> handle.</div>
+            <h4>How tool wiring works</h4>
+            <p>
+              For simple tools the <code>rig_derive</code> crate exposes <code>#[rig_tool]</code>,
+              which transforms a function into a <code>rig::tool::Tool</code>. For full control,
+              implement the <code>Tool</code> trait by hand; <code>schemars::JsonSchema</code> can
+              derive the parameter schema for you.
+            </p>
+            <h4>How agent wiring works</h4>
+            <p>
+              Tools attach to an agent through the fluent builder on a provider client
+              (<code>.tool(MyTool)</code>). Multi-agent collaboration is done by sharing a
+              <code>ToolServerHandle</code> across agents — a Tokio task that owns the tools and
+              avoids shared-state locks.
+            </p>
+            <div class="twocol">
+              <div class="miniblock"><h5>Mechanism</h5><p>Trait-based; compiles to a native Rust binary; runs on the Tokio async runtime.</p></div>
+              <div class="miniblock"><h5>Notes</h5><p>Tool schemas are written manually or generated via the <code>schemars::JsonSchema</code> derive macro; both require more declaration than type-hint-based approaches.</p></div>
+            </div>
+            <div class="src">Source · <a href="https://docs.rig.rs/docs/concepts/tools">Rig docs · Tools</a></div>
+          </div>
+        </div>
+      </article>
+
+    </div>
+  </div>
+</section>
+
+<!-- ================= COMPARISON ================= -->
+<section id="compare">
+  <div class="container">
+    <h2>Side-by-side · tool &amp; agent wiring</h2>
+    <p class="lede">Same primitives, ten dialects. Read across rows to see how each framework answers the same wiring question.</p>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th class="fw"><span class="dot" style="background:var(--lc)"></span> LangChain</th>
+            <th class="fw"><span class="dot" style="background:var(--lg)"></span> LangGraph</th>
+            <th class="fw"><span class="dot" style="background:var(--crew)"></span> CrewAI</th>
+            <th class="fw"><span class="dot" style="background:var(--adk)"></span> Google ADK</th>
+            <th class="fw"><span class="dot" style="background:var(--sk)"></span> Semantic Kernel</th>
+            <th class="fw"><span class="dot" style="background:var(--ma)"></span> Mastra</th>
+            <th class="fw"><span class="dot" style="background:var(--maf)"></span> MS Agent Fw</th>
+            <th class="fw"><span class="dot" style="background:var(--l4j)"></span> LangChain4j</th>
+            <th class="fw"><span class="dot" style="background:var(--gk)"></span> Genkit Go</th>
+            <th class="fw"><span class="dot" style="background:var(--rg)"></span> Rig</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="row-hd">Tool definition</td>
+            <td><code>@tool</code> on a function</td>
+            <td>Inherits from LangChain</td>
+            <td><code>BaseTool</code> subclass</td>
+            <td>Plain function</td>
+            <td><code>@kernel_function</code> on a plugin class</td>
+            <td><code>createTool({...})</code></td>
+            <td><code>AIFunctionFactory.Create</code></td>
+            <td><code>@Tool</code> on a POJO method</td>
+            <td><code>genkit.DefineTool(...)</code></td>
+            <td><code>impl Tool</code> / <code>#[rig_tool]</code></td>
+          </tr>
+          <tr>
+            <td class="row-hd">Schema source</td>
+            <td>Type hints + docstring</td>
+            <td>Inherits from LangChain</td>
+            <td>Pydantic <code>args_schema</code></td>
+            <td>Function sig + docstring</td>
+            <td>Decorator metadata + type hints</td>
+            <td>Zod / Valibot / ArkType</td>
+            <td><code>[Description]</code> + reflection</td>
+            <td>Annotation values + reflection</td>
+            <td>Struct tags (<code>jsonschema_description</code>)</td>
+            <td>Manual JSON or <code>schemars</code> derive</td>
+          </tr>
+          <tr>
+            <td class="row-hd">Bind to agent</td>
+            <td><code>create_agent(model, tools=[...])</code></td>
+            <td><code>create_react_agent</code> / <code>ToolNode</code></td>
+            <td><code>Agent(tools=[...])</code></td>
+            <td><code>LlmAgent(tools=[...])</code></td>
+            <td><code>kernel.add_plugin(...)</code></td>
+            <td><code>new Agent({ tools })</code></td>
+            <td><code>.AsAIAgent(..., tools)</code></td>
+            <td><code>AiServices.builder(...).tools(...)</code></td>
+            <td><code>ai.WithTools(t1, t2, ...)</code></td>
+            <td>Agent builder <code>.tool(MyTool)</code></td>
+          </tr>
+          <tr>
+            <td class="row-hd">Multi-agent</td>
+            <td>Wrap an agent as a tool</td>
+            <td>Compose <code>StateGraph</code>s</td>
+            <td><code>Crew + Process</code> (sequential / hierarchical)</td>
+            <td><code>sub_agents</code> + <code>transfer_to_agent</code></td>
+            <td><code>AgentGroupChat</code> + selection / termination</td>
+            <td><code>agents: { ... }</code> auto-exposed</td>
+            <td>Workflow primitives + DI</td>
+            <td>Agents-as-tools; dynamic <code>ToolProvider</code></td>
+            <td>Compose flows + <code>WithReturnToolRequests</code></td>
+            <td>Shared <code>ToolServer</code> handle</td>
+          </tr>
+          <tr>
+            <td class="row-hd">Parallel tool calls</td>
+            <td>Provider-dependent</td>
+            <td>Native via <code>ToolNode</code></td>
+            <td>Serial</td>
+            <td>Native (async)</td>
+            <td>Optional via <code>AllowParallelCalls</code></td>
+            <td>Native (provider)</td>
+            <td>Native (provider)</td>
+            <td>Java 21+ virtual threads</td>
+            <td>Goroutines</td>
+            <td>Serial by default</td>
+          </tr>
+          <tr>
+            <td class="row-hd">MCP support</td>
+            <td>Built-in</td>
+            <td>Built-in</td>
+            <td>Built-in</td>
+            <td>Built-in (tool server)</td>
+            <td><code>kernel.as_mcp_server</code></td>
+            <td>Built-in (consume + serve)</td>
+            <td>Built-in</td>
+            <td>Built-in</td>
+            <td>Built-in</td>
+            <td>Built-in (via <code>rmcp</code>)</td>
+          </tr>
+          <tr>
+            <td class="row-hd">Doc anchor</td>
+            <td><code>langchain/tools.py</code></td>
+            <td><code>chat_agent_executor.py</code></td>
+            <td><code>crewai/tools/base_tool.py</code></td>
+            <td><code>function_tool.py</code></td>
+            <td><code>kernel_function_decorator.py</code></td>
+            <td><code>@mastra/core/tools</code></td>
+            <td><code>AIFunctionFactory</code></td>
+            <td><code>dev.langchain4j.service.AiServices</code></td>
+            <td><code>genkit/tools.go</code></td>
+            <td><code>rig::tool::Tool</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- ================= TAKEAWAYS ================= -->
+<section id="takeaways">
+  <div class="container">
+    <h2>Summary observations</h2>
+    <p class="lede">Six factual observations drawn from the per-framework data above.</p>
+    <div class="takeaways">
+      <div class="ta">
+        <span class="tag">SHAPE</span>
+        <h4>1 · The tool object has the same four fields in every framework</h4>
+        <p>Decorators, macros, builders, and reflection all produce the same four-field object: a unique name, a description, a JSON schema for arguments, and a callable. The differences across frameworks are in how those four fields are declared, not in what the model receives.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">SCHEMA</span>
+        <h4>2 · Five distinct schema-source patterns are in use</h4>
+        <p>Type hints plus docstring (LangChain, LangGraph, ADK); Pydantic or Zod model (CrewAI, Mastra); reflection plus attribute or annotation metadata (LangChain4j, MAF); struct tags (Genkit Go); derive macros or manual JSON (Rig).</p>
+      </div>
+      <div class="ta">
+        <span class="tag">CONTROL</span>
+        <h4>3 · The tool-call loop is run by one of three actors</h4>
+        <p>By the framework (LangChain, LangGraph, CrewAI, ADK, Mastra, MAF, LangChain4j); by the Kernel (Semantic Kernel); or by the application code with a convenience opt-out (Genkit Go via <code>WithReturnToolRequests</code>, Rig). Frameworks in the third category expose more intervention points to caller code.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">SCALE</span>
+        <h4>4 · Multi-agent composition uses one of three patterns</h4>
+        <p><b>Agent-as-tool</b> (LangChain, Mastra, LangChain4j) — a sub-agent is wrapped as a tool. <b>Transfer-of-control</b> (ADK, CrewAI hierarchical) — an active agent signals a switch to a named sibling. <b>Composition</b> (LangGraph, ADK workflow agents, SK <code>AgentGroupChat</code>) — a parent orchestrator schedules children.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">PARALLELISM</span>
+        <h4>5 · Parallel tool execution is available in four frameworks by default</h4>
+        <p>LangGraph's <code>ToolNode</code>, ADK (async generators), and LangChain4j (with Java 21+ virtual threads) execute multiple tool calls concurrently by default. Mastra and MAF inherit parallelism from their provider SDK. CrewAI, Semantic Kernel, and Rig execute tool calls serially under default configuration.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">PORTABILITY</span>
+        <h4>6 · All ten frameworks support MCP as a tool source</h4>
+        <p>Every framework on this list ships first-class MCP consumer support. Several also support exposing their own tools as an MCP server (e.g. Semantic Kernel's <code>kernel.as_mcp_server</code>). Tools defined as MCP servers are therefore portable across all ten frameworks without modification.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ================= GLOSSARY ================= -->
+<section id="glossary">
+  <div class="container">
+    <h2>Mini-glossary</h2>
+    <p class="lede">A few terms used above that mean different things in different frameworks.</p>
+    <div class="gloss">
+      <div><b>Tool / Function / Plugin function</b> — a callable the model can ask the framework to run, exposed by a JSON schema.</div>
+      <div><b>Tool call</b> — the LLM's structured request to run a tool with named arguments (provider-native function calling).</div>
+      <div><b>FunctionChoiceBehavior</b> (SK) — Auto / Required / None; tells the Kernel whether the model picks functions and whether to auto-invoke them.</div>
+      <div><b>ToolNode</b> (LangGraph) — prebuilt node that executes every <code>tool_call</code> on the last <code>AIMessage</code> in parallel.</div>
+      <div><b>FunctionTool</b> (ADK) — wrapper that turns a native function (or method) into a model-callable tool; auto-applied when you pass a function into <code>LlmAgent(tools=[...])</code>.</div>
+      <div><b>AIFunctionFactory</b> (MAF) — .NET helper that turns any C# method into an <code>AIFunction</code> the agent can call.</div>
+      <div><b>AiServices</b> (LangChain4j) — facade that generates an agent implementation from a Java interface and wires in <code>@Tool</code>-annotated objects.</div>
+      <div><b>ToolServer</b> (Rig) — Tokio task that owns a set of tools and serves them to one or many agents via a handle, avoiding shared-state locks.</div>
+      <div><b>transfer_to_agent</b> (ADK) — structured action a tool can emit to hand control to a named sibling agent.</div>
+      <div><b>Crew / Process</b> (CrewAI) — outer-loop primitives: a <code>Crew</code> owns agents and tasks; a <code>Process</code> (sequential or hierarchical) decides the execution order.</div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    Compiled from the upstream documentation of LangChain, LangGraph, CrewAI, Google ADK,
+    Microsoft Semantic Kernel, Mastra, Microsoft Agent Framework, LangChain4j, Genkit, and Rig.
+    Framework selection follows the
+    <a href="/whitepapers/operational-excellence-index.html">Operational Excellence Index</a>;
+    format adapted from the companion paper
+    <a href="/whitepapers/agent-orchestration.html">How AI Agent Frameworks Orchestrate Tool Calls</a>.
+    <p class="copyright">© 2026 <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>. Licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
+  </div>
+</footer>
+
+<script>
+  // smooth-scroll for the pill nav
+  document.querySelectorAll('a.pill').forEach(a => {
+    a.addEventListener('click', e => {
+      const id = a.getAttribute('href');
+      if (id && id.startsWith('#')) {
+        const el = document.querySelector(id);
+        if (el) {
+          e.preventDefault();
+          el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          history.replaceState(null, '', id);
+        }
+      }
+    });
+  });
+</script>
+
+</body>
+</html>

--- a/www/whitepapers/index.html
+++ b/www/whitepapers/index.html
@@ -160,6 +160,52 @@
 
     <h3 class="group-heading">Standalone papers</h3>
 
+    <a class="index-entry" href="/whitepapers/agent-tool-wiring.html">
+      <p class="meta">
+        <span class="pill-tag">Standalone</span>
+        <span>Research date · May 25, 2026</span>
+      </p>
+      <h2>How AI Agent Frameworks Wire In Tools and Agents</h2>
+      <p class="dek">
+        A code-first reference across ten AI agent frameworks — LangChain,
+        LangGraph, CrewAI, Google ADK, Semantic Kernel, Mastra, Microsoft
+        Agent Framework, LangChain4j, Genkit Go, and Rig — covering how each
+        one declares tools, defines their schemas, and composes multiple
+        agents.
+      </p>
+      <span class="read-arrow">Read paper →</span>
+    </a>
+
+    <a class="index-entry" href="/whitepapers/agent-remote-tools.html">
+      <p class="meta">
+        <span class="pill-tag">Standalone</span>
+        <span>Research date · May 25, 2026</span>
+      </p>
+      <h2>Internal vs Remote Tools — How AI Agent Frameworks Wire In Each</h2>
+      <p class="dek">
+        A reference map of where tools can live across ten AI agent
+        frameworks — in-process code, MCP servers, OpenAPI specs, remote
+        agents over A2A, and generic RPC — and the documented declaration
+        and call mechanism for each.
+      </p>
+      <span class="read-arrow">Read paper →</span>
+    </a>
+
+    <a class="index-entry" href="/whitepapers/mcp-explained.html">
+      <p class="meta">
+        <span class="pill-tag">Standalone</span>
+        <span>Research date · May 25, 2026</span>
+      </p>
+      <h2>Model Context Protocol — How It Works, On Your Desktop and In the Cloud</h2>
+      <p class="dek">
+        A protocol-level reference for MCP — the wire model, stdio and
+        streamable HTTP transports, the initialize / tools/list / tools/call
+        lifecycle, the OAuth 2.1 authorization model, and how desktop AI
+        apps and server-hosted agents both consume MCP servers.
+      </p>
+      <span class="read-arrow">Read paper →</span>
+    </a>
+
     <a class="index-entry" href="/whitepapers/agent-orchestration.html">
       <p class="meta">
         <span class="pill-tag">Standalone</span>

--- a/www/whitepapers/mcp-explained.html
+++ b/www/whitepapers/mcp-explained.html
@@ -1,0 +1,1280 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Model Context Protocol — How It Works, On Your Desktop and In the Cloud</title>
+<meta name="description" content="A protocol-level reference for MCP (Model Context Protocol): the wire model, stdio and streamable HTTP transports, the initialize / tools/list / tools/call lifecycle, the OAuth 2.1 authorization model, and how desktop AI apps (Claude Code, VS Code, Cursor) and server-hosted AI agents both consume MCP servers." />
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="TruvaG3">
+<meta property="og:title" content="Model Context Protocol — How It Works, On Your Desktop and In the Cloud">
+<meta property="og:description" content="A protocol-level reference for MCP: wire model, transports, lifecycle, authorization, and how desktop apps and server-hosted agents both consume MCP servers.">
+<meta property="og:url" content="https://truvag3.dev/whitepapers/mcp-explained">
+<meta property="og:image" content="https://truvag3.dev/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="TruvaG3 — Microagents Framework for Go">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Model Context Protocol — How It Works">
+<meta name="twitter:description" content="A protocol-level reference for MCP: wire model, transports, lifecycle, authorization, and how desktop apps and server-hosted agents both consume MCP servers.">
+<meta name="twitter:image" content="https://truvag3.dev/og-image.png">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="/favicon-192.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="stylesheet" href="/assets/css/site-nav.css">
+<style>
+  :root {
+    --bg: #0b0f17; --bg-2: #121826; --bg-3: #1a2236;
+    --ink: #e6edf7; --muted: #9aa6bd; --line: #2a3550;
+    --accent: #7cc4ff; --warn: #fbbf24; --good: #34d399;
+    --brand-truva-light: #DBEEFB; --brand-truva-dark: #4A8AB8;
+    --brand-g3-light: #FFD080; --brand-g3-dark: #C56710;
+    /* Section accents */
+    --client: #60a5fa;   /* blue */
+    --server: #34d399;   /* green */
+    --transport: #fbbf24; /* amber */
+    --auth:   #f472b6;   /* pink */
+    --maxw: 1180px;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: radial-gradient(1200px 800px at 50% -10%, #1c2541 0%, var(--bg) 60%);
+    color: var(--ink);
+    font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  p code, li code, td code, h3 code, h4 code { color: #c9e2ff; background: rgba(124,196,255,.08); padding: 1px 5px; border-radius: 4px; font-size: 0.92em; }
+  pre {
+    background: var(--bg-3); border: 1px solid var(--line); border-radius: 10px;
+    padding: 14px 16px; overflow: auto; font-size: 12.5px; line-height: 1.55; color: #cfe1ff;
+    margin: 8px 0 6px;
+  }
+  pre code { background: transparent; padding: 0; color: inherit; font-size: inherit; }
+  .snip-src {
+    margin: 0 0 16px; padding-left: 4px;
+    font-size: 11.5px; color: var(--muted); line-height: 1.45;
+  }
+  .snip-src::before { content: "↳  "; color: #4b6688; }
+  .snip-src a { color: var(--muted); border-bottom: 1px dotted rgba(154,166,189,.4); text-decoration: none; }
+  .snip-src a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+  .container { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+
+  /* Hero */
+  header.hero { padding: 64px 0 36px; text-align: center; border-bottom: 1px solid var(--line); position: relative; }
+  .research-date { display: inline-block; margin-bottom: 18px; padding: 5px 14px; border-radius: 999px; background: var(--bg-2); border: 1px solid var(--line); color: var(--muted); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; }
+  .research-date b { color: var(--ink); font-weight: 600; letter-spacing: 0; text-transform: none; }
+  .ai-capsule { display: inline-block; margin-bottom: 18px; margin-left: 8px; padding: 5px 14px; border-radius: 999px; background: var(--bg-2); border: 1px solid var(--warn); color: var(--warn); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; }
+  header.hero h1 { font-size: clamp(28px, 4.4vw, 46px); line-height: 1.1; margin: 0 0 14px; letter-spacing: -0.02em; background: linear-gradient(90deg, #ffffff 0%, #9ec5ff 60%, #c4b5fd 100%); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  header.hero .subtitle { color: var(--muted); font-size: 17px; max-width: 820px; margin: 0 auto 22px; }
+  .pillrow { display: flex; flex-wrap: wrap; justify-content: center; gap: 8px; }
+  .pill { display: inline-flex; align-items: center; gap: 8px; padding: 7px 13px; border-radius: 999px; background: var(--bg-2); border: 1px solid var(--line); color: var(--ink); font-size: 13px; cursor: pointer; transition: transform .15s ease, background .15s ease, border-color .15s ease; }
+  .pill:hover { transform: translateY(-1px); border-color: #3a4a72; text-decoration: none; }
+  .dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; }
+
+  /* Sections */
+  section { padding: 56px 0; border-bottom: 1px solid var(--line); }
+  section h2 { font-size: clamp(22px, 2.5vw, 30px); letter-spacing: -0.01em; margin: 0 0 8px; }
+  section h3 { font-size: 19px; margin: 26px 0 8px; }
+  section h4 { font-size: 15px; margin: 18px 0 6px; color: var(--accent); letter-spacing: .03em; text-transform: uppercase; }
+  section .lede { color: var(--muted); max-width: 820px; margin: 0 0 28px; }
+  section p { color: #d4dcef; }
+
+  /* Diagram + explanation card */
+  .diagram-card {
+    background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.005));
+    border: 1px solid var(--line); border-radius: 14px;
+    padding: 22px; margin: 22px 0 28px;
+  }
+  .diagram-card .svg-wrap {
+    background: var(--bg-2); border: 1px solid var(--line); border-radius: 12px;
+    padding: 12px; margin-bottom: 14px; overflow-x: auto;
+  }
+  .diagram-card svg { max-width: 100%; height: auto; display: block; margin: 0 auto; }
+  .diagram-card .caption { font-size: 12.5px; color: var(--muted); margin: 4px 0 14px; text-align: center; }
+
+  /* Explanation list under diagram */
+  .legend-list { display: grid; gap: 10px; margin: 0; padding: 0; list-style: none; }
+  .legend-list li {
+    display: grid; grid-template-columns: 28px 1fr; gap: 12px;
+    background: var(--bg-3); border: 1px solid var(--line); border-radius: 8px;
+    padding: 10px 14px;
+  }
+  .legend-list li .num {
+    background: var(--accent); color: #0a1a2b; border-radius: 50%;
+    width: 24px; height: 24px; display: grid; place-items: center;
+    font-weight: 700; font-size: 12.5px;
+  }
+  .legend-list li b { color: #fff; display: block; margin-bottom: 2px; font-size: 13.5px; }
+  .legend-list li p { margin: 0; font-size: 13.5px; color: #cfd9ee; }
+
+  /* Tables */
+  .table-wrap { overflow: auto; border: 1px solid var(--line); border-radius: 12px; }
+  table { width: 100%; border-collapse: collapse; font-size: 13.5px; min-width: 720px; }
+  th, td { padding: 12px 14px; border-bottom: 1px solid var(--line); vertical-align: top; text-align: left; }
+  thead th { background: var(--bg-2); font-weight: 600; }
+  td.row-hd { background: var(--bg-2); font-weight: 600; white-space: nowrap; }
+
+  /* Takeaways */
+  .takeaways { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+  @media (max-width: 880px) { .takeaways { grid-template-columns: 1fr; } }
+  .ta { background: var(--bg-2); border: 1px solid var(--line); border-radius: 14px; padding: 18px; }
+  .ta h4 { margin: 0 0 8px; font-size: 15px; color: #fff; text-transform: none; letter-spacing: 0; }
+  .ta p { margin: 0; color: #cfd9ee; font-size: 14px; }
+  .ta .tag { display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 999px; background: #19243d; color: #9fc2ff; margin-bottom: 8px; }
+
+  /* Glossary */
+  .gloss { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px 22px; }
+  @media (max-width: 720px) { .gloss { grid-template-columns: 1fr; } }
+  .gloss div { padding: 8px 0; border-bottom: 1px dashed var(--line); color: #cfd9ee; }
+  .gloss b { color: #fff; }
+
+  /* Notes / callouts */
+  .note-box {
+    background: rgba(124,196,255,.06); border: 1px solid rgba(124,196,255,.25);
+    border-left: 3px solid var(--accent); border-radius: 8px;
+    padding: 12px 14px; margin: 14px 0; font-size: 14px; color: #d4dcef;
+  }
+
+  footer { padding: 36px 0 64px; text-align: center; color: var(--muted); font-size: 13px; }
+  .copyright { color: var(--muted); font-size: 0.85rem; text-align: center; margin-top: 1.5rem; margin-bottom: 0; }
+
+  /* SVG flow-line animation */
+  @keyframes dash { to { stroke-dashoffset: -40; } }
+  .flow-line { stroke-dasharray: 6 6; animation: dash 4s linear infinite; }
+</style>
+</head>
+<body>
+
+<nav class="site-nav">
+  <div class="container">
+    <a class="nav-brand" href="/"><span class="brand-truva">Truva</span><span class="brand-g3">G3</span></a>
+    <div class="nav-links">
+      <a href="/blogs/">Blog</a>
+      <a href="/whitepapers/">Whitepapers</a>
+      <a href="https://docs.truvag3.dev/docs/intro/">Docs</a>
+      <a href="https://github.com/truvaagents/truva-g3">GitHub</a>
+    </div>
+  </div>
+</nav>
+
+<header class="hero">
+  <div class="container">
+    <div class="research-date">Research date · <b>May 25, 2026</b></div>
+    <div class="ai-capsule">Generated with AI</div>
+    <h1>Model Context Protocol — How It Works, On Your Desktop and In the Cloud</h1>
+    <p class="subtitle">
+      A protocol-level reference for the Model Context Protocol (MCP): the wire model, the two
+      current transports (stdio and Streamable HTTP), the connection lifecycle, the OAuth&nbsp;2.1
+      authorization model, and how the same protocol powers both desktop AI applications (Claude Code,
+      VS Code, Cursor) and server-hosted AI agents. Every JSON-RPC example is taken from the
+      official MCP specification revision <b>2025-11-25</b>.
+    </p>
+    <div class="pillrow">
+      <a class="pill" href="#overview"><span class="dot" style="background:#9ec5ff"></span>The wire model</a>
+      <a class="pill" href="#stdio"><span class="dot" style="background:var(--transport)"></span>stdio transport</a>
+      <a class="pill" href="#http"><span class="dot" style="background:var(--transport)"></span>Streamable HTTP</a>
+      <a class="pill" href="#lifecycle"><span class="dot" style="background:var(--client)"></span>Lifecycle</a>
+      <a class="pill" href="#desktop"><span class="dot" style="background:var(--server)"></span>Desktop apps</a>
+      <a class="pill" href="#hosted"><span class="dot" style="background:var(--server)"></span>Hosted agents</a>
+      <a class="pill" href="#auth"><span class="dot" style="background:var(--auth)"></span>Authorization</a>
+      <a class="pill" href="#authoring"><span class="dot" style="background:var(--server)"></span>Authoring a server</a>
+      <a class="pill" href="#compare"><span class="dot" style="background:#fff"></span>Side-by-side</a>
+      <a class="pill" href="#takeaways"><span class="dot" style="background:var(--good)"></span>Summary</a>
+    </div>
+  </div>
+</header>
+
+<!-- ============================================================
+     VERSION NOTICE
+     ============================================================ -->
+<section id="version-notice" style="padding: 36px 0 0; border-bottom: none;">
+  <div class="container">
+    <div class="note-box" style="border-left-color: var(--warn); background: rgba(251,191,36,.06); border-color: rgba(251,191,36,.30);">
+      <b style="color: var(--warn);">Spec revision in this paper · <code>2025-11-25</code> (current stable).</b>
+      A <a href="https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/">release candidate for revision <code>2026-07-28</code></a>
+      was locked on May 21, 2026; the final ships July 28, 2026. It is the largest revision
+      since launch and contains breaking changes. The most consequential for this paper:
+      <ul style="margin: 8px 0 0; padding-left: 22px; color: #d4dcef;">
+        <li>The <code>initialize</code> / <code>notifications/initialized</code> handshake is removed (<a href="https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575">SEP-2575</a>). Protocol version, client info, and client capabilities now travel in <code>_meta</code> on every request; a new <code>server/discover</code> method fetches server capabilities on demand. §4 of this paper describes the <i>current</i> handshake.</li>
+        <li>The <code>MCP-Session-Id</code> header and protocol-level session are removed (<a href="https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567">SEP-2567</a>). Any request can land on any server instance — no sticky routing required. §3, §6, §9, and §11 of this paper describe the <i>current</i> session model.</li>
+        <li>New required Streamable HTTP headers: <code>MCP-Protocol-Version</code>, <code>Mcp-Method</code>, and <code>Mcp-Name</code> on every request, so gateways can route without inspecting the body.</li>
+        <li><i>Roots</i>, <i>Sampling</i>, and <i>Logging</i> capabilities are deprecated (continue to work; replacements documented in the RC notes).</li>
+        <li>Tools' <code>inputSchema</code> / <code>outputSchema</code> are lifted to full JSON Schema 2020-12, with support for <code>oneOf</code>, <code>anyOf</code>, <code>allOf</code>, <code>$ref</code>, and <code>$defs</code>.</li>
+        <li>The <i>Tasks</i> feature graduates out of the core spec into an Extensions track.</li>
+      </ul>
+      <span style="display: block; margin-top: 8px; font-size: 12.5px;">This paper will be updated after the <code>2026-07-28</code> spec is finalised. Until then, every claim below is verified against the current stable revision <code>2025-11-25</code>.</span>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     SECTION 1 — THE WIRE MODEL
+     ============================================================ -->
+<section id="overview">
+  <div class="container">
+    <h2>1 · The wire model</h2>
+    <p class="lede">
+      MCP is an open, JSON-RPC 2.0–based protocol that connects an <b>MCP client</b> (typically an LLM
+      application or agent runtime) to one or more <b>MCP servers</b> (processes that expose
+      <em>tools</em>, <em>resources</em>, and <em>prompts</em>). The protocol is transport-agnostic; the
+      current revision (<b>2025-11-25</b>) standardises two transports: <b>stdio</b> and
+      <b>Streamable HTTP</b>.
+    </p>
+
+    <div class="diagram-card">
+      <div class="svg-wrap">
+<svg viewBox="0 0 900 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="MCP wire model overview">
+  <defs>
+    <marker id="arr-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#9ec5ff"/></marker>
+    <marker id="arr-amber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#fbbf24"/></marker>
+    <linearGradient id="g-client" x1="0" x2="1"><stop offset="0" stop-color="#1e40af"/><stop offset="1" stop-color="#3b82f6"/></linearGradient>
+    <linearGradient id="g-server" x1="0" x2="1"><stop offset="0" stop-color="#047857"/><stop offset="1" stop-color="#10b981"/></linearGradient>
+  </defs>
+
+  <!-- Client (host application) — pushed to the left edge -->
+  <rect x="10" y="60" width="210" height="200" rx="14" fill="url(#g-client)"/>
+  <text x="115" y="92" text-anchor="middle" fill="#fff" font-size="15" font-weight="700">MCP Client (host)</text>
+  <text x="115" y="115" text-anchor="middle" fill="#dbeafe" font-size="12">desktop app · agent runtime</text>
+  <rect x="30" y="135" width="170" height="32" rx="6" fill="#0a2540" stroke="#3a8aff"/>
+  <text x="115" y="156" text-anchor="middle" fill="#9ec5ff" font-size="11">LLM (Claude · GPT · Gemini · …)</text>
+  <rect x="30" y="175" width="170" height="32" rx="6" fill="#0a2540" stroke="#3a8aff"/>
+  <text x="115" y="196" text-anchor="middle" fill="#9ec5ff" font-size="11">MCP client library</text>
+  <text x="115" y="232" text-anchor="middle" fill="#dbeafe" font-size="11">owns one connection per server</text>
+
+  <!-- Transport channel — width shrunk 15% (240→204), centered at x=450 -->
+  <rect x="348" y="120" width="204" height="80" rx="12" fill="#171f33" stroke="var(--transport)" stroke-width="1.5" stroke-dasharray="4 5"/>
+  <text x="450" y="148" text-anchor="middle" fill="#fbbf24" font-size="13" font-weight="700">Transport</text>
+  <text x="450" y="167" text-anchor="middle" fill="#fde68a" font-size="11">stdio (local subprocess)</text>
+  <text x="450" y="184" text-anchor="middle" fill="#fde68a" font-size="11">or Streamable HTTP (remote)</text>
+
+  <!-- Server — pushed to the right edge -->
+  <rect x="680" y="60" width="210" height="200" rx="14" fill="url(#g-server)"/>
+  <text x="785" y="92" text-anchor="middle" fill="#fff" font-size="15" font-weight="700">MCP Server</text>
+  <text x="785" y="115" text-anchor="middle" fill="#dcfce7" font-size="12">tools · resources · prompts</text>
+  <rect x="700" y="135" width="170" height="32" rx="6" fill="#03241f" stroke="#34d399"/>
+  <text x="785" y="156" text-anchor="middle" fill="#bbf7d0" font-size="11">tool: get_weather(loc)</text>
+  <rect x="700" y="175" width="170" height="32" rx="6" fill="#03241f" stroke="#34d399"/>
+  <text x="785" y="196" text-anchor="middle" fill="#bbf7d0" font-size="11">tool: search_db(query)</text>
+  <text x="785" y="232" text-anchor="middle" fill="#dcfce7" font-size="11">in-process or hosted service</text>
+
+  <!-- Forward arrows (client → transport → server). Each gap is 128 px, plenty of room for labels. -->
+  <text x="284" y="142" text-anchor="middle" fill="#9ec5ff" font-size="11" font-weight="600">JSON-RPC request</text>
+  <path d="M220,150 L348,150" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#arr-blue)"/>
+  <text x="616" y="142" text-anchor="middle" fill="#9ec5ff" font-size="11" font-weight="600">JSON-RPC request</text>
+  <path d="M552,150 L680,150" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#arr-blue)"/>
+
+  <!-- Reverse arrows (responses + notifications). -->
+  <text x="616" y="200" text-anchor="middle" fill="#fbbf24" font-size="11" font-weight="600">response · notification</text>
+  <path d="M680,180 L552,180" stroke="#fbbf24" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#arr-amber)" class="flow-line"/>
+  <text x="284" y="200" text-anchor="middle" fill="#fbbf24" font-size="11" font-weight="600">response · notification</text>
+  <path d="M348,180 L220,180" stroke="#fbbf24" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#arr-amber)" class="flow-line"/>
+
+  <!-- (boundary annotations removed; the corresponding facts live in the legend below) -->
+</svg>
+      </div>
+      <div class="caption">Figure 1 · MCP wire model: client and server communicate JSON-RPC 2.0 messages over a transport. The blue arrows show client-initiated requests; the amber dashed arrows show server-initiated responses and notifications.</div>
+
+      <ol class="legend-list">
+        <li><span class="num">1</span><div><b>Client (host)</b><p>The application that hosts the LLM and orchestrates tool use. Examples in this paper: Claude Code, VS Code (Copilot Chat), Cursor, and any custom agent runtime that links the MCP client library.</p></div></li>
+        <li><span class="num">2</span><div><b>Server</b><p>A separate process (local subprocess or remote service) that exposes tools, resources, and/or prompts. One client maintains one logical connection per server. A client typically connects to several servers concurrently.</p></div></li>
+        <li><span class="num">3</span><div><b>Transport</b><p>Either <code>stdio</code> (server runs as a child process; messages flow through stdin/stdout) or <code>Streamable HTTP</code> (server is a network endpoint reached over HTTP POST, with optional Server-Sent Events for server-initiated messages).</p></div></li>
+        <li><span class="num">4</span><div><b>Messages</b><p>Three JSON-RPC 2.0 message types: <em>requests</em> (have an <code>id</code>, expect a response), <em>responses</em> (match a request by <code>id</code>), and <em>notifications</em> (no <code>id</code>, no response). All messages share a single bidirectional channel.</p></div></li>
+      </ol>
+      <p class="snip-src">Source: <a href="https://modelcontextprotocol.io/specification/2025-11-25/architecture">modelcontextprotocol.io · Specification 2025-11-25 · Architecture</a> · <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic">Base Protocol overview</a> · <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/transports">Transports</a></p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     SECTION 2 — STDIO TRANSPORT
+     ============================================================ -->
+<section id="stdio">
+  <div class="container">
+    <h2>2 · The <code>stdio</code> transport</h2>
+    <p class="lede">
+      Under the stdio transport, the client launches the server as a child process and exchanges
+      newline-delimited JSON-RPC messages over the server's standard input and standard output. The
+      server may write UTF-8 strings to standard error for logging. This is the default transport for
+      local, single-user tools (filesystem access, local databases, local scripts).
+    </p>
+
+    <div class="diagram-card">
+      <div class="svg-wrap">
+<svg viewBox="0 0 900 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="stdio transport detail">
+  <defs>
+    <marker id="arr-b2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#9ec5ff"/></marker>
+    <marker id="arr-g2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#34d399"/></marker>
+    <marker id="arr-r2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#fb7185"/></marker>
+  </defs>
+
+  <!-- Single-host boundary -->
+  <rect x="10" y="20" width="880" height="280" rx="14" fill="none" stroke="#3a4a72" stroke-dasharray="3 5"/>
+  <text x="30" y="40" fill="#9aa6bd" font-size="11">Single host machine — both processes run as the same user</text>
+
+  <!-- Parent process (client) — pushed to the left edge -->
+  <rect x="20" y="70" width="265" height="200" rx="12" fill="#0a2540" stroke="#3a8aff"/>
+  <text x="152" y="98" text-anchor="middle" fill="#fff" font-size="14" font-weight="700">Parent process</text>
+  <text x="152" y="118" text-anchor="middle" fill="#9ec5ff" font-size="12">Client (Claude Code, IDE, …)</text>
+  <rect x="35" y="140" width="235" height="32" rx="6" fill="#171f33" stroke="#3a4a72"/>
+  <text x="152" y="161" text-anchor="middle" fill="#cfe1ff" font-size="11">spawn(command, args, env)</text>
+  <rect x="35" y="180" width="235" height="32" rx="6" fill="#171f33" stroke="#3a4a72"/>
+  <text x="152" y="201" text-anchor="middle" fill="#cfe1ff" font-size="11">write(stdin) · read(stdout)</text>
+  <rect x="35" y="220" width="235" height="32" rx="6" fill="#171f33" stroke="#3a4a72"/>
+  <text x="152" y="241" text-anchor="middle" fill="#cfe1ff" font-size="11">on shutdown: send SIGTERM</text>
+
+  <!-- Child process (server) — pushed to the right edge -->
+  <rect x="615" y="70" width="265" height="200" rx="12" fill="#03241f" stroke="#34d399"/>
+  <text x="748" y="98" text-anchor="middle" fill="#fff" font-size="14" font-weight="700">Child process</text>
+  <text x="748" y="118" text-anchor="middle" fill="#bbf7d0" font-size="12">MCP server (e.g. npx mcp-server-filesystem)</text>
+  <rect x="630" y="140" width="235" height="32" rx="6" fill="#0a2520" stroke="#10b981"/>
+  <text x="748" y="161" text-anchor="middle" fill="#bbf7d0" font-size="11">read(stdin) — one JSON-RPC per line</text>
+  <rect x="630" y="180" width="235" height="32" rx="6" fill="#0a2520" stroke="#10b981"/>
+  <text x="748" y="201" text-anchor="middle" fill="#bbf7d0" font-size="11">write(stdout) — one JSON-RPC per line</text>
+  <rect x="630" y="220" width="235" height="32" rx="6" fill="#0a2520" stroke="#10b981"/>
+  <text x="748" y="241" text-anchor="middle" fill="#bbf7d0" font-size="11">write(stderr) — free-form log text</text>
+
+  <!-- Three pipe arrows in the gap (x=285-615 ≈ 330 px). Labels above each arrow. -->
+  <!-- stdin arrow -->
+  <text x="450" y="148" text-anchor="middle" fill="#9ec5ff" font-size="11" font-weight="600">stdin · JSON-RPC requests</text>
+  <path d="M285,158 L610,158" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#arr-b2)"/>
+
+  <!-- stdout arrow -->
+  <text x="450" y="195" text-anchor="middle" fill="#34d399" font-size="11" font-weight="600">stdout · JSON-RPC responses &amp; notifications</text>
+  <path d="M610,205 L285,205" stroke="#34d399" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#arr-g2)" class="flow-line"/>
+
+  <!-- stderr arrow -->
+  <text x="450" y="240" text-anchor="middle" fill="#fb7185" font-size="11" font-weight="600">stderr · log text (optional)</text>
+  <path d="M610,250 L285,250" stroke="#fb7185" stroke-width="1.5" stroke-dasharray="4 3" fill="none" marker-end="url(#arr-r2)"/>
+</svg>
+      </div>
+      <div class="caption">Figure 2 · stdio transport: the client spawns the server as a child process. Each JSON-RPC message is a single line of UTF-8 JSON terminated by <code>\n</code> and MUST NOT contain embedded newlines. stderr is reserved for free-form server logs.</div>
+
+      <ol class="legend-list">
+        <li><span class="num">1</span><div><b>Launch</b><p>The client invokes the server's <code>command</code> with <code>args</code> and an optional <code>env</code> map. The server inherits the client's working directory unless the client overrides it. No network sockets are opened.</p></div></li>
+        <li><span class="num">2</span><div><b>Framing</b><p>Each JSON-RPC message is one UTF-8 line terminated by <code>\n</code>. Embedded newlines are forbidden, so multi-line content must be JSON-escaped. There is no separate header frame; the line itself is the message.</p></div></li>
+        <li><span class="num">3</span><div><b>Logging</b><p>The server MAY write any UTF-8 text to stderr; the client captures and surfaces it for debugging. This is the only out-of-band channel — anything written to stdout MUST be a valid JSON-RPC message.</p></div></li>
+        <li><span class="num">4</span><div><b>Lifecycle</b><p>The connection ends when either process closes its end of the pipes. The client typically sends SIGTERM/SIGKILL to shut down the server cleanly.</p></div></li>
+      </ol>
+    </div>
+
+    <p class="snip-src">Source: <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/transports">modelcontextprotocol.io · Specification 2025-11-25 · Transports</a></p>
+  </div>
+</section>
+
+<!-- ============================================================
+     SECTION 3 — STREAMABLE HTTP TRANSPORT
+     ============================================================ -->
+<section id="http">
+  <div class="container">
+    <h2>3 · The <code>Streamable HTTP</code> transport</h2>
+    <p class="lede">
+      Streamable HTTP is the standardised transport for remote MCP servers. The server exposes a
+      single HTTP endpoint that supports both <code>POST</code> (for client-to-server messages) and
+      <code>GET</code> (for the optional server-initiated message stream). A response to a
+      <code>POST</code> can be either a single JSON object or a Server-Sent Events (SSE) stream,
+      depending on whether the server needs to emit multiple messages in reply.
+    </p>
+
+    <div class="diagram-card">
+      <div class="svg-wrap">
+<svg viewBox="0 0 900 410" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Streamable HTTP transport detail">
+  <defs>
+    <marker id="arr-b3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#9ec5ff"/></marker>
+    <marker id="arr-g3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#34d399"/></marker>
+    <marker id="arr-y3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#fbbf24"/></marker>
+  </defs>
+
+  <!-- Boundary labels -->
+  <text x="15" y="28" fill="#9aa6bd" font-size="11">Client host</text>
+  <text x="885" y="28" text-anchor="end" fill="#9aa6bd" font-size="11">Server host (anywhere reachable over HTTP)</text>
+
+  <!-- Client (pushed flush left) -->
+  <rect x="15" y="60" width="240" height="320" rx="14" fill="#0a2540" stroke="#3a8aff"/>
+  <text x="135" y="92" text-anchor="middle" fill="#fff" font-size="14" font-weight="700">MCP Client</text>
+  <text x="135" y="113" text-anchor="middle" fill="#9ec5ff" font-size="12">desktop app · hosted agent</text>
+  <rect x="30" y="135" width="210" height="32" rx="6" fill="#171f33" stroke="#3a4a72"/>
+  <text x="135" y="156" text-anchor="middle" fill="#cfe1ff" font-size="11">HTTP client (POST writer)</text>
+  <rect x="30" y="175" width="210" height="32" rx="6" fill="#171f33" stroke="#3a4a72"/>
+  <text x="135" y="196" text-anchor="middle" fill="#cfe1ff" font-size="11">POST-response SSE reader</text>
+  <rect x="30" y="215" width="210" height="40" rx="6" fill="#171f33" stroke="#3a4a72"/>
+  <text x="135" y="234" text-anchor="middle" fill="#cfe1ff" font-size="11">Auth: Bearer &lt;access_token&gt;</text>
+  <text x="135" y="248" text-anchor="middle" fill="#9aa6bd" font-size="10">(OAuth 2.1 token; see §6)</text>
+  <!-- Bottom anchor for the long-lived GET channel -->
+  <rect x="30" y="320" width="210" height="40" rx="6" fill="#171f33" stroke="#fbbf24" stroke-dasharray="3 3"/>
+  <text x="135" y="338" text-anchor="middle" fill="#fde68a" font-size="11">Long-lived GET listener</text>
+  <text x="135" y="354" text-anchor="middle" fill="#9aa6bd" font-size="10">(SSE stream, optional)</text>
+
+  <!-- Network channel — extended so all four arrows live inside it -->
+  <rect x="335" y="100" width="230" height="280" rx="12" fill="none" stroke="#fbbf24" stroke-dasharray="4 4"/>
+  <text x="450" y="125" text-anchor="middle" fill="#fbbf24" font-size="12" font-weight="700">HTTP / HTTPS</text>
+
+  <!-- Server endpoint (pushed flush right) -->
+  <rect x="645" y="60" width="240" height="320" rx="14" fill="#03241f" stroke="#34d399"/>
+  <text x="765" y="92" text-anchor="middle" fill="#fff" font-size="14" font-weight="700">MCP Server</text>
+  <text x="765" y="113" text-anchor="middle" fill="#bbf7d0" font-size="12">single endpoint, e.g. /mcp</text>
+  <rect x="660" y="135" width="210" height="32" rx="6" fill="#0a2520" stroke="#10b981"/>
+  <text x="765" y="156" text-anchor="middle" fill="#bbf7d0" font-size="11">POST /mcp  (client → server)</text>
+  <rect x="660" y="175" width="210" height="32" rx="6" fill="#0a2520" stroke="#10b981"/>
+  <text x="765" y="196" text-anchor="middle" fill="#bbf7d0" font-size="11">POST response writer</text>
+  <rect x="660" y="215" width="210" height="40" rx="6" fill="#0a2520" stroke="#10b981"/>
+  <text x="765" y="234" text-anchor="middle" fill="#bbf7d0" font-size="11">MCP-Session-Id (correlation)</text>
+  <text x="765" y="248" text-anchor="middle" fill="#a7f3d0" font-size="10">issued in initialize response</text>
+  <!-- Bottom anchor for the long-lived GET channel -->
+  <rect x="660" y="320" width="210" height="40" rx="6" fill="#0a2520" stroke="#fbbf24" stroke-dasharray="3 3"/>
+  <text x="765" y="338" text-anchor="middle" fill="#fde68a" font-size="11">GET /mcp  SSE writer</text>
+  <text x="765" y="354" text-anchor="middle" fill="#9aa6bd" font-size="10">(server-initiated channel)</text>
+
+  <!-- Arrow 1 · Request -->
+  <path d="M255,155 L645,155" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#arr-b3)"/>
+  <text x="450" y="148" text-anchor="middle" fill="#9ec5ff" font-size="11">POST  Accept: application/json, text/event-stream</text>
+
+  <!-- Arrow 2 · Single JSON response -->
+  <path d="M645,195 L255,195" stroke="#34d399" stroke-width="2" fill="none" marker-end="url(#arr-g3)"/>
+  <text x="450" y="190" text-anchor="middle" fill="#34d399" font-size="11">200 OK  Content-Type: application/json  (single response)</text>
+
+  <!-- Arrow 3 · SSE response stream -->
+  <path d="M645,235 L255,235" stroke="#fbbf24" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#arr-y3)" class="flow-line"/>
+  <text x="450" y="230" text-anchor="middle" fill="#fbbf24" font-size="11">— OR — 200 OK  Content-Type: text/event-stream  (SSE)</text>
+
+  <!-- Arrow 4 · Long-lived GET stream — label sits right above the arrow, between the bottom panels -->
+  <path d="M645,340 L255,340" stroke="#fbbf24" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#arr-y3)" class="flow-line"/>
+  <text x="450" y="333" text-anchor="middle" fill="#fbbf24" font-size="11">GET /mcp (open SSE) — server-initiated requests &amp; notifications</text>
+</svg>
+      </div>
+      <div class="caption">Figure 3 · Streamable HTTP transport: one HTTP endpoint handles all traffic. Clients <code>POST</code> requests; the server responds with either a single JSON body or an SSE stream of multiple messages. A separate, optional <code>GET</code> opens a channel for server-initiated requests.</div>
+
+      <ol class="legend-list">
+        <li><span class="num">1</span><div><b>Single endpoint</b><p>The server exposes one path (commonly <code>/mcp</code>). The client sends <code>Accept: application/json, text/event-stream</code> so the server may choose its response format per call.</p></div></li>
+        <li><span class="num">2</span><div><b>Two response shapes</b><p>If the server returns one response, it sends <code>Content-Type: application/json</code>. If it needs to stream multiple messages (e.g. a server-initiated request in the middle of handling a tool call), it returns <code>Content-Type: text/event-stream</code>.</p></div></li>
+        <li><span class="num">3</span><div><b>Sessions</b><p>On <code>initialize</code>, the server MAY return an <code>MCP-Session-Id</code> header. The client echoes that header on subsequent requests to keep them on the same logical session. Session state allows the server to scale horizontally while still routing related calls together.</p></div></li>
+        <li><span class="num">4</span><div><b>Server-initiated stream</b><p>For notifications (e.g. <code>tools/list_changed</code>, progress updates) and server-initiated requests (e.g. sampling), the client opens a long-lived <code>GET</code> against the same endpoint. The server streams messages over SSE.</p></div></li>
+        <li><span class="num">5</span><div><b>Authorization</b><p>Requests carry a Bearer token from the OAuth 2.1 flow described in §6. The server validates the token's audience matches its own URI (RFC 8707 resource indicator) before processing the JSON-RPC envelope.</p></div></li>
+      </ol>
+    </div>
+
+    <div class="note-box">
+      <b>About the legacy SSE transport.</b> The earlier two-endpoint HTTP+SSE transport from spec revision <code>2024-11-05</code> is now deprecated. Servers MAY continue to expose it for backwards compatibility, and clients SHOULD attempt Streamable HTTP first and fall back to the legacy SSE shape only if they receive HTTP 400/404/405 on POST.
+    </div>
+
+    <p class="snip-src">Source: <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/transports">modelcontextprotocol.io · Specification 2025-11-25 · Transports</a> · <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#backwards-compatibility">Backwards compatibility</a></p>
+  </div>
+</section>
+
+<!-- ============================================================
+     SECTION 4 — LIFECYCLE
+     ============================================================ -->
+<section id="lifecycle">
+  <div class="container">
+    <h2>4 · Connection lifecycle</h2>
+    <p class="lede">
+      Every MCP connection follows the same four-step lifecycle: <b>initialize</b> the connection,
+      acknowledge with the <b>initialized</b> notification, <b>list</b> the server's capabilities,
+      and then <b>invoke</b> tools as needed. The lifecycle is identical for stdio and Streamable
+      HTTP — only the framing differs.
+    </p>
+
+    <div class="diagram-card">
+      <div class="svg-wrap">
+<svg viewBox="0 0 900 740" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="MCP connection lifecycle sequence diagram">
+  <defs>
+    <marker id="seq-arr"   viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#9ec5ff"/></marker>
+    <marker id="seq-arr-g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#34d399"/></marker>
+    <marker id="seq-arr-y" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#fbbf24"/></marker>
+  </defs>
+
+  <!-- Lifelines -->
+  <rect x="120" y="20" width="170" height="40" rx="10" fill="#0a2540" stroke="#3a8aff"/>
+  <text x="205" y="45" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">Client</text>
+
+  <rect x="610" y="20" width="170" height="40" rx="10" fill="#03241f" stroke="#34d399"/>
+  <text x="695" y="45" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">Server</text>
+
+  <line x1="205" y1="60" x2="205" y2="720" stroke="#3a4a72" stroke-dasharray="3 4"/>
+  <line x1="695" y1="60" x2="695" y2="720" stroke="#3a4a72" stroke-dasharray="3 4"/>
+
+  <!-- PHASE 1 -->
+  <rect x="20" y="90" width="100" height="22" rx="11" fill="#19243d" stroke="#3a4a72"/>
+  <text x="70" y="105" text-anchor="middle" fill="#9fc2ff" font-size="11">PHASE 1</text>
+
+  <!-- Message 1: initialize request -->
+  <text x="450" y="148" text-anchor="middle" fill="#9ec5ff" font-size="12" font-weight="600">initialize  (request id:1)</text>
+  <path d="M210,158 L690,158" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#seq-arr)"/>
+  <text x="450" y="178" text-anchor="middle" fill="#cfe1ff" font-size="10.5">params: protocolVersion, capabilities, clientInfo</text>
+
+  <!-- Message 2: initialize response -->
+  <text x="450" y="228" text-anchor="middle" fill="#34d399" font-size="12" font-weight="600">initialize response  (id:1)</text>
+  <path d="M690,238 L210,238" stroke="#34d399" stroke-width="2" fill="none" marker-end="url(#seq-arr-g)"/>
+  <text x="450" y="258" text-anchor="middle" fill="#a7f3d0" font-size="10.5">result: protocolVersion, capabilities, serverInfo</text>
+
+  <!-- Message 3: initialized notification -->
+  <text x="450" y="305" text-anchor="middle" fill="#fbbf24" font-size="12" font-weight="600">notifications/initialized  (notification, no id)</text>
+  <path d="M210,315 L690,315" stroke="#fbbf24" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#seq-arr-y)" class="flow-line"/>
+
+  <!-- PHASE 2 -->
+  <rect x="20" y="345" width="100" height="22" rx="11" fill="#19243d" stroke="#3a4a72"/>
+  <text x="70" y="360" text-anchor="middle" fill="#9fc2ff" font-size="11">PHASE 2</text>
+
+  <!-- Message 4: tools/list request -->
+  <text x="450" y="395" text-anchor="middle" fill="#9ec5ff" font-size="12" font-weight="600">tools/list  (request id:2)</text>
+  <path d="M210,405 L690,405" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#seq-arr)"/>
+  <text x="450" y="425" text-anchor="middle" fill="#cfe1ff" font-size="10.5">optional params: cursor (pagination)</text>
+
+  <!-- Message 5: tools/list response -->
+  <text x="450" y="465" text-anchor="middle" fill="#34d399" font-size="12" font-weight="600">tools/list response  (id:2)</text>
+  <path d="M690,475 L210,475" stroke="#34d399" stroke-width="2" fill="none" marker-end="url(#seq-arr-g)"/>
+  <text x="450" y="495" text-anchor="middle" fill="#a7f3d0" font-size="10.5">result: tools[] (name, description, inputSchema)</text>
+
+  <!-- PHASE 3 -->
+  <rect x="20" y="525" width="100" height="22" rx="11" fill="#19243d" stroke="#3a4a72"/>
+  <text x="70" y="540" text-anchor="middle" fill="#9fc2ff" font-size="11">PHASE 3</text>
+
+  <!-- Message 6: tools/call request -->
+  <text x="450" y="575" text-anchor="middle" fill="#9ec5ff" font-size="12" font-weight="600">tools/call  (request id:3)</text>
+  <path d="M210,585 L690,585" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#seq-arr)"/>
+  <text x="450" y="605" text-anchor="middle" fill="#cfe1ff" font-size="10.5">params: name="get_weather", arguments:{ location:"NYC" }</text>
+
+  <!-- Message 7: tools/call response -->
+  <text x="450" y="645" text-anchor="middle" fill="#34d399" font-size="12" font-weight="600">tools/call response  (id:3)</text>
+  <path d="M690,655 L210,655" stroke="#34d399" stroke-width="2" fill="none" marker-end="url(#seq-arr-g)"/>
+  <text x="450" y="675" text-anchor="middle" fill="#a7f3d0" font-size="10.5">result: content[] = [{ type:"text", text:"72°F, partly cloudy" }]</text>
+
+  <!-- Message 8: optional progress notification during a long tool call -->
+  <text x="450" y="710" text-anchor="middle" fill="#fbbf24" font-size="11">(optional) notifications/progress  during long tool calls</text>
+  <path d="M690,720 L210,720" stroke="#fbbf24" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#seq-arr-y)" class="flow-line"/>
+</svg>
+      </div>
+      <div class="caption">Figure 4 · The MCP lifecycle as a sequence diagram. Blue: client requests. Green: server responses. Amber dashed: notifications (no <code>id</code>, no response). The diagram shows one tool call; in practice phase 3 repeats for every tool the LLM invokes.</div>
+
+      <ol class="legend-list">
+        <li><span class="num">1</span><div><b>Phase 1 · <i>Initialization</i></b><p>The client sends <code>initialize</code> with its <code>protocolVersion</code>, supported <code>capabilities</code>, and <code>clientInfo</code>. The server replies with its own <code>protocolVersion</code>, <code>capabilities</code>, and <code>serverInfo</code>. The client then sends a <code>notifications/initialized</code> notification to confirm the connection is ready.</p></div></li>
+        <li><span class="num">2</span><div><b>Phase 2 · Discovery (within the spec's <i>Operation</i> phase)</b><p>The client calls <code>tools/list</code> (and, optionally, <code>prompts/list</code> / <code>resources/list</code>) to discover what the server exposes. Each tool comes with a <code>name</code>, a human-readable <code>description</code>, and a JSON Schema <code>inputSchema</code> that defines its arguments.</p></div></li>
+        <li><span class="num">3</span><div><b>Phase 3 · Invocation (within the spec's <i>Operation</i> phase)</b><p>When the LLM decides to call a tool, the client sends <code>tools/call</code> with the tool's <code>name</code> and <code>arguments</code>. The server returns a <code>content</code> array (typically text blocks, but image, audio, and embedded resources are also defined). For long-running calls, the server MAY emit <code>notifications/progress</code>.</p></div></li>
+        <li><span class="num">4</span><div><b>Notifications</b><p>Throughout the connection, the server can push <code>notifications/tools/list_changed</code> (when the available tool list changes), <code>notifications/resources/.../updated</code>, and <code>notifications/logging/message</code>. Notifications have no <code>id</code> and never receive a response.</p></div></li>
+        <li><span class="num">5</span><div><b>The spec's three formal phases</b><p>The MCP specification names three lifecycle phases: <i>Initialization</i>, <i>Operation</i>, and <i>Shutdown</i>. Phase 1 above maps to <i>Initialization</i>; phases 2 and 3 are both within <i>Operation</i> and are split here for clarity. <i>Shutdown</i> is transport-specific and is not shown.</p></div></li>
+      </ol>
+      <p class="snip-src">Source: <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle">modelcontextprotocol.io · Specification 2025-11-25 · Lifecycle</a></p>
+    </div>
+
+    <h3>Wire example — the four messages</h3>
+    <p>The following four JSON-RPC envelopes are taken from the spec, showing one full turn of the lifecycle.</p>
+
+    <h4>1 · Client → Server: <code>initialize</code></h4>
+<pre><code>{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-11-25",
+    "capabilities": {
+      "roots": { "listChanged": true },
+      "sampling": {},
+      "elicitation": { "form": {}, "url": {} }
+    },
+    "clientInfo": {
+      "name": "ExampleClient",
+      "title": "Example Client Display Name",
+      "version": "1.0.0"
+    }
+  }
+}</code></pre>
+    <p class="snip-src">Source: <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle">modelcontextprotocol.io · Specification 2025-11-25 · Lifecycle</a></p>
+
+    <h4>2 · Server → Client: <code>initialize</code> response</h4>
+<pre><code>{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-11-25",
+    "capabilities": {
+      "logging": {},
+      "prompts":   { "listChanged": true },
+      "resources": { "subscribe": true, "listChanged": true },
+      "tools":     { "listChanged": true }
+    },
+    "serverInfo": {
+      "name": "ExampleServer",
+      "title": "Example Server Display Name",
+      "version": "1.0.0"
+    },
+    "instructions": "Optional instructions for the client"
+  }
+}</code></pre>
+    <p class="snip-src">Source: <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle">modelcontextprotocol.io · Specification 2025-11-25 · Lifecycle</a></p>
+
+    <h4>3 · Client → Server: <code>tools/list</code> response (shape)</h4>
+<pre><code>{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "tools": [
+      {
+        "name": "get_weather",
+        "title": "Weather Information Provider",
+        "description": "Get current weather information for a location",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "City name or zip code"
+            }
+          },
+          "required": ["location"]
+        }
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}</code></pre>
+    <p class="snip-src">Source: <a href="https://modelcontextprotocol.io/specification/2025-11-25/server/tools">modelcontextprotocol.io · Specification 2025-11-25 · Server / Tools</a></p>
+
+    <h4>4 · Client → Server: <code>tools/call</code> + response</h4>
+<pre><code>// Request
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": {
+    "name": "get_weather",
+    "arguments": { "location": "New York" }
+  }
+}
+
+// Response
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Current weather in New York:\nTemperature: 72°F\nConditions: Partly cloudy"
+      }
+    ],
+    "isError": false
+  }
+}</code></pre>
+    <p class="snip-src">Source: <a href="https://modelcontextprotocol.io/specification/2025-11-25/server/tools">modelcontextprotocol.io · Specification 2025-11-25 · Server / Tools</a></p>
+  </div>
+</section>
+
+<!-- ============================================================
+     SECTION 5 — DESKTOP APPS
+     ============================================================ -->
+<section id="desktop">
+  <div class="container">
+    <h2>5 · Pattern A — Desktop AI applications</h2>
+    <p class="lede">
+      A desktop AI app (Claude Code, VS Code, Cursor, and several others) ships an MCP client built
+      into the application process. The app reads a configuration file that lists MCP servers; on
+      startup, it spawns each stdio server as a child process and opens HTTP connections to each
+      remote server. Tools from all servers are presented to the LLM as a single combined toolset.
+    </p>
+
+    <div class="diagram-card">
+      <div class="svg-wrap">
+<svg viewBox="0 0 900 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Desktop AI application with multiple MCP servers">
+  <defs>
+    <marker id="d-arr-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#9ec5ff"/></marker>
+    <marker id="d-arr-y" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#fbbf24"/></marker>
+  </defs>
+
+  <!-- User — vertical centre now aligned with the LLM/GitHub row (y=140) -->
+  <circle cx="60" cy="140" r="22" fill="#0a2540" stroke="#3a8aff"/>
+  <text x="60" y="145" text-anchor="middle" fill="#9ec5ff" font-size="11">User</text>
+
+  <!-- Desktop app boundary (taller, so the config-file → stdio gap can grow) -->
+  <rect x="120" y="60" width="320" height="400" rx="14" fill="none" stroke="#3a4a72" stroke-dasharray="3 5"/>
+  <text x="140" y="80" fill="#9aa6bd" font-size="11">Desktop app process (Claude Code · VS Code · Cursor)</text>
+
+  <!-- LLM + Client lib (height now 80, matches the GitHub MCP box on the right) -->
+  <rect x="150" y="100" width="260" height="80" rx="10" fill="url(#g-client)" />
+  <text x="280" y="130" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">LLM + MCP client library</text>
+  <text x="280" y="151" text-anchor="middle" fill="#dbeafe" font-size="11">reads mcp.json / settings on startup</text>
+
+  <!-- Config file -->
+  <rect x="150" y="210" width="260" height="70" rx="10" fill="#171f33" stroke="#3a4a72"/>
+  <text x="280" y="232" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">Config file</text>
+  <text x="280" y="251" text-anchor="middle" fill="#cfe1ff" font-size="10.5">.mcp.json · .vscode/mcp.json · ~/.cursor/mcp.json</text>
+  <text x="280" y="267" text-anchor="middle" fill="#9aa6bd" font-size="10">{ "mcpServers": { … } } or { "servers": { … } }</text>
+
+  <!-- Local stdio servers — pushed down (now y=340) to give the spawn arrows room to breathe -->
+  <rect x="150" y="340" width="125" height="110" rx="10" fill="#03241f" stroke="#34d399"/>
+  <text x="212" y="367" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">stdio server</text>
+  <text x="212" y="385" text-anchor="middle" fill="#bbf7d0" font-size="10.5">filesystem</text>
+  <text x="212" y="403" text-anchor="middle" fill="#a7f3d0" font-size="10">npx mcp-server-…</text>
+  <text x="212" y="423" text-anchor="middle" fill="#a7f3d0" font-size="10">(child process)</text>
+
+  <rect x="285" y="340" width="125" height="110" rx="10" fill="#03241f" stroke="#34d399"/>
+  <text x="347" y="367" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">stdio server</text>
+  <text x="347" y="385" text-anchor="middle" fill="#bbf7d0" font-size="10.5">postgres</text>
+  <text x="347" y="403" text-anchor="middle" fill="#a7f3d0" font-size="10">python my_server.py</text>
+  <text x="347" y="423" text-anchor="middle" fill="#a7f3d0" font-size="10">(child process)</text>
+
+  <!-- Internet / cloud (height matched to the Desktop enclosure) -->
+  <rect x="490" y="60" width="380" height="400" rx="14" fill="none" stroke="#3a4a72" stroke-dasharray="3 5"/>
+  <text x="510" y="80" fill="#9aa6bd" font-size="11">Internet — remote MCP servers (Streamable HTTP)</text>
+
+  <!-- GitHub MCP — aligned vertically with the LLM box (y=100, height 80) -->
+  <rect x="520" y="100" width="320" height="80" rx="10" fill="#03241f" stroke="#34d399"/>
+  <text x="680" y="128" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">GitHub MCP (api.githubcopilot.com/mcp/)</text>
+  <text x="680" y="148" text-anchor="middle" fill="#bbf7d0" font-size="11">type: streamable-http  ·  auth: Bearer</text>
+  <text x="680" y="166" text-anchor="middle" fill="#a7f3d0" font-size="10.5">tools: list_issues, create_issue, get_pull_request, …</text>
+
+  <!-- Linear MCP — aligned with the config-file row -->
+  <rect x="520" y="210" width="320" height="70" rx="10" fill="#03241f" stroke="#34d399"/>
+  <text x="680" y="234" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">Linear MCP · custom org MCP · …</text>
+  <text x="680" y="252" text-anchor="middle" fill="#bbf7d0" font-size="11">any HTTPS endpoint speaking MCP</text>
+  <text x="680" y="268" text-anchor="middle" fill="#a7f3d0" font-size="10.5">scoped per workspace via project config</text>
+
+  <!-- Auth server — aligned with the stdio row -->
+  <rect x="520" y="340" width="320" height="110" rx="10" fill="#0a2540" stroke="#3a8aff"/>
+  <text x="680" y="380" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">OAuth 2.1 authorization server</text>
+  <text x="680" y="402" text-anchor="middle" fill="#9ec5ff" font-size="10.5">issues access tokens (see §6)</text>
+
+  <!-- Arrow: User → LLM (now a horizontal straight line) -->
+  <path d="M84,140 L150,140" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#d-arr-b)"/>
+  <text x="115" y="130" text-anchor="middle" fill="#9aa6bd" font-size="10">prompt</text>
+
+  <!-- Arrow: LLM → GitHub MCP (horizontal straight line, both boxes share y=100-180) -->
+  <path d="M410,140 L520,140" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#d-arr-b)"/>
+  <text x="465" y="130" text-anchor="middle" fill="#9aa6bd" font-size="10">HTTPS + Bearer</text>
+
+  <!-- Arrow: LLM → Linear MCP (diagonal from the LLM bottom-right to Linear's left edge) -->
+  <path d="M410,170 L520,245" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#d-arr-b)"/>
+  <text x="475" y="200" text-anchor="middle" fill="#9aa6bd" font-size="10">HTTPS + Bearer</text>
+
+  <!-- Arrows: Config file → stdio servers (longer vertical drop, label sits between the boxes) -->
+  <path d="M212,280 L212,340" stroke="#fbbf24" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#d-arr-y)" class="flow-line"/>
+  <path d="M347,280 L347,340" stroke="#fbbf24" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#d-arr-y)" class="flow-line"/>
+  <text x="280" y="307" text-anchor="middle" fill="#fbbf24" font-size="10.5" font-weight="600">spawn · stdin/stdout</text>
+  <text x="280" y="322" text-anchor="middle" fill="#fde68a" font-size="10">one child process per entry</text>
+</svg>
+      </div>
+      <div class="caption">Figure 5 · The desktop pattern: one application process embeds the MCP client library, spawns local stdio servers as children, and opens authenticated HTTPS connections to remote MCP servers. The configuration file lists both kinds together.</div>
+
+      <ol class="legend-list">
+        <li><span class="num">1</span><div><b>Config-driven</b><p>The application loads a JSON config (location and root key vary by app; see snippets below) that lists every MCP server it should connect to. Servers are typically scoped at three levels: user-wide, workspace/project, and (in Claude Code) enterprise-managed.</p></div></li>
+        <li><span class="num">2</span><div><b>One process, many servers</b><p>Each <code>stdio</code> server is started as a child process. Each remote server is reached over HTTPS. All of them feed tools into the same client; the LLM sees a single combined toolset (with names typically prefixed by server name to avoid collisions).</p></div></li>
+        <li><span class="num">3</span><div><b>Auth lives at the transport</b><p>Remote servers are authenticated per the OAuth 2.1 flow described in §6 — the desktop app stores the access token in the OS keychain and passes it as <code>Authorization: Bearer …</code> on every request.</p></div></li>
+        <li><span class="num">4</span><div><b>Lifecycle is per-connection</b><p>The client repeats <code>initialize → tools/list → tools/call</code> independently for each server. Servers do not see each other; the client merges their tool lists before showing them to the LLM.</p></div></li>
+      </ol>
+    </div>
+
+    <h3>Configuration — Claude Code</h3>
+    <p>
+      Claude Code reads <code>.mcp.json</code> at the project root (or <code>~/.claude.json</code> for
+      user-wide servers). The <code>type</code> field accepts <code>stdio</code>, <code>http</code>,
+      or <code>streamable-http</code> (alias for <code>http</code>).
+    </p>
+<pre><code>{
+  "mcpServers": {
+    "github": {
+      "type": "streamable-http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN"
+      }
+    },
+    "my-db": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@bytebase/dbhub", "--dsn",
+               "postgresql://readonly:pass@prod.db.com:5432/analytics"],
+      "env": { "DB_TIMEOUT": "30000" }
+    }
+  }
+}</code></pre>
+    <p class="snip-src">Source: <a href="https://code.claude.com/docs/en/mcp">code.claude.com/docs/en/mcp · Connect Claude Code to tools via MCP</a></p>
+
+    <h3>Configuration — VS Code (Copilot Chat)</h3>
+    <p>
+      VS Code reads <code>.vscode/mcp.json</code> for workspace-scoped servers (or a user-profile
+      <code>mcp.json</code> for user-wide). The root key is <code>servers</code> (not
+      <code>mcpServers</code>); the <code>type</code> field accepts <code>stdio</code> or
+      <code>http</code>.
+    </p>
+<pre><code>{
+  "servers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@microsoft/mcp-server-playwright"]
+    }
+  }
+}</code></pre>
+    <p class="snip-src">Source: <a href="https://code.visualstudio.com/docs/copilot/customization/mcp-servers">code.visualstudio.com · Copilot · MCP servers</a></p>
+
+    <h3>Configuration — Cursor</h3>
+    <p>
+      Cursor reads <code>~/.cursor/mcp.json</code> (global) or <code>.cursor/mcp.json</code> (project).
+      The root key is <code>mcpServers</code>; if the <code>url</code> field is present, the
+      transport defaults to HTTP.
+    </p>
+<pre><code>{
+  "mcpServers": {
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/"
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "mcp-server-filesystem", "/path/to/project"],
+      "env": { "LOG_LEVEL": "info" }
+    }
+  }
+}</code></pre>
+    <p class="snip-src">Source: <a href="https://cursor.com/docs/mcp">cursor.com/docs/mcp</a></p>
+
+    <div class="note-box">
+      <b>Naming quirks across clients.</b> Claude Code and Cursor use <code>mcpServers</code>; VS Code uses <code>servers</code>. Claude Code's HTTP type is <code>streamable-http</code> (with <code>http</code> accepted as alias); VS Code uses <code>http</code>; Cursor infers HTTP when <code>url</code> is set. All three accept the same stdio fields (<code>command</code>, <code>args</code>, <code>env</code>).
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     SECTION 6 — SERVER-HOSTED AGENTS
+     ============================================================ -->
+<section id="hosted">
+  <div class="container">
+    <h2>6 · Pattern B — Server-hosted AI agents</h2>
+    <p class="lede">
+      In this pattern, an MCP client lives inside an agent runtime running in a container, a serverless
+      function, or a long-lived service. Local stdio servers are uncommon here because the agent
+      process may be ephemeral and may not have a writable filesystem; instead, the agent connects to
+      one or more <em>remote</em> MCP servers over Streamable HTTP. Many remote MCP servers can be
+      hosted on the same cluster as the agent, or with a third party.
+    </p>
+
+    <div class="diagram-card">
+      <div class="svg-wrap">
+<svg viewBox="0 0 900 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Server-hosted agent calling remote MCP servers">
+  <defs>
+    <marker id="h-arr-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#9ec5ff"/></marker>
+    <marker id="h-arr-g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#34d399"/></marker>
+    <marker id="h-arr-y" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#fbbf24"/></marker>
+  </defs>
+
+  <!-- End user / API caller — vertically aligned with the Ingress row (centre y=102) -->
+  <rect x="20" y="80" width="80" height="44" rx="10" fill="#0a2540" stroke="#3a8aff"/>
+  <text x="60" y="100" text-anchor="middle" fill="#fff" font-size="12">End user</text>
+  <text x="60" y="115" text-anchor="middle" fill="#9ec5ff" font-size="10">or API client</text>
+
+  <!-- Agent cluster boundary — taller -->
+  <rect x="130" y="40" width="380" height="400" rx="14" fill="none" stroke="#3a4a72" stroke-dasharray="3 5"/>
+  <text x="150" y="60" fill="#9aa6bd" font-size="11">Agent cluster (Kubernetes · serverless · VM)</text>
+
+  <!-- Ingress / load balancer -->
+  <rect x="160" y="80" width="320" height="44" rx="10" fill="#171f33" stroke="#3a4a72"/>
+  <text x="320" y="106" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">Ingress / load balancer (HTTPS)</text>
+
+  <!-- Agent replicas — taller (height 260), top y=160 aligned with first right-stack box -->
+  <rect x="160" y="160" width="100" height="260" rx="10" fill="url(#g-client)"/>
+  <text x="210" y="210" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">Agent</text>
+  <text x="210" y="228" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">replica 1</text>
+  <text x="210" y="258" text-anchor="middle" fill="#dbeafe" font-size="10">LLM</text>
+  <text x="210" y="274" text-anchor="middle" fill="#dbeafe" font-size="10">+ MCP client</text>
+
+  <rect x="270" y="160" width="100" height="260" rx="10" fill="url(#g-client)" opacity="0.85"/>
+  <text x="320" y="210" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">Agent</text>
+  <text x="320" y="228" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">replica 2</text>
+  <text x="320" y="258" text-anchor="middle" fill="#dbeafe" font-size="10">LLM</text>
+  <text x="320" y="274" text-anchor="middle" fill="#dbeafe" font-size="10">+ MCP client</text>
+
+  <rect x="380" y="160" width="100" height="260" rx="10" fill="url(#g-client)" opacity="0.7"/>
+  <text x="430" y="210" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">Agent</text>
+  <text x="430" y="228" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">replica N</text>
+  <text x="430" y="258" text-anchor="middle" fill="#dbeafe" font-size="10">LLM</text>
+  <text x="430" y="274" text-anchor="middle" fill="#dbeafe" font-size="10">+ MCP client</text>
+
+  <!-- Internet boundary — narrower, sits flush with the right edge -->
+  <rect x="610" y="40" width="270" height="400" rx="14" fill="none" stroke="#3a4a72" stroke-dasharray="3 5"/>
+  <text x="630" y="60" fill="#9aa6bd" font-size="11">Internet / private network</text>
+
+  <!-- Internal MCP — narrower (width 240), top y=160 aligned with replicas -->
+  <rect x="630" y="160" width="240" height="80" rx="10" fill="#03241f" stroke="#34d399"/>
+  <text x="750" y="186" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">Internal MCP (same cluster)</text>
+  <text x="750" y="206" text-anchor="middle" fill="#bbf7d0" font-size="10.5">company KB · CRM · orders DB</text>
+  <text x="750" y="224" text-anchor="middle" fill="#a7f3d0" font-size="10">private mesh · mTLS or OAuth</text>
+
+  <!-- 3rd-party MCP -->
+  <rect x="630" y="260" width="240" height="80" rx="10" fill="#03241f" stroke="#34d399"/>
+  <text x="750" y="286" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">3rd-party MCP server</text>
+  <text x="750" y="306" text-anchor="middle" fill="#bbf7d0" font-size="10.5">GitHub · Stripe · Linear · …</text>
+  <text x="750" y="324" text-anchor="middle" fill="#a7f3d0" font-size="10">HTTPS + OAuth 2.1 Bearer</text>
+
+  <!-- Authorization server -->
+  <rect x="630" y="360" width="240" height="80" rx="10" fill="#0a2540" stroke="#3a8aff"/>
+  <text x="750" y="388" text-anchor="middle" fill="#fff" font-size="12" font-weight="700">Authorization server</text>
+  <text x="750" y="408" text-anchor="middle" fill="#9ec5ff" font-size="10.5">issues per-resource tokens</text>
+  <text x="750" y="424" text-anchor="middle" fill="#9ec5ff" font-size="10">(RFC 8707)</text>
+
+  <!-- Arrow: End user → Ingress (horizontal at y=102) -->
+  <path d="M100,102 L160,102" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#h-arr-b)"/>
+  <text x="130" y="93" text-anchor="middle" fill="#9aa6bd" font-size="10">HTTPS</text>
+
+  <!-- Arrow: Replicas → Internal MCP (horizontal at Internal MCP centre y=200) -->
+  <path d="M480,200 L630,200" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#h-arr-b)"/>
+  <text x="555" y="191" text-anchor="middle" fill="#9aa6bd" font-size="11">MCP over HTTP (private mesh)</text>
+
+  <!-- Arrow pair: Replicas ↔ 3rd-party MCP (both arrows in the same gap) -->
+  <path d="M480,290 L630,290" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#h-arr-b)"/>
+  <text x="555" y="281" text-anchor="middle" fill="#9aa6bd" font-size="11">POST /mcp · Bearer token</text>
+  <path d="M630,310 L480,310" stroke="#34d399" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#h-arr-g)" class="flow-line"/>
+  <text x="555" y="325" text-anchor="middle" fill="#34d399" font-size="11">JSON-RPC response · SSE</text>
+
+  <!-- Arrow: Replicas → Authorization server (token exchange) -->
+  <path d="M480,400 L630,400" stroke="#fbbf24" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#h-arr-y)" class="flow-line"/>
+  <text x="555" y="391" text-anchor="middle" fill="#fbbf24" font-size="11">OAuth 2.1 token exchange</text>
+</svg>
+      </div>
+      <div class="caption">Figure 6 · A horizontally-scaled agent service consuming MCP servers. Each replica embeds an MCP client and opens its own connections to internal and third-party servers. <code>MCP-Session-Id</code> lets server-side load balancers pin a logical session to one backend.</div>
+
+      <ol class="legend-list">
+        <li><span class="num">1</span><div><b>Stateless replicas</b><p>Agent replicas are typically stateless at the process level. Each replica that handles a request opens (or reuses) its own MCP connections. Session affinity is achieved at the MCP layer via <code>MCP-Session-Id</code> rather than at the load balancer.</p></div></li>
+        <li><span class="num">2</span><div><b>Streamable HTTP everywhere</b><p>stdio is rarely usable because the agent process may not have permission to spawn subprocesses, or may be cold-started per request. Streamable HTTP is the default; even MCP servers that originally shipped as stdio are commonly wrapped in a small HTTP front so a hosted agent can reach them.</p></div></li>
+        <li><span class="num">3</span><div><b>Two trust domains</b><p>"Internal" MCP servers (inside the same VPC or cluster) often authenticate with mTLS or short-lived JWTs. "External" MCP servers (third-party vendors) use OAuth 2.1 with per-resource access tokens. The agent runtime is responsible for fetching and refreshing both.</p></div></li>
+        <li><span class="num">4</span><div><b>Tool selection happens in the LLM</b><p>Just like the desktop pattern, all tools from all MCP servers are flattened into the model's tool list at each turn. The choice of which tool to call is the LLM's; the MCP client just routes calls to the right server.</p></div></li>
+      </ol>
+      <p class="snip-src">Source: <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management">modelcontextprotocol.io · Specification 2025-11-25 · Transports · Session management</a> (<code>MCP-Session-Id</code> semantics) · <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization">Authorization</a> (OAuth 2.1 token model). The architectural commentary about stateless replicas, ephemeral runtimes, and trust domains is not in the spec; it describes how MCP is commonly deployed in containerised agent runtimes.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     SECTION 7 — AUTHORIZATION
+     ============================================================ -->
+<section id="auth">
+  <div class="container">
+    <h2>7 · Authorization (Streamable HTTP)</h2>
+    <p class="lede">
+      For remote (HTTP) MCP servers, the spec mandates <b>OAuth 2.1</b> with three RFC profiles:
+      <b>PKCE</b> (mandatory on all clients), <b>Resource Indicators</b> (RFC 8707; tokens are
+      bound to a specific MCP server URI), and <b>Protected Resource Metadata</b> (RFC 9728;
+      clients discover the authorization server from the resource server). Dynamic Client
+      Registration (RFC 7591) is supported for backwards compatibility but Client ID Metadata
+      Documents are now the preferred path.
+    </p>
+
+    <div class="diagram-card">
+      <div class="svg-wrap">
+<svg viewBox="0 0 900 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="OAuth 2.1 authorization flow for MCP">
+  <defs>
+    <marker id="a-arr"   viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#9ec5ff"/></marker>
+    <marker id="a-arr-y" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#fbbf24"/></marker>
+    <marker id="a-arr-g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#34d399"/></marker>
+    <marker id="a-arr-r" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#fb7185"/></marker>
+  </defs>
+
+  <!-- Three lifelines -->
+  <rect x="60"  y="20" width="180" height="40" rx="10" fill="#0a2540" stroke="#3a8aff"/>
+  <text x="150" y="45" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">MCP Client</text>
+  <rect x="360" y="20" width="180" height="40" rx="10" fill="#2b1e3f" stroke="#a78bfa"/>
+  <text x="450" y="45" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">Authorization Server</text>
+  <rect x="660" y="20" width="180" height="40" rx="10" fill="#03241f" stroke="#34d399"/>
+  <text x="750" y="45" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">MCP Server</text>
+
+  <line x1="150" y1="60" x2="150" y2="580" stroke="#3a4a72" stroke-dasharray="3 4"/>
+  <line x1="450" y1="60" x2="450" y2="580" stroke="#3a4a72" stroke-dasharray="3 4"/>
+  <line x1="750" y1="60" x2="750" y2="580" stroke="#3a4a72" stroke-dasharray="3 4"/>
+
+  <!-- Phase A — DISCOVERY -->
+  <rect x="20" y="80" width="120" height="22" rx="11" fill="#19243d" stroke="#3a4a72"/>
+  <text x="80" y="95" text-anchor="middle" fill="#9fc2ff" font-size="11">A · DISCOVERY</text>
+
+  <!-- 1: client → server (unauthenticated probe) -->
+  <text x="450" y="118" text-anchor="middle" fill="#9ec5ff" font-size="11" font-weight="600">1 · GET /mcp  (unauthenticated probe)</text>
+  <path d="M155,128 L745,128" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#a-arr)"/>
+
+  <!-- 2: server → client (401 + header) — split across two lines -->
+  <text x="450" y="158" text-anchor="middle" fill="#fb7185" font-size="11" font-weight="600">2 · 401 Unauthorized</text>
+  <text x="450" y="174" text-anchor="middle" fill="#fb7185" font-size="10.5">WWW-Authenticate: Bearer  resource_metadata="…/.well-known/oauth-protected-resource"</text>
+  <path d="M745,184 L155,184" stroke="#fb7185" stroke-width="2" fill="none" marker-end="url(#a-arr-r)"/>
+
+  <!-- 3: client → server (fetch resource metadata) -->
+  <text x="450" y="214" text-anchor="middle" fill="#9ec5ff" font-size="11" font-weight="600">3 · GET /.well-known/oauth-protected-resource  (RFC 9728)</text>
+  <path d="M155,224 L745,224" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#a-arr)"/>
+
+  <!-- 4: server → client (metadata response) -->
+  <text x="450" y="254" text-anchor="middle" fill="#34d399" font-size="11" font-weight="600">4 · 200 OK</text>
+  <text x="450" y="270" text-anchor="middle" fill="#34d399" font-size="10.5">{ authorization_servers: […], resource: "https://server.example/mcp" }</text>
+  <path d="M745,280 L155,280" stroke="#34d399" stroke-width="2" fill="none" marker-end="url(#a-arr-g)"/>
+
+  <!-- Phase B — AUTHORIZATION -->
+  <rect x="20" y="305" width="180" height="22" rx="11" fill="#2b1e3f" stroke="#a78bfa"/>
+  <text x="110" y="320" text-anchor="middle" fill="#c4b5fd" font-size="11">B · AUTHORIZATION (PKCE)</text>
+
+  <!-- 5: client → AS (authorize) -->
+  <text x="300" y="345" text-anchor="middle" fill="#9ec5ff" font-size="11" font-weight="600">5 · authorize</text>
+  <text x="300" y="361" text-anchor="middle" fill="#9ec5ff" font-size="10.5">PKCE code_challenge  +  resource=…  +  scopes</text>
+  <path d="M155,371 L445,371" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#a-arr)"/>
+
+  <!-- 6: AS → client (authorization code) -->
+  <text x="300" y="395" text-anchor="middle" fill="#34d399" font-size="11" font-weight="600">6 · authorization code  (after user consent)</text>
+  <path d="M445,405 L155,405" stroke="#34d399" stroke-width="2" fill="none" marker-end="url(#a-arr-g)"/>
+
+  <!-- 7: client → AS (token exchange) -->
+  <text x="300" y="430" text-anchor="middle" fill="#9ec5ff" font-size="11" font-weight="600">7 · token exchange</text>
+  <text x="300" y="446" text-anchor="middle" fill="#9ec5ff" font-size="10.5">code  +  PKCE code_verifier  +  resource</text>
+  <path d="M155,456 L445,456" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#a-arr)"/>
+
+  <!-- 8: AS → client (access token) -->
+  <text x="300" y="480" text-anchor="middle" fill="#34d399" font-size="11" font-weight="600">8 · access_token  (audience = MCP server URI)</text>
+  <path d="M445,490 L155,490" stroke="#34d399" stroke-width="2" fill="none" marker-end="url(#a-arr-g)"/>
+
+  <!-- Phase C — AUTHENTICATED MCP -->
+  <rect x="20" y="515" width="200" height="22" rx="11" fill="#03241f" stroke="#34d399"/>
+  <text x="120" y="530" text-anchor="middle" fill="#bbf7d0" font-size="11">C · AUTHENTICATED MCP</text>
+
+  <!-- 9: client → server (initialize with Bearer) -->
+  <text x="450" y="555" text-anchor="middle" fill="#9ec5ff" font-size="11" font-weight="600">9 · POST /mcp  ·  Authorization: Bearer &lt;access_token&gt;  ·  initialize</text>
+  <path d="M155,565 L745,565" stroke="#9ec5ff" stroke-width="2" fill="none" marker-end="url(#a-arr)"/>
+
+  <!-- 10: server → client (initialize response) -->
+  <text x="450" y="590" text-anchor="middle" fill="#34d399" font-size="11" font-weight="600">10 · 200 OK · initialize response  (server validates token audience)</text>
+</svg>
+      </div>
+      <div class="caption">Figure 7 · OAuth 2.1 + RFC 9728 + RFC 8707 flow. The client probes the MCP server unauthenticated, follows the discovery chain to the authorization server, completes a PKCE-protected authorization code exchange with the target resource indicator, and then makes its authenticated MCP request.</div>
+
+      <ol class="legend-list">
+        <li><span class="num">1</span><div><b>Discovery (steps 1–4)</b><p>The client makes an unauthenticated request, receives a <code>401</code> with a <code>WWW-Authenticate</code> header pointing at the resource metadata document, and fetches that document to learn which authorization server(s) protect this resource.</p></div></li>
+        <li><span class="num">2</span><div><b>Authorization code + PKCE (steps 5–6)</b><p>The client redirects the user to the authorization server with a PKCE code challenge and the <code>resource</code> parameter (RFC 8707) naming the MCP server's URI. After user consent, the authorization server returns an authorization code.</p></div></li>
+        <li><span class="num">3</span><div><b>Token exchange (steps 7–8)</b><p>The client exchanges the code (plus the PKCE verifier) for an access token. The token's audience is bound to the specific MCP server URI; it cannot be replayed against another resource server.</p></div></li>
+        <li><span class="num">4</span><div><b>Authenticated MCP (steps 9–10 and onward)</b><p>The client includes <code>Authorization: Bearer …</code> on every HTTP request to the MCP server. The server validates audience, signature, and scopes before processing the JSON-RPC envelope. On scope failure, the server returns <code>403</code> with <code>WWW-Authenticate: Bearer error="insufficient_scope", scope="…"</code> and the client initiates a step-up authorization.</p></div></li>
+      </ol>
+    </div>
+
+    <p class="snip-src">Source: <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization">modelcontextprotocol.io · Specification 2025-11-25 · Authorization</a></p>
+  </div>
+</section>
+
+<!-- ============================================================
+     SECTION 8 — AUTHORING A SERVER
+     ============================================================ -->
+<section id="authoring">
+  <div class="container">
+    <h2>8 · Authoring an MCP server</h2>
+    <p class="lede">
+      The official MCP SDKs are maintained at <code>modelcontextprotocol/python-sdk</code> and
+      <code>modelcontextprotocol/typescript-sdk</code>. Both ship a high-level API
+      (<code>FastMCP</code> in Python, <code>McpServer</code> in TypeScript) that hides the JSON-RPC
+      plumbing, plus a lower-level API for fine-grained control. The same server code can be served
+      over stdio or Streamable HTTP by choosing a different transport at startup.
+    </p>
+
+    <h3>Python — FastMCP</h3>
+    <p>
+      Install with <code>pip install mcp</code>. A minimal server exposes one tool and runs over
+      stdio:
+    </p>
+<pre><code>from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("greeting-server")
+
+@mcp.tool()
+def greet(name: str) -> str:
+    """Greet someone by name"""
+    return f"Hello, {name}!"
+
+if __name__ == "__main__":
+    mcp.run()              # stdio is the default transport</code></pre>
+    <p class="snip-src">Source: <a href="https://github.com/modelcontextprotocol/python-sdk">github.com/modelcontextprotocol/python-sdk · README quickstart</a></p>
+
+    <p>To serve the same code over Streamable HTTP, change one line:</p>
+<pre><code>if __name__ == "__main__":
+    mcp.run(transport="streamable-http", host="127.0.0.1", port=8000)
+    # server is now reachable at http://localhost:8000/mcp</code></pre>
+    <p class="snip-src">Source: <a href="https://gofastmcp.com/deployment/running-server">gofastmcp.com · Running your server</a></p>
+
+    <h3>TypeScript — <code>McpServer</code></h3>
+    <p>
+      Install with <code>npm install @modelcontextprotocol/sdk zod</code>. A minimal stdio server:
+    </p>
+<pre><code>import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const server = new McpServer({ name: "greeting-server", version: "1.0.0" });
+
+server.registerTool(
+  "greet",
+  {
+    description: "Greet someone by name",
+    inputSchema: z.object({ name: z.string() }),
+  },
+  async ({ name }) =&gt; ({
+    content: [{ type: "text", text: `Hello, ${name}!` }],
+  }),
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);</code></pre>
+    <p class="snip-src">Source: <a href="https://github.com/modelcontextprotocol/typescript-sdk">github.com/modelcontextprotocol/typescript-sdk · README quickstart</a></p>
+
+    <p>The Streamable HTTP variant swaps the transport import and provides network options:</p>
+<pre><code>import { StreamableHTTPServerTransport }
+  from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+const transport = new StreamableHTTPServerTransport({ /* options */ });
+await server.connect(transport);
+// Mount the transport's HTTP handler on your web framework (Express, Hono, …).</code></pre>
+    <p class="snip-src">Source: <a href="https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/server.md">github.com/modelcontextprotocol/typescript-sdk · docs/server.md · Streamable HTTP transport</a></p>
+
+    <div class="note-box">
+      <b>The tool function signature is the schema.</b> In both SDKs, the tool's parameter types are also its JSON Schema <code>inputSchema</code>. Python derives the schema from type hints and docstring; TypeScript derives it from the Zod schema. The result is what the model sees in the <code>tools/list</code> response.
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     SECTION 9 — SIDE-BY-SIDE
+     ============================================================ -->
+<section id="compare">
+  <div class="container">
+    <h2>9 · Side-by-side · stdio vs Streamable HTTP</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th><span class="dot" style="background:var(--transport)"></span> stdio</th>
+            <th><span class="dot" style="background:var(--transport)"></span> Streamable HTTP</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td class="row-hd">Process model</td>
+              <td>Server is a child process of the client</td>
+              <td>Server is an independent network service</td></tr>
+          <tr><td class="row-hd">Framing</td>
+              <td>Newline-delimited JSON-RPC on stdin/stdout</td>
+              <td>HTTP POST body (one JSON-RPC message); response is either JSON or SSE</td></tr>
+          <tr><td class="row-hd">Server-initiated messages</td>
+              <td>Server writes to stdout at any time</td>
+              <td>Server uses SSE — either as a response to a POST or via a long-lived GET</td></tr>
+          <tr><td class="row-hd">Authentication</td>
+              <td>Inherits the OS user of the client process</td>
+              <td>OAuth 2.1 with PKCE; tokens bound to resource URI (RFC 8707)</td></tr>
+          <tr><td class="row-hd">Concurrency</td>
+              <td>One client per server process</td>
+              <td>One server may serve many concurrent clients</td></tr>
+          <tr><td class="row-hd">Session affinity</td>
+              <td>Implicit (one process)</td>
+              <td>Explicit via <code>MCP-Session-Id</code> header</td></tr>
+          <tr><td class="row-hd">Logs</td>
+              <td>stderr</td>
+              <td>Server's own logging stack</td></tr>
+          <tr><td class="row-hd">Typical use</td>
+              <td>Local tools on a developer machine; CLI integrations</td>
+              <td>Remote / multi-tenant tools; hosted agent runtimes; vendor APIs</td></tr>
+          <tr><td class="row-hd">Spec section</td>
+              <td colspan="2"><a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/transports">modelcontextprotocol.io · Specification 2025-11-25 · Transports</a></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- ============================================================
+     SECTION 10 — SUMMARY OBSERVATIONS
+     ============================================================ -->
+<section id="takeaways">
+  <div class="container">
+    <h2>10 · Summary observations</h2>
+    <p class="lede">Six factual observations drawn from the spec and current SDK behaviour.</p>
+    <div class="takeaways">
+      <div class="ta">
+        <span class="tag">PROTOCOL</span>
+        <h4>1 · MCP is a thin JSON-RPC 2.0 protocol</h4>
+        <p>The wire format is plain JSON-RPC. There are three message types (request, response, notification), four core methods for tools (<code>initialize</code>, <code>notifications/initialized</code>, <code>tools/list</code>, <code>tools/call</code>), and a small set of capability flags negotiated in the handshake.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">TRANSPORTS</span>
+        <h4>2 · Two transports are standardised; the legacy SSE one is deprecated</h4>
+        <p>The current spec (revision 2025-11-25) defines <code>stdio</code> and <code>Streamable HTTP</code>. The earlier two-endpoint HTTP+SSE transport remains documented for backwards compatibility only.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">DESKTOP</span>
+        <h4>3 · Desktop apps merge tools from many servers</h4>
+        <p>Claude Code, VS Code, and Cursor each load a JSON config file (<code>.mcp.json</code> / <code>.vscode/mcp.json</code> / <code>.cursor/mcp.json</code>) listing stdio and remote servers. The client merges their tools into one combined list for the LLM.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">HOSTED</span>
+        <h4>4 · Hosted agents use HTTP almost exclusively</h4>
+        <p>Server-hosted agent runtimes prefer Streamable HTTP because container/serverless environments often cannot spawn subprocesses, share filesystem state, or persist between invocations. Session affinity for multi-call interactions is achieved via the <code>MCP-Session-Id</code> header rather than load-balancer stickiness.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">AUTH</span>
+        <h4>5 · The HTTP transport mandates OAuth 2.1 + PKCE + resource indicators</h4>
+        <p>Discovery uses Protected Resource Metadata (RFC 9728); authorization uses OAuth 2.1 with PKCE; tokens are scoped to a specific MCP server URI via Resource Indicators (RFC 8707). Dynamic Client Registration (RFC 7591) is supported for backwards compatibility; Client ID Metadata Documents are the preferred registration path going forward.</p>
+      </div>
+      <div class="ta">
+        <span class="tag">SDKS</span>
+        <h4>6 · The official SDKs hide the JSON-RPC plumbing</h4>
+        <p>FastMCP in Python and <code>McpServer</code> in TypeScript reduce a tool-exposing server to a class, a decorator/<code>registerTool</code> call, and a <code>run()</code>/<code>connect()</code> entry point. Switching between stdio and Streamable HTTP is a one-line change in both SDKs.</p>
+      </div>
+    </div>
+    <p class="snip-src">Sources for the six observations above, in order: <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic">Base Protocol</a> · <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/transports">Transports</a> · client docs cited in §5 (<a href="https://code.claude.com/docs/en/mcp">Claude Code</a>, <a href="https://code.visualstudio.com/docs/copilot/customization/mcp-servers">VS Code</a>, <a href="https://cursor.com/docs/mcp">Cursor</a>) · <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management">Session Management</a> · <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization">Authorization</a> · SDK docs cited in §8 (<a href="https://github.com/modelcontextprotocol/python-sdk">Python</a>, <a href="https://github.com/modelcontextprotocol/typescript-sdk">TypeScript</a>).</p>
+  </div>
+</section>
+
+<!-- ============================================================
+     SECTION 11 — GLOSSARY
+     ============================================================ -->
+<section id="glossary">
+  <div class="container">
+    <h2>11 · Mini-glossary</h2>
+    <p class="lede">Terms used throughout this paper.</p>
+    <div class="gloss">
+      <div><b>MCP</b> — Model Context Protocol; an open JSON-RPC 2.0 protocol for connecting LLM applications to tool servers. Spec at <a href="https://modelcontextprotocol.io">modelcontextprotocol.io</a>.</div>
+      <div><b>Client / Host</b> — the application that hosts the LLM and the MCP client library (Claude Code, VS Code, a hosted agent runtime).</div>
+      <div><b>Server</b> — a process that exposes tools, resources, and/or prompts to MCP clients. Can be a local subprocess (stdio) or a network service (HTTP).</div>
+      <div><b>Tool</b> — a callable exposed by a server, described by <code>name</code>, <code>description</code>, and a JSON Schema <code>inputSchema</code>. Invoked via <code>tools/call</code>.</div>
+      <div><b>Resource</b> — a piece of read-only content (file, document, query result) the server can supply. Listed via <code>resources/list</code> and fetched via <code>resources/read</code>.</div>
+      <div><b>Prompt</b> — a parameterised template the server exposes that the client can render and present to the user.</div>
+      <div><b>stdio transport</b> — server runs as a child process; messages flow over newline-delimited JSON on stdin/stdout.</div>
+      <div><b>Streamable HTTP transport</b> — server exposes one HTTP endpoint; clients POST requests; responses are JSON or SSE; a separate GET opens a server-to-client SSE stream.</div>
+      <div><b>MCP-Session-Id</b> — header issued in the <code>initialize</code> response that the client echoes on every subsequent request to keep them on the same logical session.</div>
+      <div><b>FastMCP</b> — high-level Python SDK API; decorator-based server authoring.</div>
+      <div><b>McpServer</b> — high-level TypeScript SDK API; <code>registerTool</code>-based server authoring with Zod schemas.</div>
+      <div><b>RFC 8707 (Resource Indicators)</b> — OAuth 2.0 extension that binds an access token to a specific resource server, preventing token replay.</div>
+      <div><b>RFC 9728 (Protected Resource Metadata)</b> — discovery document at <code>/.well-known/oauth-protected-resource</code> that tells clients which authorization server protects a resource.</div>
+      <div><b>PKCE</b> — Proof Key for Code Exchange (RFC 7636); mandatory in OAuth 2.1 to prevent authorization code interception.</div>
+    </div>
+    <p class="snip-src">All MCP-specific term definitions above are taken from the <a href="https://modelcontextprotocol.io/specification/2025-11-25">MCP Specification 2025-11-25</a> (Base Protocol, Transports, Lifecycle, Authorization, and Server / Tools sub-pages). RFC numbers refer to the published IETF documents.</p>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    Compiled from the official MCP specification at <a href="https://modelcontextprotocol.io">modelcontextprotocol.io</a> (revision 2025-11-25), the Python and TypeScript SDK repositories, and the official MCP configuration docs for Claude Code, VS Code, and Cursor.
+    <p class="copyright">© 2026 <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>. Licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
+  </div>
+</footer>
+
+<script>
+  document.querySelectorAll('a.pill').forEach(a => {
+    a.addEventListener('click', e => {
+      const id = a.getAttribute('href');
+      if (id && id.startsWith('#')) {
+        const el = document.querySelector(id);
+        if (el) {
+          e.preventDefault();
+          el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          history.replaceState(null, '', id);
+        }
+      }
+    });
+  });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **3 new whitepapers** under `/whitepapers/` — `agent-tool-wiring` (how 10 frameworks declare tools and compose agents), `agent-remote-tools` (where tools can live: in-process, MCP, OpenAPI, A2A, RPC), and `mcp-explained` (protocol-level MCP reference: transports, lifecycle, OAuth 2.1)
- **1 new blog** at `/blogs/truvag3-agentic-memory` — TruvaG3's four-tier shared memory system, the research it came from, and the pipeline hooks that wire it in
- **1 new docs page** at `docs/orchestration/PIPELINE_HOOKS_GUIDE.md` — mechanism reference for the four pipeline-hook stages, the PipelineContext/Enrichments contract, and short-circuit semantics
- **Homepage Recent Reading restructured** into Blogs and Whitepapers subsections, each with 2 always-visible cards plus an expandable "Show N more" pill toggle (amber, animated reveal via `::details-content` + `interpolate-size: allow-keywords`)
- **Sitemap and listing pages** updated with the four new URLs; lastmod refreshed on `/blogs/` and `/whitepapers/` index entries

## Test plan

- [ ] Open the homepage and verify the Recent Reading section renders the new Blogs/Whitepapers subsections with the correct 2 always-visible cards each
- [ ] Click "Show 1 more blog" and "Show 6 more whitepapers" — confirm the smooth reveal animation (~510ms easeInOutCubic), the toggle text swaps to "Hide", and the pill stays anchored at the bottom of each subsection in both states
- [ ] Open each of the 4 new pages (3 whitepapers + 1 blog) and confirm the site nav, theme, and footer match the existing pages
- [ ] On the agentic-memory blog, scroll to Figure 8 and confirm "REGULATED ·" / "PHYSICAL ISOLATION" wrap correctly inside the red band
- [ ] Confirm `/whitepapers/` and `/blogs/` listing pages show the new entries at the top, with consistent styling
- [ ] Validate `sitemap.xml` parses and contains the four new `<url>` entries
- [ ] Spot-check internal cross-links (e.g. `agent-remote-tools` → `agent-tool-wiring`) resolve correctly
- [ ] Open `docs/orchestration/PIPELINE_HOOKS_GUIDE.md` on GitHub and verify the markdown renders cleanly and that links to `ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md` resolve to its existing sections