### PR TITLE
feat: configurable user_id normalization for user memory + Go 1.26.4 alignment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ By participating in this project, you agree to abide by our Code of Conduct:
 
 ### Prerequisites
 
-- **Go 1.26 or higher** (the module is pinned to `go 1.26.2` in `go.mod`)
+- **Go 1.26 or higher** (the module is pinned to `go 1.26.4` in `go.mod`)
 - **Docker** (recommended) for running the in-tree Redis/Valkey backend used by integration tests and example deployments
 - **kind** (Kubernetes-in-Docker) for running the example multi-agent system locally
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -33,9 +33,9 @@ TruvaG3 is designed to run on Kubernetes. For local development, we use [Kind](h
 
 ### Required Software
 
-> **Go version**: the framework's `go.mod` declares `go 1.26.2`, so building
+> **Go version**: the framework's `go.mod` declares `go 1.26.4`, so building
 > from source needs Go 1.26+. With Go's toolchain auto-upgrade (default since
-> Go 1.21), an older Go install will fetch 1.26.2 on first build — but some
+> Go 1.21), an older Go install will fetch 1.26.4 on first build — but some
 > controlled environments disable auto-upgrade, so installing a current Go
 > directly is the simplest path.
 
@@ -55,7 +55,7 @@ brew install kind kubectl
 **Linux (Ubuntu/Debian):**
 ```bash
 # Go (substitute the latest 1.26+ release for $GO_VERSION)
-GO_VERSION=1.26.2
+GO_VERSION=1.26.4
 wget "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
 sudo rm -rf /usr/local/go
 sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"

--- a/docs/building/AGENT_DEVELOPMENT_GUIDE.md
+++ b/docs/building/AGENT_DEVELOPMENT_GUIDE.md
@@ -1669,7 +1669,7 @@ Agents depend on four framework modules: `ai`, `core`, `orchestration`, and `tel
 ```go
 module github.com/truvaagents/truva-g3/examples/your-agent
 
-go 1.26.2
+go 1.26.4
 
 require (
     github.com/google/uuid v1.6.0

--- a/docs/building/TOOL_DEVELOPMENT_GUIDE.md
+++ b/docs/building/TOOL_DEVELOPMENT_GUIDE.md
@@ -1097,7 +1097,7 @@ TruvaG3 uses a multi-module workspace. Each tool depends on `core` and `telemetr
 ```go
 module github.com/truvaagents/truva-g3/examples/your-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
     github.com/truvaagents/truva-g3/core v0.9.1
@@ -1119,7 +1119,7 @@ replace (
 For publishing to a container registry. Copies the tool directory only — no local module references.
 
 ```dockerfile
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 RUN apk add --no-cache git make gcc musl-dev ca-certificates
 
@@ -1169,7 +1169,7 @@ docker build -f examples/your-tool/Dockerfile.workspace -t your-tool:latest .
 # Workspace Dockerfile for your-tool
 # Usage (from truvag3 root): docker build -f examples/your-tool/Dockerfile.workspace -t your-tool:latest .
 
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 RUN apk add --no-cache git make gcc musl-dev ca-certificates
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -67,7 +67,7 @@ control plane isn't an option.
 
 ## What you need
 
