### PR TITLE
ci: validate Docusaurus build on PRs and pre-push for docs changes

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Pre-push hook: validate the Docusaurus build when docs/ or docs-site/ change.
+# Install: git config core.hooksPath .githooks  (already configured in this repo)
+#
+# Behavior:
+#   - If the commits being pushed don't touch docs/ or docs-site/, exits silently.
+#   - Otherwise runs `npm run build` from docs-site/ and blocks the push on failure.
+#   - Soft-skips (with a warning) if npm or node_modules are missing — CI catches it.
+#   - Bypass with: git push --no-verify
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+ZERO="0000000000000000000000000000000000000000"
+
+# Pre-push receives one line per ref being pushed on stdin:
+#   <local_ref> <local_oid> <remote_ref> <remote_oid>
+# Determine the commit range for each ref and check whether docs/ or docs-site/
+# is touched anywhere in the about-to-be-pushed history.
+DOCS_TOUCHED=0
+while read -r local_ref local_oid remote_ref remote_oid; do
+    if [ "$local_oid" = "$ZERO" ]; then
+        # Deleting a ref — nothing to inspect
+        continue
+    fi
+
+    if [ "$remote_oid" = "$ZERO" ]; then
+        # New branch on the remote — compare against origin/main if available
+        if git rev-parse --verify origin/main >/dev/null 2>&1; then
+            base="$(git merge-base "$local_oid" origin/main 2>/dev/null || true)"
+            if [ -n "$base" ] && [ "$base" != "$local_oid" ]; then
+                range="$base..$local_oid"
+            else
+                range="$local_oid"
+            fi
+        else
+            range="$local_oid"
+        fi
+    else
+        range="$remote_oid..$local_oid"
+    fi
+
+    if git diff --name-only "$range" -- docs/ docs-site/ 2>/dev/null | grep -q .; then
+        DOCS_TOUCHED=1
+        break
+    fi
+done
+
+if [ "$DOCS_TOUCHED" -eq 0 ]; then
+    exit 0
+fi
+
+echo "📚 Docs change detected — validating Docusaurus build before push..."
+
+if ! command -v npm >/dev/null 2>&1; then
+    echo -e "${YELLOW}⚠️  npm not installed — skipping build check.${NC}"
+    echo "    CI will run the same check on the PR."
+    exit 0
+fi
+
+if [ ! -d docs-site/node_modules ]; then
+    echo -e "${YELLOW}⚠️  docs-site/node_modules missing — skipping build check.${NC}"
+    echo "    Run 'cd docs-site && npm install' once to enable this gate."
+    echo "    CI will still run the same check on the PR."
+    exit 0
+fi
+
+if (cd docs-site && npm run build); then
+    echo -e "${GREEN}✅ Docusaurus build passed${NC}"
+    exit 0
+else
+    echo ""
+    echo -e "${RED}🚨 Push blocked: Docusaurus build failed.${NC}"
+    echo ""
+    echo "Fix the errors above and re-push, or bypass with: git push --no-verify"
+    exit 1
+fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'docs-site/**'
+      - 'scripts/rewrite-getting-started-links.py'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'docs-site/**'
+      - 'scripts/rewrite-getting-started-links.py'
+      - '.github/workflows/docs.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: docusaurus build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v5
+        with:
+          # docs-site/package.json pins "engines": { "node": ">=20.0" }
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: docs-site/package-lock.json
+      - name: Install dependencies
+        working-directory: docs-site
+        run: npm ci
+      - name: Build site
+        # `npm run build` runs the prebuild step (Python sync-docs script) first,
+        # then `docusaurus build`. Docusaurus 3.x defaults `onBrokenLinks: throw`,
+        # so any broken internal link in docs/ will fail this job.
+        working-directory: docs-site
+        run: npm run build


### PR DESCRIPTION
## Summary

The existing `ci.yml` workflow explicitly excludes `docs/**` and `**/*.md` via `paths-ignore`, which means a broken docs build (e.g. a busted internal link in a `.md` file under `docs/`) gets zero CI coverage today and only surfaces after merge. This PR closes that gap with two complementary layers.

- **`.github/workflows/docs.yml`** — new GitHub Actions job that runs `npm run build` from `docs-site/` on every push to `main` or PR that touches `docs/`, `docs-site/`, or `scripts/rewrite-getting-started-links.py`. The job uses `actions/setup-node@v5` with Node 20 (matches `docs-site/package.json` engines pin), `npm ci` with cached install, then `npm run build` (which runs the `prebuild` sync-docs script before `docusaurus build`). Docusaurus 3.x defaults `onBrokenLinks: throw`, so any broken internal link in `docs/` fails the job.
- **`.githooks/pre-push`** — new local hook (executable, hooked into the existing `core.hooksPath = .githooks` setup so no install step needed) that runs the same build, but only when the commits being pushed touch `docs/` or `docs-site/`. Soft-skips with a friendly warning if `npm` or `docs-site/node_modules` is missing — CI still catches it on the PR. Bypass with `git push --no-verify`.

The existing `ci.yml` `paths-ignore` is left alone, so docs-only changes still skip the expensive Go test/lint/vuln/examples jobs.

## Test plan

- [x] **Negative-case smoke test (local)**: simulated `git push` of the CI-only commits in this branch → hook detects no `docs/` change and exits silently
- [x] **Positive-case smoke test (local)**: simulated `git push` of the just-merged content branch (PR #25, which added `docs/orchestration/PIPELINE_HOOKS_GUIDE.md`) → hook detects the docs change, starts the Docusaurus build
- [x] **Workflow YAML parses cleanly** (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] **Hook script passes `bash -n`** syntax check
- [ ] Confirm `docs` workflow runs on this PR (it should NOT, since this PR touches `.github/workflows/docs.yml` itself — which is in the `paths` filter, so it *will* trigger; verify the build passes)
- [ ] After merge, open a follow-up PR that intentionally adds a broken link in a `docs/` markdown file and confirm the `docs` workflow blocks it
- [ ] After merge, contributors with `core.hooksPath = .githooks` set picks up the new hook automatically on next `git pull`; ones who haven't installed hooks need to run `git config core.hooksPath .githooks` once

## Notes for reviewers

- The pre-push hook handles three commit-range cases: deleted ref (skip), new branch (compare against `origin/main` via `merge-base`), and existing branch (compare `remote_oid..local_oid`). Fail-open philosophy: missing `npm`/`node_modules` warns and skips rather than blocking the push, so OSS contributors without the docs toolchain aren't forced to install it.
- The workflow runs on `push: main` as well as `pull_request` so direct pushes to `main` (e.g. dependabot bumps that auto-merge) are still validated.