-- **Go 1.26+** (the framework's `go.mod` declares 1.26.2)
+- **Go 1.26+** (the framework's `go.mod` declares 1.26.4)
 - **Docker** (or [Podman](https://podman.io/) as a drop-in)
 - **Kind + kubectl** — for the local Kubernetes cluster
 - **One AI provider API key** — [Groq](https://groq.com/) has a free tier and is the fastest to start; OpenAI, Anthropic, Gemini, and others are supported

--- a/examples/agent-example/README.md
+++ b/examples/agent-example/README.md
@@ -453,11 +453,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/agent-example/go.mod
+++ b/examples/agent-example/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/agent-example
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/agent-with-async/README.md
+++ b/examples/agent-with-async/README.md
@@ -454,11 +454,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/agent-with-async/go.mod
+++ b/examples/agent-with-async/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/agent-with-async
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/agent-with-human-approval/go.mod
+++ b/examples/agent-with-human-approval/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/agent-with-human-approval
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/agent-with-human-approval/handlers.go
+++ b/examples/agent-with-human-approval/handlers.go
@@ -472,9 +472,12 @@ func setCORSHeaders(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, OPTIONS")
 }
 
-// getUserID extracts the user ID from the X-User-ID header.
+// getUserID extracts the user ID from the X-User-ID header and canonicalizes
+// it (lowercase + trim) so session identity and user memory share one bucket
+// regardless of header casing. Uses the framework's canonical form so the app
+// edge and the user memory hooks can never disagree.
 func getUserID(r *http.Request) string {
-	return r.Header.Get("X-User-ID")
+	return orchestration.NormalizeUserIDLowercaseTrim(r.Header.Get("X-User-ID"))
 }
 
 // writeJSON writes a JSON response with CORS headers.

--- a/examples/agent-with-human-approval/setup.sh
+++ b/examples/agent-with-human-approval/setup.sh
@@ -217,7 +217,7 @@ build_app() {
     # Create temporary go.work to use local framework modules
     log_info "Creating temporary go.work for local module resolution..."
     cat > go.work << 'GOWORK'
-go 1.25.7
+go 1.26.4
 
 use (
     .

--- a/examples/agent-with-orchestration/README.md
+++ b/examples/agent-with-orchestration/README.md
@@ -449,11 +449,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/agent-with-orchestration/go.mod
+++ b/examples/agent-with-orchestration/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/agent-with-orchestration
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/agent-with-orchestration/setup.sh
+++ b/examples/agent-with-orchestration/setup.sh
@@ -52,7 +52,7 @@ check_prerequisites() {
     # Check Go
     if ! command -v go &> /dev/null; then
         echo -e "${RED}Error: Go is not installed${NC}"
-        echo "Please install Go 1.23+ from https://golang.org/dl/"
+        echo "Please install Go 1.26+ from https://golang.org/dl/"
         exit 1
     fi
     echo -e "${GREEN}✓ Go installed: $(go version)${NC}"

--- a/examples/agent-with-resilience/README.md
+++ b/examples/agent-with-resilience/README.md
@@ -451,11 +451,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/agent-with-resilience/go.mod
+++ b/examples/agent-with-resilience/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/agent-with-resilience
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/agent-with-telemetry/README.md
+++ b/examples/agent-with-telemetry/README.md
@@ -448,11 +448,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/agent-with-telemetry/go.mod
+++ b/examples/agent-with-telemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/agent-with-telemetry
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/agentic-memory-tool/go.mod
+++ b/examples/agentic-memory-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/agentic-memory-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/arxiv-tool/README.md
+++ b/examples/arxiv-tool/README.md
@@ -283,9 +283,9 @@ go version
 <summary><strong>Linux Installation</strong></summary>
 
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 go version
 ```

--- a/examples/arxiv-tool/go.mod
+++ b/examples/arxiv-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/arxiv-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/clinical-trials-tool/README.md
+++ b/examples/clinical-trials-tool/README.md
@@ -283,9 +283,9 @@ go version
 <summary><strong>Linux Installation</strong></summary>
 
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 go version
 ```

--- a/examples/clinical-trials-tool/go.mod
+++ b/examples/clinical-trials-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/clinical-trials-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/confluence-tool/README.md
+++ b/examples/confluence-tool/README.md
@@ -327,9 +327,9 @@ go version
 
 **Manual installation (recommended for latest version):**
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 ```
 

--- a/examples/confluence-tool/go.mod
+++ b/examples/confluence-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/confluence-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/country-info-tool/README.md
+++ b/examples/country-info-tool/README.md
@@ -443,11 +443,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/country-info-tool/go.mod
+++ b/examples/country-info-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/country-info-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/currency-global-tool/README.md
+++ b/examples/currency-global-tool/README.md
@@ -445,11 +445,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/currency-global-tool/go.mod
+++ b/examples/currency-global-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/currency-global-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/currency-tool/README.md
+++ b/examples/currency-tool/README.md
@@ -445,11 +445,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/currency-tool/go.mod
+++ b/examples/currency-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/currency-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/demographics-tool/README.md
+++ b/examples/demographics-tool/README.md
@@ -325,9 +325,9 @@ go version
 
 **Manual installation (recommended for latest version):**
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 ```
 

--- a/examples/demographics-tool/go.mod
+++ b/examples/demographics-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/demographics-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/devops-chat-agent/go.mod
+++ b/examples/devops-chat-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/devops-chat-agent
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/devops-chat-agent/handlers.go
+++ b/examples/devops-chat-agent/handlers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/truvaagents/truva-g3/core"
+	"github.com/truvaagents/truva-g3/orchestration"
 	"github.com/truvaagents/truva-g3/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -279,9 +280,12 @@ func extractPathParam(path, prefix string) string {
 	return param
 }
 
-// getUserID extracts the user ID from the X-User-ID header.
+// getUserID extracts the user ID from the X-User-ID header and canonicalizes
+// it (lowercase + trim) so session identity and user memory share one bucket
+// regardless of header casing. Uses the framework's canonical form so the app
+// edge and the user memory hooks can never disagree.
 func getUserID(r *http.Request) string {
-	return r.Header.Get("X-User-ID")
+	return orchestration.NormalizeUserIDLowercaseTrim(r.Header.Get("X-User-ID"))
 }
 
 // handleListSessions lists sessions for a user with pagination.

--- a/examples/devops-chat-agent/sse_handler.go
+++ b/examples/devops-chat-agent/sse_handler.go
@@ -287,8 +287,8 @@ func (h *SSEHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract user ID from header
-	userID := r.Header.Get("X-User-ID")
+	// Extract user ID from header (canonicalized — see getUserID)
+	userID := getUserID(r)
 
 	// Create or get session
 	sessionID := req.SessionID

--- a/examples/devops-observability-tool/go.mod
+++ b/examples/devops-observability-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/devops-observability-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/devops-tool/go.mod
+++ b/examples/devops-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/devops-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0

--- a/examples/economic-data-tool/README.md
+++ b/examples/economic-data-tool/README.md
@@ -329,9 +329,9 @@ go version
 
 **Manual installation (recommended for latest version):**
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 ```
 

--- a/examples/economic-data-tool/go.mod
+++ b/examples/economic-data-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/economic-data-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/event-driven-agent/go.mod
+++ b/examples/event-driven-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/event-driven-agent
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/fiscal-data-tool/README.md
+++ b/examples/fiscal-data-tool/README.md
@@ -359,9 +359,9 @@ go version
 
 **Manual installation (recommended for latest version):**
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 ```
 

--- a/examples/fiscal-data-tool/go.mod
+++ b/examples/fiscal-data-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/fiscal-data-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/flight-tool/README.md
+++ b/examples/flight-tool/README.md
@@ -438,11 +438,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/flight-tool/go.mod
+++ b/examples/flight-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/flight-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/geocoding-tool/README.md
+++ b/examples/geocoding-tool/README.md
@@ -449,11 +449,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/geocoding-tool/go.mod
+++ b/examples/geocoding-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/geocoding-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/github-pr-review-agent/README.md
+++ b/examples/github-pr-review-agent/README.md
@@ -45,7 +45,7 @@ Local dev without Kubernetes:
 
 ## Prerequisites
 
-- **Go 1.26.2** (workspace builds require it; standalone Docker uses 1.25.7).
+- **Go 1.26.4** (both workspace and standalone Docker builds use it).
 - **Docker** for the local Redis container and for image builds.
 - **Kind** + **kubectl** for the Kubernetes path.
 - An **AI provider key** (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `GROQ_API_KEY`).

--- a/examples/github-pr-review-agent/go.mod
+++ b/examples/github-pr-review-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/github-pr-review-agent
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/github-tool/go.mod
+++ b/examples/github-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/github-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/grocery-tool/README.md
+++ b/examples/grocery-tool/README.md
@@ -451,11 +451,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/grocery-tool/go.mod
+++ b/examples/grocery-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/grocery-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/hotel-tool/README.md
+++ b/examples/hotel-tool/README.md
@@ -327,9 +327,9 @@ go version
 
 **Manual installation (recommended for latest version):**
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 ```
 

--- a/examples/hotel-tool/go.mod
+++ b/examples/hotel-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/hotel-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/jira-tool/README.md
+++ b/examples/jira-tool/README.md
@@ -325,9 +325,9 @@ go version
 
 **Manual installation (recommended for latest version):**
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 ```
 

--- a/examples/jira-tool/go.mod
+++ b/examples/jira-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/jira-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/k8-deployment/setup-env-lib.sh
+++ b/examples/k8-deployment/setup-env-lib.sh
@@ -333,7 +333,7 @@ truvag3_check_prerequisites() {
     _truvag3_log_info "Checking prerequisites..."
 
     if ! command -v go &> /dev/null; then
-        echo "ERROR: Go is not installed. Please install Go 1.25+ from https://golang.org/dl/"
+        echo "ERROR: Go is not installed. Please install Go 1.26+ from https://golang.org/dl/"
         exit 1
     fi
     _truvag3_log_success "Go installed: $(go version)"

--- a/examples/my-async-agent/go.mod
+++ b/examples/my-async-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/my-async-agent
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/ai v0.9.1

--- a/examples/my-streaming-agent/go.mod
+++ b/examples/my-streaming-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/my-streaming-agent
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/ai v0.9.1

--- a/examples/my-tool/go.mod
+++ b/examples/my-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/my-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/news-tool/README.md
+++ b/examples/news-tool/README.md
@@ -447,11 +447,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/news-tool/go.mod
+++ b/examples/news-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/news-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/openfda-tool/README.md
+++ b/examples/openfda-tool/README.md
@@ -283,9 +283,9 @@ go version
 <summary><strong>Linux Installation</strong></summary>
 
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 go version
 ```

--- a/examples/openfda-tool/go.mod
+++ b/examples/openfda-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/openfda-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/places-tool/README.md
+++ b/examples/places-tool/README.md
@@ -284,9 +284,9 @@ go version
 <summary><strong>Linux Installation</strong></summary>
 
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 go version
 ```

--- a/examples/places-tool/go.mod
+++ b/examples/places-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/places-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/playwright-tool/README.md
+++ b/examples/playwright-tool/README.md
@@ -369,9 +369,9 @@ go version
 <summary><strong>Linux Installation</strong></summary>
 
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 ```
 

--- a/examples/playwright-tool/go.mod
+++ b/examples/playwright-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/playwright-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6

--- a/examples/prometheus-query-tool/README.md
+++ b/examples/prometheus-query-tool/README.md
@@ -283,9 +283,9 @@ go version
 <summary><strong>Linux Installation</strong></summary>
 
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 go version
 ```

--- a/examples/prometheus-query-tool/go.mod
+++ b/examples/prometheus-query-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/prometheus-query-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/pubmed-tool/README.md
+++ b/examples/pubmed-tool/README.md
@@ -283,9 +283,9 @@ go version
 <summary><strong>Linux Installation</strong></summary>
 
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 go version
 ```

--- a/examples/pubmed-tool/go.mod
+++ b/examples/pubmed-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/pubmed-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/qa-agent/go.mod
+++ b/examples/qa-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/qa-agent
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/registry-viewer-app/go.mod
+++ b/examples/registry-viewer-app/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/registry-viewer-app
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/registry-viewer-app/setup.sh
+++ b/examples/registry-viewer-app/setup.sh
@@ -82,7 +82,7 @@ check_prerequisites() {
     # Check Go
     if ! command -v go &> /dev/null; then
         log_error "Go is not installed"
-        echo "Please install Go 1.25+ from https://golang.org/dl/"
+        echo "Please install Go 1.26+ from https://golang.org/dl/"
         exit 1
     fi
     log_success "Go installed: $(go version)"

--- a/examples/scheduled-executor/go.mod
+++ b/examples/scheduled-executor/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/scheduled-executor
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/scheduler-tool/go.mod
+++ b/examples/scheduler-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/scheduler-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/semantic-scholar-tool/README.md
+++ b/examples/semantic-scholar-tool/README.md
@@ -283,9 +283,9 @@ go version
 <summary><strong>Linux Installation</strong></summary>
 
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 go version
 ```

--- a/examples/semantic-scholar-tool/go.mod
+++ b/examples/semantic-scholar-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/semantic-scholar-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/slack-tool/README.md
+++ b/examples/slack-tool/README.md
@@ -325,9 +325,9 @@ go version
 
 **Manual installation (recommended for latest version):**
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 ```
 

--- a/examples/slack-tool/go.mod
+++ b/examples/slack-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/slack-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/stock-market-tool/README.md
+++ b/examples/stock-market-tool/README.md
@@ -443,11 +443,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/stock-market-tool/go.mod
+++ b/examples/stock-market-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/stock-market-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/system-utilities-tool/go.mod
+++ b/examples/system-utilities-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/system-utilities-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0

--- a/examples/tool-example/go.mod
+++ b/examples/tool-example/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/tool-example
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/travel-advisory-tool/README.md
+++ b/examples/travel-advisory-tool/README.md
@@ -283,9 +283,9 @@ go version
 <summary><strong>Linux Installation</strong></summary>
 
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 go version
 ```

--- a/examples/travel-advisory-tool/go.mod
+++ b/examples/travel-advisory-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/travel-advisory-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/travel-chat-agent/chat_agent.go
+++ b/examples/travel-chat-agent/chat_agent.go
@@ -238,9 +238,8 @@ devops-chat-agent and return its synthesized response.`,
 
 	// Activate user_id canonicalization in the memory hooks as defense-in-depth.
 	// The app already normalizes at the edge (getUserID), so metadata["user_id"]
-	// arrives canonical; this keeps recall/storage consistent even for any future
-	// caller that reaches the hooks with a non-normalized id, without depending on
-	// the TRUVAG3_USER_MEMORY_USER_ID_NORMALIZATION deployment env var.
+	// arrives canonical; this keeps recall and storage consistent even for any
+	// future caller that reaches the hooks with a non-normalized id.
 	userHooks, userHooksCloser := orchestration.BuildUserMemoryHooks(userMemBackend.ToDeps(), t.AI, t.Logger,
 		orchestration.WithUserIDNormalizer(orchestration.NormalizeUserIDLowercaseTrim),
 	)

--- a/examples/travel-chat-agent/chat_agent.go
+++ b/examples/travel-chat-agent/chat_agent.go
@@ -236,7 +236,14 @@ devops-chat-agent and return its synthesized response.`,
 	)
 	t.userMemBackend = userMemBackend
 
-	userHooks, userHooksCloser := orchestration.BuildUserMemoryHooks(userMemBackend.ToDeps(), t.AI, t.Logger)
+	// Activate user_id canonicalization in the memory hooks as defense-in-depth.
+	// The app already normalizes at the edge (getUserID), so metadata["user_id"]
+	// arrives canonical; this keeps recall/storage consistent even for any future
+	// caller that reaches the hooks with a non-normalized id, without depending on
+	// the TRUVAG3_USER_MEMORY_USER_ID_NORMALIZATION deployment env var.
+	userHooks, userHooksCloser := orchestration.BuildUserMemoryHooks(userMemBackend.ToDeps(), t.AI, t.Logger,
+		orchestration.WithUserIDNormalizer(orchestration.NormalizeUserIDLowercaseTrim),
+	)
 	t.userMemCloser = userHooksCloser
 	// ── End user memory setup ───────────────────────────────────────────
 

--- a/examples/travel-chat-agent/go.mod
+++ b/examples/travel-chat-agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/travel-chat-agent
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5

--- a/examples/travel-chat-agent/handlers.go
+++ b/examples/travel-chat-agent/handlers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/truvaagents/truva-g3/core"
+	"github.com/truvaagents/truva-g3/orchestration"
 	"github.com/truvaagents/truva-g3/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -275,9 +276,14 @@ func extractPathParam(path, prefix string) string {
 	return param
 }
 
-// getUserID extracts the user ID from the X-User-ID header.
+// getUserID extracts the user ID from the X-User-ID header and canonicalizes
+// it (lowercase + trim). Normalizing at this single edge keeps session identity
+// (session ownership, listing, history) and user memory in the same bucket
+// regardless of how the caller cased the header — "Joe", " joe ", and "JOE" are
+// one user. Uses the framework's canonical form so the app edge and the user
+// memory hooks can never disagree.
 func getUserID(r *http.Request) string {
-	return r.Header.Get("X-User-ID")
+	return orchestration.NormalizeUserIDLowercaseTrim(r.Header.Get("X-User-ID"))
 }
 
 // handleListSessions lists sessions for a user with pagination.

--- a/examples/travel-chat-agent/sse_handler.go
+++ b/examples/travel-chat-agent/sse_handler.go
@@ -196,8 +196,8 @@ func (h *SSEHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract user ID from header
-	userID := r.Header.Get("X-User-ID")
+	// Extract user ID from header (canonicalized — see getUserID)
+	userID := getUserID(r)
 
 	// Create or get session
 	sessionID := req.SessionID

--- a/examples/weather-tool-v2/README.md
+++ b/examples/weather-tool-v2/README.md
@@ -446,11 +446,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/weather-tool-v2/go.mod
+++ b/examples/weather-tool-v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/weather-tool-v2
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/web-search-tool/README.md
+++ b/examples/web-search-tool/README.md
@@ -443,11 +443,11 @@ go version
 **Manual installation (recommended for latest version):**
 ```bash
 # Download Go (replace version as needed)
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 
 # Remove any previous installation and extract
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 
 # Add to PATH (add to ~/.bashrc or ~/.profile for persistence)
 export PATH=$PATH:/usr/local/go/bin

--- a/examples/web-search-tool/go.mod
+++ b/examples/web-search-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/web-search-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/examples/world-health-tool/README.md
+++ b/examples/world-health-tool/README.md
@@ -283,9 +283,9 @@ go version
 <summary><strong>Linux Installation</strong></summary>
 
 ```bash
-curl -LO https://go.dev/dl/go1.26.2.linux-amd64.tar.gz
+curl -LO https://go.dev/dl/go1.26.4.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.26.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.4.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 go version
 ```

--- a/examples/world-health-tool/go.mod
+++ b/examples/world-health-tool/go.mod
@@ -1,6 +1,6 @@
 module github.com/truvaagents/truva-g3/examples/world-health-tool
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/truvaagents/truva-g3/core v0.9.1

--- a/orchestration/user_id_normalizer.go
+++ b/orchestration/user_id_normalizer.go
@@ -1,0 +1,34 @@
+package orchestration
+
+import "strings"
+
+// UserIDNormalizer canonicalizes a user_id before it is used as the isolation
+// key for user memory. It is applied at the two framework chokepoints where
+// user_id enters the user-memory subsystem — recall (enrichment) and storage
+// (extraction) — so a single normalizer guarantees the same person reads and
+// writes the same memory bucket regardless of how the caller cased the id.
+//
+// The framework default is identity (no-op): user_id stays case-sensitive and
+// verbatim, preserving existing behavior for callers that deliberately treat
+// distinct casings as distinct users. Opt in to canonicalization with an
+// explicit normalizer via WithUserIDNormalizer (Layer 1 builder) or the
+// per-hook options (Layer 3).
+//
+// Normalization changes the identity key, so it is a deliberate code-level
+// policy — made once, consistently — not a per-deployment toggle: flipping it
+// against a populated store would silently fork or orphan user-memory buckets.
+// That is why it is a WithXXX() behavioural plug and not an environment
+// variable (per FRAMEWORK_DESIGN_PRINCIPLES Configuration Split).
+type UserIDNormalizer func(string) string
+
+// IdentityUserIDNormalizer returns the user_id unchanged. This is the framework
+// default — case-sensitive, verbatim user isolation.
+func IdentityUserIDNormalizer(id string) string { return id }
+
+// NormalizeUserIDLowercaseTrim canonicalizes a user_id by trimming surrounding
+// whitespace and lowercasing. This is the recommended canonical form: it folds
+// "Joe", " joe ", and "JOE" into a single bucket, removing the case-split class
+// of cross-session memory surprises.
+func NormalizeUserIDLowercaseTrim(id string) string {
+	return strings.ToLower(strings.TrimSpace(id))
+}

--- a/orchestration/user_id_normalizer_test.go
+++ b/orchestration/user_id_normalizer_test.go
@@ -1,0 +1,107 @@
+package orchestration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/truvaagents/truva-g3/core"
+)
+
+func TestNormalizeUserIDLowercaseTrim(t *testing.T) {
+	cases := map[string]string{
+		"Joe":      "joe",
+		" joe ":    "joe",
+		"JOE":      "joe",
+		"Neelabh":  "neelabh",
+		"neelabh":  "neelabh",
+		"\tUser\n": "user",
+		"":         "",
+		"  ":       "",
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, NormalizeUserIDLowercaseTrim(in), "input %q", in)
+	}
+}
+
+func TestIdentityUserIDNormalizer(t *testing.T) {
+	assert.Equal(t, "Joe", IdentityUserIDNormalizer("Joe"))
+	assert.Equal(t, " Joe ", IdentityUserIDNormalizer(" Joe "))
+}
+
+// ─── Chokepoint integration: recall reads the canonical bucket ───────────────
+
+// With a lowercase-trim normalizer, a request carrying "Joe" recalls facts that
+// were stored under the canonical "joe" — the case-split is folded away.
+func TestEnrichmentHook_NormalizesUserIDOnRecall(t *testing.T) {
+	mem := newTestUserMemory()
+	ctx := context.Background()
+	require.NoError(t, mem.Remember(ctx, "joe", core.UserFact{
+		FactID: "f1", Namespace: "travel", Category: "preference",
+		Content: "User prefers window seats", Source: core.SourceExplicit, Confidence: 0.95,
+	}))
+
+	hook := NewUserMemoryEnrichmentHook(mem, "travel", &core.NoOpLogger{},
+		WithUserMemoryEnrichmentUserIDNormalizer(NormalizeUserIDLowercaseTrim),
+	)
+	pctx := &core.PipelineContext{
+		Request:  "window seats",
+		Metadata: map[string]interface{}{"user_id": "Joe"},
+	}
+
+	_, err := hook.BeforePlanning(ctx, pctx)
+	require.NoError(t, err)
+	require.NotNil(t, pctx.Enrichments)
+	profile, _ := pctx.Enrichments[core.EnrichmentUserProfile].(string)
+	assert.Contains(t, profile, "User prefers window seats",
+		"mixed-case id should recall facts stored under the canonical id")
+}
+
+// The default (no normalizer) preserves case-sensitive isolation: "Joe" does
+// NOT see facts stored under "joe". Guards against an accidental behavior change.
+func TestEnrichmentHook_DefaultIsCaseSensitive(t *testing.T) {
+	mem := newTestUserMemory()
+	ctx := context.Background()
+	require.NoError(t, mem.Remember(ctx, "joe", core.UserFact{
+		FactID: "f1", Namespace: "travel", Category: "preference",
+		Content: "User prefers window seats", Source: core.SourceExplicit, Confidence: 0.95,
+	}))
+
+	hook := NewUserMemoryEnrichmentHook(mem, "travel", &core.NoOpLogger{})
+	pctx := &core.PipelineContext{
+		Request:  "window seats",
+		Metadata: map[string]interface{}{"user_id": "Joe"},
+	}
+
+	_, err := hook.BeforePlanning(ctx, pctx)
+	require.NoError(t, err)
+	assert.Nil(t, pctx.Enrichments, "case-sensitive default must not cross buckets")
+}
+
+// Storage and recall agree end-to-end: a fact stored under the normalized "joe"
+// is recalled by a later "JOE" request when both use the same normalizer.
+func TestExtractionAndEnrichment_ShareCanonicalBucket(t *testing.T) {
+	mem := newTestUserMemory()
+	ctx := context.Background()
+
+	normalized := NormalizeUserIDLowercaseTrim("Joe")
+	require.Equal(t, "joe", normalized)
+	require.NoError(t, mem.Remember(ctx, normalized, core.UserFact{
+		FactID: "f1", Namespace: "travel", Category: "preference",
+		Content: "User prefers aisle seats", Source: core.SourceExplicit, Confidence: 0.95,
+	}))
+
+	hook := NewUserMemoryEnrichmentHook(mem, "travel", &core.NoOpLogger{},
+		WithUserMemoryEnrichmentUserIDNormalizer(NormalizeUserIDLowercaseTrim),
+	)
+	pctx := &core.PipelineContext{
+		Request:  "aisle seats",
+		Metadata: map[string]interface{}{"user_id": "JOE"},
+	}
+	_, err := hook.BeforePlanning(ctx, pctx)
+	require.NoError(t, err)
+	require.NotNil(t, pctx.Enrichments)
+	profile, _ := pctx.Enrichments[core.EnrichmentUserProfile].(string)
+	assert.Contains(t, profile, "User prefers aisle seats")
+}

--- a/orchestration/user_id_normalizer_test.go
+++ b/orchestration/user_id_normalizer_test.go
@@ -79,29 +79,74 @@ func TestEnrichmentHook_DefaultIsCaseSensitive(t *testing.T) {
 	assert.Nil(t, pctx.Enrichments, "case-sensitive default must not cross buckets")
 }
 
-// Storage and recall agree end-to-end: a fact stored under the normalized "joe"
-// is recalled by a later "JOE" request when both use the same normalizer.
+// The extraction hook normalizes user_id before storage: a fact extracted for
+// a mixed-case "Joe" lands in the canonical "joe" bucket, not "Joe".
+func TestExtractionHook_NormalizesUserIDOnStorage(t *testing.T) {
+	mem := newTestUserMemory()
+	ctx := context.Background()
+	extractor := newSlowFactExtractor([]core.UserFact{
+		{Content: "User prefers aisle seats", Category: "preference", Source: core.SourceExplicit, Confidence: 0.95},
+	}, 0)
+
+	// Synchronous (Layer-3 default): AfterSynthesis blocks until storage.
+	hook := NewUserMemoryExtractionHook(
+		mem, nil, nil, "travel", &core.NoOpLogger{},
+		extractor, &addAllReconciler{},
+		WithUserExtractionUserIDNormalizer(NormalizeUserIDLowercaseTrim),
+	)
+	t.Cleanup(func() { _ = hook.Close() })
+
+	_, err := hook.AfterSynthesis(ctx, &core.PipelineContext{
+		Request:  "book me an aisle seat",
+		Metadata: map[string]interface{}{"user_id": "Joe"},
+	}, "aisle seat booked")
+	require.NoError(t, err)
+
+	canonical, _ := mem.Recall(ctx, "joe", "travel", "", 10)
+	require.NotEmpty(t, canonical, "extraction must store under the normalized user id")
+	assert.Equal(t, "User prefers aisle seats", canonical[0].Content)
+
+	raw, _ := mem.Recall(ctx, "Joe", "travel", "", 10)
+	assert.Empty(t, raw, "nothing should be stored under the raw mixed-case id")
+}
+
+// End-to-end: a fact STORED via the extraction hook for "Joe" is RECALLED via
+// the enrichment hook for "JOE" — both hooks fold to the same canonical bucket.
+// Exercises both chokepoints (AfterSynthesis storage + BeforePlanning recall),
+// not a manual mem.Remember seed.
 func TestExtractionAndEnrichment_ShareCanonicalBucket(t *testing.T) {
 	mem := newTestUserMemory()
 	ctx := context.Background()
+	norm := NormalizeUserIDLowercaseTrim
 
-	normalized := NormalizeUserIDLowercaseTrim("Joe")
-	require.Equal(t, "joe", normalized)
-	require.NoError(t, mem.Remember(ctx, normalized, core.UserFact{
-		FactID: "f1", Namespace: "travel", Category: "preference",
-		Content: "User prefers aisle seats", Source: core.SourceExplicit, Confidence: 0.95,
-	}))
+	// Storage side: extraction hook persists a fact for "Joe".
+	extractor := newSlowFactExtractor([]core.UserFact{
+		{Content: "User prefers aisle seats", Category: "preference", Source: core.SourceExplicit, Confidence: 0.95},
+	}, 0)
+	extractHook := NewUserMemoryExtractionHook(
+		mem, nil, nil, "travel", &core.NoOpLogger{},
+		extractor, &addAllReconciler{},
+		WithUserExtractionUserIDNormalizer(norm),
+	)
+	t.Cleanup(func() { _ = extractHook.Close() })
+	_, err := extractHook.AfterSynthesis(ctx, &core.PipelineContext{
+		Request:  "book me an aisle seat",
+		Metadata: map[string]interface{}{"user_id": "Joe"},
+	}, "aisle seat booked")
+	require.NoError(t, err)
 
-	hook := NewUserMemoryEnrichmentHook(mem, "travel", &core.NoOpLogger{},
-		WithUserMemoryEnrichmentUserIDNormalizer(NormalizeUserIDLowercaseTrim),
+	// Recall side: enrichment hook for a different casing ("JOE") finds it.
+	enrichHook := NewUserMemoryEnrichmentHook(mem, "travel", &core.NoOpLogger{},
+		WithUserMemoryEnrichmentUserIDNormalizer(norm),
 	)
 	pctx := &core.PipelineContext{
 		Request:  "aisle seats",
 		Metadata: map[string]interface{}{"user_id": "JOE"},
 	}
-	_, err := hook.BeforePlanning(ctx, pctx)
+	_, err = enrichHook.BeforePlanning(ctx, pctx)
 	require.NoError(t, err)
 	require.NotNil(t, pctx.Enrichments)
 	profile, _ := pctx.Enrichments[core.EnrichmentUserProfile].(string)
-	assert.Contains(t, profile, "User prefers aisle seats")
+	assert.Contains(t, profile, "User prefers aisle seats",
+		"a fact stored for 'Joe' must be recalled for 'JOE' via the shared canonical bucket")
 }

--- a/orchestration/user_memory_extraction.go
+++ b/orchestration/user_memory_extraction.go
@@ -65,13 +65,14 @@ type UserMemoryExtractionHook struct {
 	extractor         UserFactExtractor
 	reconciler        UserFactReconciler
 	persistencePolicy UserFactPersistencePolicy
-	summaryModel      string         // from TRUVAG3_USER_MEMORY_EXTRACTION_MODEL
-	summaryMaxRespLen int            // from TRUVAG3_USER_MEMORY_SUMMARY_MAX_RESPONSE_LEN (default: 500)
-	maxSplitClauses   int            // from TRUVAG3_USER_MEMORY_MAX_SPLIT_CLAUSES (default: 3)
-	debugStore        LLMDebugStore  // optional — set by factory duck-typing propagation
-	debugWg           sync.WaitGroup // tracks in-flight debug recordings
-	asynchronous      bool           // default false (sync); enable via WithAsynchronousUserExtraction
-	extractionWg      sync.WaitGroup // tracks in-flight async extraction goroutines
+	summaryModel      string           // from TRUVAG3_USER_MEMORY_EXTRACTION_MODEL
+	summaryMaxRespLen int              // from TRUVAG3_USER_MEMORY_SUMMARY_MAX_RESPONSE_LEN (default: 500)
+	maxSplitClauses   int              // from TRUVAG3_USER_MEMORY_MAX_SPLIT_CLAUSES (default: 3)
+	normalizeUserID   UserIDNormalizer // canonicalizes user_id before storage (default: identity)
+	debugStore        LLMDebugStore    // optional — set by factory duck-typing propagation
+	debugWg           sync.WaitGroup   // tracks in-flight debug recordings
+	asynchronous      bool             // default false (sync); enable via WithAsynchronousUserExtraction
+	extractionWg      sync.WaitGroup   // tracks in-flight async extraction goroutines
 }
 
 // UserMemoryExtractionOption configures UserMemoryExtractionHook (Layer 3).
@@ -83,6 +84,17 @@ func WithUserExtractionPersistencePolicy(p UserFactPersistencePolicy) UserMemory
 	return func(h *UserMemoryExtractionHook) {
 		if p != nil {
 			h.persistencePolicy = p
+		}
+	}
+}
+
+// WithUserExtractionUserIDNormalizer sets the function that canonicalizes
+// user_id before facts are stored. Pair it with the matching enrichment-hook
+// option so reads and writes land in the same bucket. Nil is ignored.
+func WithUserExtractionUserIDNormalizer(n UserIDNormalizer) UserMemoryExtractionOption {
+	return func(h *UserMemoryExtractionHook) {
+		if n != nil {
+			h.normalizeUserID = n
 		}
 	}
 }
@@ -157,6 +169,11 @@ func NewUserMemoryExtractionHook(
 	for _, opt := range opts {
 		opt(h)
 	}
+	// Default to identity when no normalizer was supplied. Must match the
+	// enrichment hook's choice so storage and recall agree.
+	if h.normalizeUserID == nil {
+		h.normalizeUserID = IdentityUserIDNormalizer
+	}
 	return h
 }
 
@@ -221,6 +238,12 @@ func (h *UserMemoryExtractionHook) AfterSynthesis(ctx context.Context, pctx *cor
 	userID, ok := pctx.Metadata["user_id"].(string)
 	if !ok || userID == "" {
 		return response, nil // No user context — skip, pass response through
+	}
+	// Canonicalize before storage so facts land in the same bucket recall reads.
+	// normalizeUserID is constructor-guaranteed non-nil (defaults to identity).
+	userID = h.normalizeUserID(userID)
+	if userID == "" {
+		return response, nil // Normalized away — nothing to attribute
 	}
 
 	// Snapshot the inputs as values before (possibly) crossing a goroutine

--- a/orchestration/user_memory_hook_builder.go
+++ b/orchestration/user_memory_hook_builder.go
@@ -101,6 +101,7 @@ type userMemoryHookConfig struct {
 	persistencePolicy     UserFactPersistencePolicy
 	retrievalWeights      core.RetrievalWeights
 	synchronousExtraction bool
+	userIDNormalizer      UserIDNormalizer
 }
 
 // BuildUserMemoryHooksOption configures behavioural plugs.
@@ -154,6 +155,24 @@ func WithUserFactPersistencePolicy(p UserFactPersistencePolicy) BuildUserMemoryH
 			return fmt.Errorf("user fact persistence policy cannot be nil")
 		}
 		c.persistencePolicy = p
+		return nil
+	}
+}
+
+// WithUserIDNormalizer canonicalizes user_id before it is used as the user
+// memory isolation key. The same normalizer is applied to both recall
+// (enrichment) and storage (extraction), so reads and writes always agree.
+//
+// Default (no option) is identity — case-sensitive, verbatim isolation. Pass
+// NormalizeUserIDLowercaseTrim to fold casing/whitespace variants of the same
+// id into one bucket. Normalization changes the identity key, so it is a
+// deliberate code-level policy rather than a per-deployment env toggle.
+func WithUserIDNormalizer(n UserIDNormalizer) BuildUserMemoryHooksOption {
+	return func(c *userMemoryHookConfig) error {
+		if n == nil {
+			return fmt.Errorf("user id normalizer cannot be nil")
+		}
+		c.userIDNormalizer = n
 		return nil
 	}
 }
@@ -266,10 +285,15 @@ func BuildUserMemoryHooks(
 		cfg.persistencePolicy = NewDefaultUserFactPersistencePolicy()
 	}
 
-	// Build hooks in correct pipeline order
-	enrichHook := NewUserMemoryEnrichmentHook(deps.UserMemory, deps.Namespace, logger)
+	// Pass the same normalizer to both hooks so recall and storage stay in
+	// lockstep. When nil, each hook independently defaults to identity, which is
+	// still identical across the two.
+	enrichHook := NewUserMemoryEnrichmentHook(deps.UserMemory, deps.Namespace, logger,
+		WithUserMemoryEnrichmentUserIDNormalizer(cfg.userIDNormalizer),
+	)
 	extractOpts := []UserMemoryExtractionOption{
 		WithUserExtractionPersistencePolicy(cfg.persistencePolicy),
+		WithUserExtractionUserIDNormalizer(cfg.userIDNormalizer),
 	}
 	// Layer 1 preset defaults to async. Developers can opt out via
 	// WithSynchronousExtraction() — if the flag is not set, enable async.

--- a/orchestration/user_memory_hooks.go
+++ b/orchestration/user_memory_hooks.go
@@ -28,16 +28,17 @@ type UserMemoryEnrichmentHook struct {
 	userMemory        core.UserMemory
 	namespace         string
 	logger            core.Logger
-	maxFacts          int            // from TRUVAG3_USER_MEMORY_MAX_FACTS_IN_PROMPT (default: 15)
-	maxIdentityFacts  int            // from TRUVAG3_USER_MEMORY_MAX_IDENTITY_FACTS (default: 5)
-	maxDurableFacts   int            // from TRUVAG3_USER_MEMORY_MAX_DURABLE_FACTS_IN_PROMPT (default: 8)
-	maxTransientFacts int            // from TRUVAG3_USER_MEMORY_MAX_TRANSIENT_FACTS_IN_PROMPT (default: 4)
-	maxSummaryFacts   int            // from TRUVAG3_USER_MEMORY_MAX_SUMMARY_FACTS_IN_PROMPT (default: 3)
-	maxStableFacts    int            // from TRUVAG3_USER_MEMORY_MAX_STABLE_FACTS_PER_CATEGORY (default: 2)
-	maxUniversalFacts int            // from TRUVAG3_USER_MEMORY_MAX_UNIVERSAL_FACTS (default: 5)
-	minConfidence     float64        // from TRUVAG3_USER_MEMORY_MIN_CONFIDENCE (default: 0.3)
-	debugStore        LLMDebugStore  // optional — set by factory duck-typing propagation
-	debugWg           sync.WaitGroup // tracks in-flight debug recordings
+	maxFacts          int              // from TRUVAG3_USER_MEMORY_MAX_FACTS_IN_PROMPT (default: 15)
+	maxIdentityFacts  int              // from TRUVAG3_USER_MEMORY_MAX_IDENTITY_FACTS (default: 5)
+	maxDurableFacts   int              // from TRUVAG3_USER_MEMORY_MAX_DURABLE_FACTS_IN_PROMPT (default: 8)
+	maxTransientFacts int              // from TRUVAG3_USER_MEMORY_MAX_TRANSIENT_FACTS_IN_PROMPT (default: 4)
+	maxSummaryFacts   int              // from TRUVAG3_USER_MEMORY_MAX_SUMMARY_FACTS_IN_PROMPT (default: 3)
+	maxStableFacts    int              // from TRUVAG3_USER_MEMORY_MAX_STABLE_FACTS_PER_CATEGORY (default: 2)
+	maxUniversalFacts int              // from TRUVAG3_USER_MEMORY_MAX_UNIVERSAL_FACTS (default: 5)
+	minConfidence     float64          // from TRUVAG3_USER_MEMORY_MIN_CONFIDENCE (default: 0.3)
+	normalizeUserID   UserIDNormalizer // canonicalizes user_id before recall (default: identity)
+	debugStore        LLMDebugStore    // optional — set by factory duck-typing propagation
+	debugWg           sync.WaitGroup   // tracks in-flight debug recordings
 }
 
 // UserMemoryEnrichmentOption configures UserMemoryEnrichmentHook (Layer 3).
@@ -103,7 +104,23 @@ func NewUserMemoryEnrichmentHook(
 	for _, opt := range opts {
 		opt(h)
 	}
+
+	// Default to identity when no normalizer was supplied (no-op, case-sensitive).
+	if h.normalizeUserID == nil {
+		h.normalizeUserID = IdentityUserIDNormalizer
+	}
 	return h
+}
+
+// WithUserMemoryEnrichmentUserIDNormalizer sets the function that canonicalizes
+// user_id before recall. Pair it with the matching extraction-hook option so
+// reads and writes land in the same bucket. Nil is ignored (keeps the default).
+func WithUserMemoryEnrichmentUserIDNormalizer(n UserIDNormalizer) UserMemoryEnrichmentOption {
+	return func(h *UserMemoryEnrichmentHook) {
+		if n != nil {
+			h.normalizeUserID = n
+		}
+	}
 }
 
 func (h *UserMemoryEnrichmentHook) Name() string { return "user-memory-enrichment" }
@@ -156,6 +173,12 @@ func (h *UserMemoryEnrichmentHook) BeforePlanning(ctx context.Context, pctx *cor
 	userID, ok := pctx.Metadata["user_id"].(string)
 	if !ok || userID == "" {
 		return nil, nil // No user context — skip silently
+	}
+	// Canonicalize before any recall so reads match the form used at storage.
+	// normalizeUserID is constructor-guaranteed non-nil (defaults to identity).
+	userID = h.normalizeUserID(userID)
+	if userID == "" {
+		return nil, nil // Normalized away (e.g. whitespace-only) — nothing to recall
 	}
 
 	requestID := GetRequestID(ctx)

--- a/telemetry/ARCHITECTURE.md
+++ b/telemetry/ARCHITECTURE.md
@@ -1074,7 +1074,7 @@ OTEL_RESOURCE_ATTRIBUTES="deployment.environment=production,cluster.name=us-west
 ### Dockerfile Best Practices
 
 ```dockerfile
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -487,7 +487,7 @@ Here's how to configure telemetry for containerized applications:
 
 ```dockerfile
 # Dockerfile
-FROM golang:1.21 AS builder
+FROM golang:1.26.4-alpine AS builder
 WORKDIR /app
 COPY . .
 RUN go build -o myapp .


### PR DESCRIPTION
## Summary

Fixes a user-memory isolation bug where casing/whitespace variants of the same `user_id` (e.g. `Joe` vs `joe`) split into **separate memory buckets**, so recall and storage silently diverged. Adds a configurable normalizer at the framework chokepoints and wires the canonical form at the app edge. Also aligns all Go version references to `1.26.4`.

Two logically separate commits:

### 1. `feat(orchestration)` — configurable user_id normalization
- New `UserIDNormalizer` applied at the **two framework chokepoints** where `user_id` enters user memory: recall (`UserMemoryEnrichmentHook.BeforePlanning`) and storage (`UserMemoryExtractionHook.AfterSynthesis`) — one normalizer guarantees reads and writes share a bucket.
- **Default is identity (no-op)** — case-sensitive, fully backward compatible; no behavior change unless opted in.
- Opt in via `WithUserIDNormalizer(...)` (Layer 1 builder) or the per-hook options (Layer 3). `NormalizeUserIDLowercaseTrim` is the canonical lowercase+trim form.
- Modeled as a `WithXXX()` behavioural plug (not an env var): normalization changes the identity key, so it's a deliberate code-level policy, not a per-deployment toggle (per the Configuration Split principle).
- **App wiring** (resolves session-identity case-splitting too): `getUserID` canonicalizes at the edge in the travel, devops, and human-approval chat agents; SSE handlers routed through `getUserID` so no raw header read bypasses it; travel agent activates `WithUserIDNormalizer`.

### 2. `chore` — bump Go version references to 1.26.4
- All 50 example `go.mod` were `go 1.26.2`, which fails to build against the framework's `replace` targets (require `>= 1.26.4`). Directive-line only — **no dependency churn**.
- Docs/READMEs install URLs, `GO_VERSION`, prose, and `golang:` Docker tags aligned to `1.26.4`; stale prerequisite minimums (`Go 1.23+`/`1.25+`) → `1.26+`.
- Leaves historical/factual references untouched (Go 1.0-compat example, `log/slog`/auto-upgrade "since Go 1.21" notes, the `Go 1.25.0` benchmark annotation, the `smithy-go v1.25.0` dependency).

## Architecture alignment
Audited against `FRAMEWORK_DESIGN_PRINCIPLES.md` and `orchestration/ARCHITECTURE.md`: behavioural plug as an option (Configuration Split), layered/no-cliffs (builder + per-hook), domain-agnostic no-op default, backward compatible, godoc on all public symbols.

## Testing
- New unit tests: normalizer behavior + end-to-end recall/storage bucket agreement + case-sensitive-default guard.
- Full gates green on `orchestration`: `go build`/`vet`/`test`, `goimports`, `golangci-lint` (0 issues), `gosec` (0), `govulncheck` (no vulns).
- All three wired example apps compile against the local framework.