### PR TITLE
feat(examples): make the setup scripts container-runtime agnostic (docker/podman)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ __pycache__/
 *~
 .DS_Store
 
+# AI coding assistant local config
+.claude/
+
 # Build artifacts
 /bin/
 /dist/

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -122,21 +122,28 @@ Clone the repo into the WSL filesystem (`~/truva-g3`) rather than `/mnt/c/...` �
 - **OCI-compliant** - Uses the same container image formats as Docker
 
 ```bash
-# macOS
+# macOS — note: kind needs a ROOTFUL podman machine
 brew install podman
-podman machine init && podman machine start
+podman machine init --rootful && podman machine start
 
 # Linux (Ubuntu/Debian)
 sudo apt install podman
 
-# Optional: Alias docker to podman
-alias docker=podman
+# The setup scripts auto-detect the running runtime (preferring Docker if its
+# daemon is up). To force podman — e.g. when Docker is also installed — set this.
+# An `alias docker=podman` will NOT work: setup.sh runs non-interactively.
+export TRUVAG3_CONTAINER_RUNTIME=podman
 
 # Kind works with Podman via:
 KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster
 ```
 
-For multi-container setups, use [Podman Compose](https://github.com/containers/podman-compose) which works with existing `docker-compose.yml` files.
+> **On Podman, especially beyond the quickstart?** macOS needs a rootful
+> machine, `alias docker=podman` won't reach `setup.sh`, the machine often
+> needs sizing up for the full example catalog, and there's a known gvproxy
+> ingress quirk. These (with upstream issue links) are collected in
+> [Podman Troubleshooting](docs/reference/PODMAN_TROUBLESHOOTING.md) — the
+> quickstart's ~7 tools work on the defaults.
 
 ### Verify Your Setup
 
@@ -285,6 +292,7 @@ cd ../currency-tool         && ./setup.sh deploy && cd -
 cd ../country-info-tool     && ./setup.sh deploy && cd -
 cd ../system-utilities-tool && ./setup.sh deploy && cd -
 cd ../travel-advisory-tool  && ./setup.sh deploy && cd -
+cd ../scheduler-tool        && ./setup.sh deploy && cd -
 # (optional, see table below) cd ../news-tool          && ./setup.sh deploy && cd -
 # (optional, see table below) cd ../flight-tool        && ./setup.sh deploy && cd -
 # (optional, see table below) cd ../hotel-tool         && ./setup.sh deploy && cd -
@@ -305,13 +313,14 @@ flights, hotels, local places, and headlines.
 | country-info-tool | Country facts — capital, languages, currency code, region | No (free, no auth) | [RestCountries](https://restcountries.com/) | [examples/country-info-tool/](examples/country-info-tool/) |
 | system-utilities-tool | Current time, timezone conversion, date math (e.g. "next Friday") | No (self-contained) | None — Go stdlib (timezone DB, date math) | [examples/system-utilities-tool/](examples/system-utilities-tool/) |
 | travel-advisory-tool | Official US State Department safety advisories per country | No (free, no auth) | [Travel Advisories API](https://cadataapi.state.gov/) | [examples/travel-advisory-tool/](examples/travel-advisory-tool/) |
+| scheduler-tool | Schedule delayed and recurring (cron-style) tasks for the agent to run later | No (self-contained) | None — in-cluster | [examples/scheduler-tool/](examples/scheduler-tool/) |
 | news-tool | Destination news / current events | **Yes** — `GNEWS_API_KEY` | [GNews.io](https://gnews.io/) (free tier: 100 req/day) | [examples/news-tool/](examples/news-tool/) |
 | flight-tool | Flight search and airport/city IATA-code lookup | **Yes** — `TRAVELPAYOUTS_TOKEN` | [Travelpayouts](https://www.travelpayouts.com/) (free signup) | [examples/flight-tool/](examples/flight-tool/) |
 | hotel-tool | Hotel search by ISO country code + city name | **Yes** — `LITEAPI_KEY` | [LiteAPI](https://liteapi.travel/) | [examples/hotel-tool/](examples/hotel-tool/) |
 | places-tool | Restaurants, attractions, and "nearby" search around coordinates | **Yes** — `FOURSQUARE_API_KEY` and/or `GEOAPIFY_API_KEY` | [Foursquare](https://location.foursquare.com/developer/) / [Geoapify](https://www.geoapify.com/places-api) | [examples/places-tool/](examples/places-tool/) |
 | currency-global-tool | Currency conversion across 170+ currencies (richer alternative to currency-tool) | **Yes** — `CURRENCYBEACON_API_KEY` | [CurrencyBeacon](https://currencybeacon.com/) | [examples/currency-global-tool/](examples/currency-global-tool/) |
 
-The first six tools (no-key) are deployed by the commands in step 4 above and
+The first seven tools (no-key) are deployed by the commands in step 4 above and
 require no additional configuration. For each keyed tool, edit its `.env`
 (e.g. `examples/flight-tool/.env`) and set the relevant key before running
 `./setup.sh deploy`. The agent discovers whatever is running via Redis — you
@@ -857,6 +866,13 @@ Common on Linux/Windows. Add the hostnames you use to your hosts file:
 ```
 
 macOS resolves `*.localhost` automatically.
+
+**Ingress hostnames intermittently time out on Podman (`curl` returns `000`) while pods are healthy:**
+
+This is Podman's gvproxy host→VM port forwarder degrading, not a cluster
+problem — see [Podman Troubleshooting — Ingress hostnames intermittently time
+out (gvproxy)](docs/reference/PODMAN_TROUBLESHOOTING.md#ingress-hostnames-intermittently-time-out-gvproxy)
+for the one-time machine refresh that restores it.
 
 **"connection refused" to Redis:**
 

--- a/README.md
+++ b/README.md
@@ -628,6 +628,8 @@ Each framework module ships with its own README covering interfaces, usage patte
 - [Limits Cheatsheet](docs/reference/LIMITS_CHEATSHEET.md) — runtime limits and tuning knobs
 - [Intelligent Error Handling](docs/orchestration/INTELLIGENT_ERROR_HANDLING.md) — LLM-assisted error analysis details
 - [TruvaG3 Tools vs MCP Servers](docs/reference/TRUVAG3_TOOLS_VS_MCP_SERVERS.md) — terminology and integration mapping
+- [Podman Troubleshooting](docs/reference/PODMAN_TROUBLESHOOTING.md) — running on Podman + kind (rootful machine, image loading, gvproxy ingress, machine sizing)
+- [Windows + WSL2 Troubleshooting](docs/reference/WINDOWS_TROUBLESHOOTING.md) — running the bash setup scripts on Windows via WSL2
 
 ## Examples
 

--- a/docs/reference/PODMAN_TROUBLESHOOTING.md
+++ b/docs/reference/PODMAN_TROUBLESHOOTING.md
@@ -1,0 +1,108 @@
+# Podman — Troubleshooting
+
+Field-tested notes for running TruvaG3 on Podman (instead of Docker Desktop / OrbStack), with `kind` as the local Kubernetes provider. The quickstart in [GETTING_STARTED.md](https://github.com/truvaagents/truva-g3/blob/main/GETTING_STARTED.md) is the supported path — come here only when something breaks, or before deploying more than the handful of components in the quickstart.
+
+Every item below is a **known upstream Podman/kind behavior**, not specific to TruvaG3 — each links the relevant issue so you can verify and track it. The example `setup.sh` scripts already work around the ones they can (runtime detection, image loading); the rest are environment-level and are on you to apply.
+
+## kind needs a rootful podman machine (macOS)
+
+Symptom: `kind create cluster` (or `./setup.sh full-deploy`) fails on macOS when the podman machine is rootless.
+
+Root cause: kind's podman provider requires root inside the VM. Apple Silicon machines default to rootless. This is a documented kind requirement.
+
+Fix:
+
+```bash
+podman machine stop
+podman machine set --rootful
+podman machine start
+export KIND_EXPERIMENTAL_PROVIDER=podman   # needed for manual kind commands (setup.sh sets it itself)
+```
+
+Upstream: [kind#3092](https://github.com/kubernetes-sigs/kind/issues/3092), [kind#2888](https://github.com/kubernetes-sigs/kind/issues/2888).
+
+## The setup scripts call `docker` by name — `alias docker=podman` won't help
+
+Symptom: `setup.sh` fails with a Docker socket error (e.g. `dial unix .../docker.sock: connect: no such file or directory`) even though `podman` works, or even though you set a shell alias.
+
+Root cause: `setup.sh` runs in a non-interactive `set -e` subshell, where shell aliases do not apply.
+
+Fix: either pin the runtime explicitly, or put a real `docker`→`podman` shim (a script, not an alias) on `PATH`:
+
+```bash
+export TRUVAG3_CONTAINER_RUNTIME=podman    # honored by the scripts' runtime detection
+```
+
+The scripts prefer `docker` only when its daemon actually responds, so a stopped Docker Desktop / OrbStack install with a dead socket is skipped in favor of podman automatically.
+
+## `kind load docker-image` fails under podman ("not present locally")
+
+Symptom: loading a locally built image into the cluster fails with `ERROR: image: "<name>:latest" not present locally`, even though `podman image ls` shows it.
+
+Root cause: a long-standing incompatibility between `kind load docker-image` and the podman provider. Podman also tags local builds as `localhost/<name>`, which containerd on the kind node will not match against a manifest's bare `image: <name>:tag` (containerd normalizes that to `docker.io/library/<name>:tag`).
+
+Fix: the example scripts handle this automatically. If you load an image by hand, use an archive and retag to the normalized reference:
+
+```bash
+podman tag <name>:latest docker.io/library/<name>:latest
+podman save docker.io/library/<name>:latest -o /tmp/img.tar
+kind load image-archive /tmp/img.tar --name "truvag3-demo-$(whoami)"
+```
+
+Upstream: [kind#3105](https://github.com/kubernetes-sigs/kind/issues/3105), [kind#2027](https://github.com/kubernetes-sigs/kind/issues/2027), [kind#2417](https://github.com/kubernetes-sigs/kind/issues/2417), [kind#3822](https://github.com/kubernetes-sigs/kind/issues/3822) (reported across versions 2021–2024).
+
+## Ingress hostnames intermittently time out (gvproxy)
+
+Symptom: `*.localhost` ingress URLs flake — `curl` returns `000` / times out, a browser loads them only sometimes — **even though the cluster is healthy**: no node resource pressure, all pods Ready, and the service answers `200` via its in-cluster ClusterIP.
+
+Root cause: Podman's host→VM port forwarder, **gvproxy**, can stop forwarding new connections reliably after a period of use — a known macOS issue. It is not a cluster or deployment problem (the backends are fine). Docker Desktop / OrbStack use different host-networking stacks and don't show this.
+
+Fix: gvproxy can't be restarted on its own — refresh it by bouncing the machine, then restart the kind node (its container restart policy is `no`) and wait for ingress:
+
+```bash
+podman machine stop && podman machine start
+# the kind node container — default cluster name is truvag3-demo-$(whoami);
+# if you renamed the cluster, derive it: podman ps -a --format '{{.Names}}' | grep -- '-control-plane$'
+podman start "truvag3-demo-$(whoami)-control-plane"
+kubectl wait --for=condition=ready pod -n ingress-nginx \
+  -l app.kubernetes.io/component=controller --timeout=120s
+```
+
+After the refresh, ingress is reliable again (verify with a few repeated `curl http://travel-chat-agent.localhost/health`).
+
+Upstream: [podman#18017 — "gvproxy runs for a while and stops forwarding"](https://github.com/containers/podman/issues/18017), [podman#28047](https://github.com/containers/podman/issues/28047), [podman#11396](https://github.com/containers/podman/issues/11396), [podman#11532](https://github.com/containers/podman/issues/11532).
+
+## Sizing the podman machine for the full example catalog
+
+The travel quickstart (~6 tools) runs fine on a modestly-sized machine. Deploying many or all of the ~45 examples does not — a small CPU/disk allocation (e.g. 2 CPUs) won't fit it.
+
+Symptoms when under-provisioned:
+- Pods stuck `Pending` with `0/1 nodes are available: 1 Insufficient cpu`.
+- Image builds failing mid-run with `no space left on device` during `go mod download` (each Go example build adds layers; dozens of sequential builds overflow a small disk).
+
+Fix — size the machine up front:
+
+```bash
+podman machine stop
+podman machine set --cpus 6 --memory 12288 --disk-size 80
+podman machine start
+```
+
+(6 CPU / 12 GB / 80 GB comfortably runs the full catalog on a 10-core / 32 GB host. Scale to your hardware.) Note that `--disk-size` enlarges the virtual disk but does **not** grow the filesystem inside the VM — see [Growing the machine disk doesn't resize the filesystem](#growing-the-machine-disk-doesnt-resize-the-filesystem) below for the one-time `growpart`/`xfs_growfs` step. Alternatively, keep the default disk and prune dangling build layers between deploys (`podman image prune -f`). The Go module-cache volume is worth keeping — it speeds rebuilds.
+
+## Growing the machine disk doesn't resize the filesystem
+
+Symptom: after `podman machine set --disk-size N`, the VM still reports the old free space and builds keep failing with `no space left on device`.
+
+Root cause: increasing the qcow disk does not auto-expand the root partition/filesystem inside the VM. (Behavior varies by podman version and provider — some report `--disk-size` having no effect at all on Apple Silicon `applehv`, requiring a machine re-create via `podman machine init`.)
+
+Fix — grow the partition and filesystem once, inside the VM:
+
+```bash
+# growpart + xfs_growfs run inside the VM; the trailing df confirms the new size
+podman machine ssh 'sudo growpart /dev/vda 4 && sudo xfs_growfs / && df -h /'
+```
+
+(`/dev/vda4` is the root partition on the current podman machine image; confirm with `podman machine ssh lsblk` if yours differs.)
+
+Upstream: [podman#25890 — "Increase Machine Disk Size has no effect"](https://github.com/containers/podman/issues/25890), [podman#20564](https://github.com/containers/podman/issues/20564), [podman#13633](https://github.com/containers/podman/issues/13633).

--- a/examples/agent-example/setup.sh
+++ b/examples/agent-example/setup.sh
@@ -74,7 +74,8 @@ check_command() {
 check_prerequisites() {
     print_step "Checking prerequisites..."
     check_command "go" "https://go.dev/doc/install"
-    check_command "docker" "https://docs.docker.com/get-docker/"
+    # Container runtime resolved by the shared lib (docker or podman)
+    check_command "${TRUVAG3_CONTAINER_RUNTIME:-docker}" "https://docs.docker.com/get-docker/ (or https://podman.io/)"
     check_command "kind" "https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
     check_command "kubectl" "https://kubernetes.io/docs/tasks/tools/"
     print_success "All prerequisites installed"
@@ -150,7 +151,7 @@ cmd_docker_build() {
 
     print_step "Building with Dockerfile.workspace (using local modules)..."
     local truvag3_root="$(dirname "$(dirname "$SCRIPT_DIR")")"
-    docker build $no_cache_flag -f "$SCRIPT_DIR/Dockerfile.workspace" -t "$APP_NAME:latest" "$truvag3_root"
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag -f "$SCRIPT_DIR/Dockerfile.workspace" -t "$APP_NAME:latest" "$truvag3_root"
 
     print_success "Docker image built: $APP_NAME:latest (from local workspace)"
     echo ""
@@ -572,8 +573,8 @@ cleanup() {
     kubectl delete -f "$SCRIPT_DIR/k8-deployment.yaml" --ignore-not-found 2>/dev/null || true
 
     # Stop local Redis
-    docker stop truvag3-redis 2>/dev/null || true
-    docker rm truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
     # Remove local binary
     rm -f "$SCRIPT_DIR/research-agent"

--- a/examples/agent-with-async/setup.sh
+++ b/examples/agent-with-async/setup.sh
@@ -71,11 +71,11 @@ setup_redis() {
         echo "Starting Redis via Docker..."
 
         # Stop existing container if any
-        docker stop truvag3-redis 2>/dev/null || true
-        docker rm truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
         # Start Redis
-        docker run -d \
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" run -d \
             --name truvag3-redis \
             -p 6379:6379 \
             redis:7-alpine
@@ -260,11 +260,11 @@ build_docker() {
     # Dockerfile which pulls dependencies from GitHub-tagged releases.
     if [ -f "$AGENT_DIR/Dockerfile.workspace" ]; then
         log_info "Building with LOCAL workspace modules (Dockerfile.workspace)"
-        docker build $no_cache_flag -f "$AGENT_DIR/Dockerfile.workspace" -t $APP_NAME:latest "$TRUVAG3_ROOT"
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag -f "$AGENT_DIR/Dockerfile.workspace" -t $APP_NAME:latest "$TRUVAG3_ROOT"
     else
         log_info "Building standalone (Dockerfile) — dependencies from GitHub"
         cd "$AGENT_DIR"
-        docker build $no_cache_flag -t $APP_NAME:latest .
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag -t $APP_NAME:latest .
     fi
     log_success "$APP_NAME:latest built"
 }
@@ -558,8 +558,8 @@ cleanup() {
     kubectl delete -f "$SCRIPT_DIR/k8-deployment.yaml" --ignore-not-found 2>/dev/null || true
 
     # Stop local Redis
-    docker stop truvag3-redis 2>/dev/null || true
-    docker rm truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
     # Remove local binary
     rm -f "$SCRIPT_DIR/async-travel-agent"

--- a/examples/agent-with-human-approval/setup.sh
+++ b/examples/agent-with-human-approval/setup.sh
@@ -64,11 +64,11 @@ setup_redis() {
         log_info "Starting Redis via Docker..."
 
         # Stop existing container if any
-        docker stop truvag3-redis 2>/dev/null || true
-        docker rm truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
         # Start Redis
-        docker run -d \
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" run -d \
             --name truvag3-redis \
             -p 6379:6379 \
             redis:7-alpine
@@ -252,7 +252,7 @@ build_docker() {
 
     # Build from truvag3 root using Dockerfile.workspace
     cd "$TRUVAG3_ROOT"
-    docker build $no_cache_flag \
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag \
         -f examples/agent-with-human-approval/Dockerfile.workspace \
         -t agent-with-human-approval:latest .
 
@@ -796,8 +796,8 @@ cleanup() {
     kubectl delete -f "$SCRIPT_DIR/k8-deployment.yaml" --ignore-not-found 2>/dev/null || true
 
     # Stop local Redis
-    docker stop truvag3-redis 2>/dev/null || true
-    docker rm truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
     # Remove local binary
     rm -f "$SCRIPT_DIR/agent-with-human-approval"

--- a/examples/agent-with-orchestration/setup.sh
+++ b/examples/agent-with-orchestration/setup.sh
@@ -57,12 +57,14 @@ check_prerequisites() {
     fi
     echo -e "${GREEN}✓ Go installed: $(go version)${NC}"
 
-    # Check Docker (optional)
-    if command -v docker &> /dev/null; then
-        echo -e "${GREEN}✓ Docker installed${NC}"
+    # Container runtime (docker or podman) — resolved by the shared lib at source
+    # time. Check the resolved runtime, not docker specifically.
+    local runtime="${TRUVAG3_CONTAINER_RUNTIME:-docker}"
+    if command -v "$runtime" &> /dev/null; then
+        echo -e "${GREEN}✓ $runtime installed${NC}"
         DOCKER_AVAILABLE=true
     else
-        echo -e "${YELLOW}! Docker not found (optional for local development)${NC}"
+        echo -e "${YELLOW}! $runtime not found (optional for local development)${NC}"
         DOCKER_AVAILABLE=false
     fi
 
@@ -110,11 +112,11 @@ setup_redis() {
         echo "Starting Redis via Docker..."
 
         # Stop existing container if any
-        docker stop truvag3-redis 2>/dev/null || true
-        docker rm truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
         # Start Redis
-        docker run -d \
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" run -d \
             --name truvag3-redis \
             -p 6379:6379 \
             redis:7-alpine
@@ -514,8 +516,8 @@ cleanup() {
     kubectl delete -f "$SCRIPT_DIR/k8-deployment.yaml" --ignore-not-found 2>/dev/null || true
 
     # Stop local Redis
-    docker stop truvag3-redis 2>/dev/null || true
-    docker rm truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
     # Remove local binary
     rm -f "$SCRIPT_DIR/travel-research-agent"
@@ -544,7 +546,7 @@ check_redis_available() {
     fi
 
     # Check Docker Redis
-    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q truvag3-redis; then
+    if "${TRUVAG3_CONTAINER_RUNTIME:-docker}" ps --format '{{.Names}}' 2>/dev/null | grep -q truvag3-redis; then
         log_success "Redis available (Docker: truvag3-redis)"
         export REDIS_URL="redis://localhost:6379"
         return 0

--- a/examples/agent-with-resilience/setup.sh
+++ b/examples/agent-with-resilience/setup.sh
@@ -73,11 +73,11 @@ setup_redis() {
         echo "Starting Redis via Docker..."
 
         # Stop existing container if any
-        docker stop truvag3-redis 2>/dev/null || true
-        docker rm truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
         # Start Redis
-        docker run -d \
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" run -d \
             --name truvag3-redis \
             -p 6379:6379 \
             redis:7-alpine
@@ -280,20 +280,20 @@ build_docker() {
 
     # Build grocery-store-api (no local replace directives, uses local context)
     if [ -d "$GROCERY_API_DIR" ]; then
-        docker build $no_cache_flag -t grocery-store-api:latest "$GROCERY_API_DIR"
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag -t grocery-store-api:latest "$GROCERY_API_DIR"
         log_success "grocery-store-api:latest built"
     fi
 
     # Build grocery-tool with Dockerfile.workspace (has local replace directives)
     if [ -d "$GROCERY_TOOL_DIR" ]; then
         log_info "Building grocery-tool with Dockerfile.workspace (using local modules)..."
-        docker build $no_cache_flag -f "$GROCERY_TOOL_DIR/Dockerfile.workspace" -t grocery-tool:latest "$truvag3_root"
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag -f "$GROCERY_TOOL_DIR/Dockerfile.workspace" -t grocery-tool:latest "$truvag3_root"
         log_success "grocery-tool:latest built (from local workspace)"
     fi
 
     # Build agent with Dockerfile.workspace (has local replace directives)
     log_info "Building agent with Dockerfile.workspace (using local modules)..."
-    docker build $no_cache_flag -f "$AGENT_DIR/Dockerfile.workspace" -t research-agent-resilience:latest "$truvag3_root"
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag -f "$AGENT_DIR/Dockerfile.workspace" -t research-agent-resilience:latest "$truvag3_root"
     log_success "research-agent-resilience:latest built (from local workspace)"
 }
 
@@ -409,8 +409,8 @@ cleanup() {
     kubectl delete -f "$SCRIPT_DIR/k8-deployment.yaml" --ignore-not-found 2>/dev/null || true
 
     # Stop local Redis
-    docker stop truvag3-redis 2>/dev/null || true
-    docker rm truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
     # Remove local binary
     rm -f "$SCRIPT_DIR/research-agent-resilience"
@@ -439,7 +439,7 @@ check_redis_available() {
     fi
 
     # Check Docker Redis
-    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q truvag3-redis; then
+    if "${TRUVAG3_CONTAINER_RUNTIME:-docker}" ps --format '{{.Names}}' 2>/dev/null | grep -q truvag3-redis; then
         log_success "Redis available (Docker: truvag3-redis)"
         export REDIS_URL="redis://localhost:6379"
         return 0

--- a/examples/chat-ui/setup.sh
+++ b/examples/chat-ui/setup.sh
@@ -20,6 +20,10 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Shared environment library: container-runtime detection (docker/podman) and a
+# kind() wrapper that makes `kind load docker-image` work under podman.
+source "$(dirname "$SCRIPT_DIR")/k8-deployment/setup-env-lib.sh"
+
 # Configuration
 CLUSTER_NAME="truvag3-demo-$(whoami)"
 NAMESPACE="truvag3-examples"
@@ -49,13 +53,14 @@ print_header() {
 check_prerequisites() {
     log_info "Checking prerequisites..."
 
-    # Check Docker
-    if ! command -v docker &> /dev/null; then
-        log_error "Docker is not installed"
-        echo "Please install Docker from https://www.docker.com/"
+    # Check the resolved container runtime (docker or podman; set by the shared lib)
+    local runtime="${TRUVAG3_CONTAINER_RUNTIME:-docker}"
+    if ! command -v "$runtime" &> /dev/null; then
+        log_error "$runtime is not installed"
+        echo "Please install Docker (https://www.docker.com/) or Podman (https://podman.io/)"
         exit 1
     fi
-    log_success "Docker installed"
+    log_success "$runtime installed"
 
     # Check kubectl
     if ! command -v kubectl &> /dev/null; then
@@ -99,7 +104,7 @@ build_image() {
     fi
 
     log_info "Building Docker image..."
-    docker build $no_cache -t ${APP_NAME}:latest .
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache -t ${APP_NAME}:latest .
     log_success "${APP_NAME}:latest built"
 }
 

--- a/examples/devops-chat-agent/setup.sh
+++ b/examples/devops-chat-agent/setup.sh
@@ -60,11 +60,11 @@ setup_redis() {
         log_info "Starting Redis via Docker..."
 
         # Stop existing container if any
-        docker stop truvag3-redis 2>/dev/null || true
-        docker rm truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
         # Start Redis
-        docker run -d \
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" run -d \
             --name truvag3-redis \
             -p 6379:6379 \
             redis:7-alpine
@@ -455,8 +455,8 @@ cleanup() {
     kubectl delete -f "$SCRIPT_DIR/k8-deployment.yaml" --ignore-not-found 2>/dev/null || true
 
     # Stop local Redis
-    docker stop truvag3-redis 2>/dev/null || true
-    docker rm truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
     # Remove local binary
     rm -f "$SCRIPT_DIR/devops-chat-agent"

--- a/examples/event-driven-agent/setup.sh
+++ b/examples/event-driven-agent/setup.sh
@@ -109,7 +109,7 @@ docker_build() {
 
     # Build from truvag3 root using Dockerfile.workspace (local modules)
     cd "$TRUVAG3_ROOT"
-    docker build $no_cache_flag \
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag \
         -f examples/event-driven-agent/Dockerfile.workspace \
         -t $APP_NAME:latest .
     cd "$SCRIPT_DIR"

--- a/examples/github-pr-review-agent/setup.sh
+++ b/examples/github-pr-review-agent/setup.sh
@@ -46,9 +46,9 @@ setup_redis() {
     fi
     if [ "${DOCKER_AVAILABLE:-false}" = true ]; then
         log_info "Starting Redis via Docker..."
-        docker stop truvag3-redis 2>/dev/null || true
-        docker rm truvag3-redis 2>/dev/null || true
-        docker run -d --name truvag3-redis -p 6379:6379 redis:7-alpine
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" run -d --name truvag3-redis -p 6379:6379 redis:7-alpine
         log_success "Redis started on port 6379"
     else
         log_error "Redis not available. Install Redis or Docker."
@@ -362,8 +362,8 @@ cleanup() {
     kubectl delete -f "$SCRIPT_DIR/k8-deployment.yaml" --ignore-not-found 2>/dev/null || true
     kubectl delete -f "$SCRIPT_DIR/k8-deployment-api.yaml" --ignore-not-found 2>/dev/null || true
     kubectl delete -f "$SCRIPT_DIR/k8-deployment-worker.yaml" --ignore-not-found 2>/dev/null || true
-    docker stop truvag3-redis 2>/dev/null || true
-    docker rm truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
     rm -f "$SCRIPT_DIR/github-pr-review-agent"
     log_success "Cleanup complete"
 }

--- a/examples/github-tool/setup.sh
+++ b/examples/github-tool/setup.sh
@@ -46,9 +46,9 @@ setup_redis() {
     fi
     if [ "${DOCKER_AVAILABLE:-false}" = true ]; then
         log_info "Starting Redis via Docker..."
-        docker stop truvag3-redis 2>/dev/null || true
-        docker rm truvag3-redis 2>/dev/null || true
-        docker run -d --name truvag3-redis -p 6379:6379 redis:7-alpine
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" run -d --name truvag3-redis -p 6379:6379 redis:7-alpine
         log_success "Redis started on port 6379"
     else
         log_error "Redis not available. Install Redis or Docker."
@@ -242,8 +242,8 @@ cleanup() {
     log_info "Removing deployed resources..."
     kubectl delete -f "$SCRIPT_DIR/k8-deployment.yaml" --ignore-not-found 2>/dev/null || true
     kubectl delete secret github-tool-secrets -n "$NAMESPACE" --ignore-not-found 2>/dev/null || true
-    docker stop truvag3-redis 2>/dev/null || true
-    docker rm truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
     rm -f "$SCRIPT_DIR/github-tool"
     log_success "Cleanup complete"
 }

--- a/examples/k8-deployment/setup-env-lib.sh
+++ b/examples/k8-deployment/setup-env-lib.sh
@@ -94,6 +94,16 @@ _truvag3_log_success() {
     fi
 }
 
+_truvag3_log_warn() {
+    if type print_warn &>/dev/null; then
+        print_warn "$1"
+    elif type log_warn &>/dev/null; then
+        log_warn "$1"
+    else
+        echo "[WARN] $1"
+    fi
+}
+
 # ─── FUNCTIONS ───────────────────────────────────────────────────────────────
 
 # truvag3_create_secret <secret_name> <namespace> [extra_keys...]
@@ -324,11 +334,89 @@ truvag3_create_tool_secret() {
 # Auto-detect K8S_DEPLOYMENT_DIR (directory containing this file)
 TRUVAG3_K8S_DEPLOYMENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# truvag3_detect_container_runtime
+#
+# Resolves which container runtime to use (docker or podman) and exports it as
+# TRUVAG3_CONTAINER_RUNTIME so the rest of the scripts are engine-agnostic. Also
+# sets DOCKER_AVAILABLE for backward compatibility.
+#
+# Resolution order:
+#   1. An explicit TRUVAG3_CONTAINER_RUNTIME set by the caller is honored as-is.
+#   2. docker, but only if its daemon actually responds (`docker info`). A docker
+#      CLI with no running daemon (e.g. Docker Desktop/OrbStack stopped) is skipped.
+#   3. podman, if installed.
+#
+# When the resolved runtime is podman, KIND_EXPERIMENTAL_PROVIDER=podman is
+# exported so `kind` uses podman as well.
+truvag3_detect_container_runtime() {
+    # 1. Respect an explicit choice — but validate it so a typo or a missing
+    #    binary surfaces here with a clear message, not as a cryptic build error.
+    if [ -n "${TRUVAG3_CONTAINER_RUNTIME:-}" ]; then
+        case "$TRUVAG3_CONTAINER_RUNTIME" in
+            docker|podman) ;;
+            *)
+                echo "ERROR: TRUVAG3_CONTAINER_RUNTIME='$TRUVAG3_CONTAINER_RUNTIME' is not supported (use 'docker' or 'podman')"
+                exit 1 ;;
+        esac
+        if ! command -v "$TRUVAG3_CONTAINER_RUNTIME" &> /dev/null; then
+            # Binary not installed — mark unavailable (like the "no runtime found"
+            # branch) so build/Redis gates report it cleanly instead of trying to
+            # exec a missing binary. Not a hard exit: detection runs at source time
+            # for every subcommand, and status/logs/help shouldn't be blocked.
+            _truvag3_log_warn "Pinned runtime '$TRUVAG3_CONTAINER_RUNTIME' is not installed / not on PATH — build and deploy steps will fail until it is"
+            export DOCKER_AVAILABLE=false
+            return
+        elif ! "$TRUVAG3_CONTAINER_RUNTIME" info &> /dev/null; then
+            # Binary present but its daemon/machine is down. Warn (symmetric with
+            # the auto-detect ladder below) but still honor the choice and proceed:
+            # the build step will surface the real engine error.
+            if [ "$TRUVAG3_CONTAINER_RUNTIME" = "podman" ]; then
+                _truvag3_log_warn "Pinned runtime 'podman' is installed but its machine is not running; run 'podman machine start'"
+            else
+                _truvag3_log_warn "Pinned runtime 'docker' is installed but its daemon is not responding; start Docker"
+            fi
+        else
+            _truvag3_log_success "Container runtime (pinned): $TRUVAG3_CONTAINER_RUNTIME"
+        fi
+    # 2. Prefer docker if its daemon is reachable.
+    elif command -v docker &> /dev/null && docker info &> /dev/null; then
+        export TRUVAG3_CONTAINER_RUNTIME=docker
+        _truvag3_log_success "Container runtime: docker"
+    # 3. Otherwise podman, but only if its machine is actually running
+    #    (symmetric with the docker daemon check above — a stopped podman machine
+    #    would otherwise be picked silently and then fail at build time).
+    elif command -v podman &> /dev/null && podman info &> /dev/null; then
+        export TRUVAG3_CONTAINER_RUNTIME=podman
+        _truvag3_log_success "Container runtime: podman"
+    # 4. A CLI is installed but its daemon/machine isn't up. Pick it and warn so
+    #    the next step fails with a clear "start your runtime" message rather than
+    #    a silent wrong choice. Docker is preferred when both are down.
+    elif command -v docker &> /dev/null; then
+        export TRUVAG3_CONTAINER_RUNTIME=docker
+        _truvag3_log_warn "docker found but its daemon is not responding; start Docker (or start/install podman)"
+    elif command -v podman &> /dev/null; then
+        export TRUVAG3_CONTAINER_RUNTIME=podman
+        _truvag3_log_warn "podman found but its machine is not running; run 'podman machine start' (or start/install Docker)"
+    else
+        export TRUVAG3_CONTAINER_RUNTIME=docker
+        _truvag3_log_info "No container runtime found (docker or podman required for K8s deployment)"
+        export DOCKER_AVAILABLE=false
+        return
+    fi
+
+    export DOCKER_AVAILABLE=true
+
+    # kind needs to be told to use podman explicitly; docker is its default.
+    if [ "$TRUVAG3_CONTAINER_RUNTIME" = "podman" ]; then
+        export KIND_EXPERIMENTAL_PROVIDER=podman
+    fi
+}
+
 # truvag3_check_prerequisites
 #
-# Checks that required tools are installed: go, docker, kind, kubectl.
-# Marks optional tools as available via DOCKER_AVAILABLE, KIND_AVAILABLE, etc.
-# Exits with error if Go is not installed.
+# Checks that required tools are installed: go, a container runtime
+# (docker or podman), kind, kubectl. Marks optional tools as available via
+# DOCKER_AVAILABLE, KIND_AVAILABLE, etc. Exits with error if Go is not installed.
 truvag3_check_prerequisites() {
     _truvag3_log_info "Checking prerequisites..."
 
@@ -338,13 +426,7 @@ truvag3_check_prerequisites() {
     fi
     _truvag3_log_success "Go installed: $(go version)"
 
-    if command -v docker &> /dev/null; then
-        _truvag3_log_success "Docker installed"
-        export DOCKER_AVAILABLE=true
-    else
-        _truvag3_log_info "Docker not found (required for K8s deployment)"
-        export DOCKER_AVAILABLE=false
-    fi
+    truvag3_detect_container_runtime
 
     if command -v kubectl &> /dev/null; then
         _truvag3_log_success "kubectl installed"
@@ -627,8 +709,74 @@ truvag3_build_docker() {
         _truvag3_log_info "Building $image_name..."
     fi
 
-    docker build $no_cache_flag -f "$dockerfile" -t "$image_name" "$context"
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag -f "$dockerfile" -t "$image_name" "$context"
     _truvag3_log_success "$image_name built"
+}
+
+# _truvag3_podman_load_image <image_name> <cluster_name>
+#
+# Loads a podman-built image into a Kind cluster via a saved archive.
+#
+# Why not `kind load docker-image`? With the podman provider that path is
+# unreliable, and podman tags local builds as `localhost/<name>` — which
+# containerd on the node will NOT match against a manifest's bare
+# `image: <name>:tag` (containerd normalizes that to `docker.io/library/<name>:tag`).
+# So we retag to the normalized ref, then load it as an image archive.
+_truvag3_podman_load_image() {
+    local image_name="$1"
+    local cluster_name="$2"
+
+    local node_ref="$image_name"
+    case "$image_name" in
+        */*) : ;;                                   # already namespaced/registry-qualified
+        *)   node_ref="docker.io/library/$image_name" ;;
+    esac
+    if [ "$node_ref" != "$image_name" ]; then
+        podman tag "$image_name" "$node_ref"
+    fi
+
+    local archive
+    archive="$(mktemp -t kind-img-XXXXXX).tar"
+    podman save -o "$archive" "$node_ref"
+    command kind load image-archive "$archive" --name "$cluster_name"
+    rm -f "$archive"
+}
+
+# kind() — transparent wrapper around the real `kind` binary.
+#
+# When the resolved runtime is podman, `kind load docker-image <imgs...> --name <c>`
+# is rewritten to the archive-based load (see _truvag3_podman_load_image), since
+# `kind load docker-image` does not work reliably with podman. Every other kind
+# invocation (create/get/load image-archive/etc.) passes straight through.
+#
+# This lets the many example scripts that call `kind load docker-image` inline
+# work under podman without each one being modified.
+kind() {
+    if [ "${TRUVAG3_CONTAINER_RUNTIME:-docker}" = "podman" ] && \
+       [ "${1:-}" = "load" ] && [ "${2:-}" = "docker-image" ]; then
+        shift 2
+        local images=() cluster=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --name)   cluster="$2"; shift 2 ;;
+                --name=*) cluster="${1#--name=}"; shift ;;
+                *)        images+=("$1"); shift ;;
+            esac
+        done
+        # Fall back to the current kind context if --name was omitted.
+        if [ -z "$cluster" ]; then
+            local ctx
+            ctx=$(kubectl config current-context 2>/dev/null)
+            [[ "$ctx" == kind-* ]] && cluster="${ctx#kind-}"
+            [ -z "$cluster" ] && cluster="${CLUSTER_NAME:-}"
+        fi
+        local img
+        for img in "${images[@]}"; do
+            _truvag3_podman_load_image "$img" "$cluster"
+        done
+        return $?
+    fi
+    command kind "$@"
 }
 
 # truvag3_load_to_kind <image_name> [cluster_name]
@@ -665,6 +813,24 @@ truvag3_load_to_kind() {
     fi
 
     _truvag3_log_info "Loading $image_name to Kind cluster '$cluster_name'..."
-    kind load docker-image --name "$cluster_name" "$image_name"
+
+    if [ "${TRUVAG3_CONTAINER_RUNTIME:-docker}" = "podman" ]; then
+        _truvag3_podman_load_image "$image_name" "$cluster_name"
+    else
+        command kind load docker-image --name "$cluster_name" "$image_name"
+    fi
+
     _truvag3_log_success "$image_name loaded to Kind"
 }
+
+# ─── SOURCE-TIME RUNTIME DETECTION ───────────────────────────────────────────
+# Resolve the container runtime as soon as the library is sourced so that
+# TRUVAG3_CONTAINER_RUNTIME (and KIND_EXPERIMENTAL_PROVIDER for podman) are set
+# for every script — including the many tool setup.sh scripts that build/load
+# images without first calling truvag3_check_prerequisites.
+#
+# Always call this, even when TRUVAG3_CONTAINER_RUNTIME is already pinned: the
+# function honors the pinned value but ALSO exports KIND_EXPERIMENTAL_PROVIDER
+# and DOCKER_AVAILABLE for it. Guarding on the pinned var would skip those
+# exports, leaving kind without its podman provider on the source-time path.
+truvag3_detect_container_runtime

--- a/examples/my-async-agent/setup.sh
+++ b/examples/my-async-agent/setup.sh
@@ -109,7 +109,7 @@ docker_build() {
 
     # Build from truvag3 root using Dockerfile.workspace (local modules)
     cd "$TRUVAG3_ROOT"
-    docker build $no_cache_flag \
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag \
         -f examples/my-async-agent/Dockerfile.workspace \
         -t $APP_NAME:latest .
     cd "$SCRIPT_DIR"

--- a/examples/my-streaming-agent/setup.sh
+++ b/examples/my-streaming-agent/setup.sh
@@ -59,11 +59,11 @@ setup_redis() {
         log_info "Starting Redis via Docker..."
 
         # Stop existing container if any
-        docker stop truvag3-redis 2>/dev/null || true
-        docker rm truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
         # Start Redis
-        docker run -d \
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" run -d \
             --name truvag3-redis \
             -p 6379:6379 \
             redis:7-alpine
@@ -457,8 +457,8 @@ cleanup() {
     kubectl delete -f "$SCRIPT_DIR/k8-deployment.yaml" --ignore-not-found 2>/dev/null || true
 
     # Stop local Redis
-    docker stop truvag3-redis 2>/dev/null || true
-    docker rm truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
     # Remove local binary
     rm -f "$SCRIPT_DIR/my-streaming-agent"

--- a/examples/qa-agent/setup.sh
+++ b/examples/qa-agent/setup.sh
@@ -94,7 +94,7 @@ cmd_docker_build() {
 
     local truvag3_root="$(dirname "$(dirname "$SCRIPT_DIR")")"
     print_info "Building from truvag3 root: $truvag3_root"
-    docker build $no_cache_flag \
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag \
         -f "$SCRIPT_DIR/Dockerfile.workspace" \
         -t $APP_NAME:latest \
         "$truvag3_root"

--- a/examples/registry-viewer-app/setup.sh
+++ b/examples/registry-viewer-app/setup.sh
@@ -11,6 +11,10 @@ EXAMPLES_DIR="$(dirname "$SCRIPT_DIR")"
 TRUVAG3_ROOT="$(dirname "$EXAMPLES_DIR")"
 K8_DEPLOYMENT_DIR="$EXAMPLES_DIR/k8-deployment"
 
+# Shared environment library: container-runtime detection (docker/podman) and a
+# kind() wrapper that makes `kind load docker-image` work under podman.
+source "$K8_DEPLOYMENT_DIR/setup-env-lib.sh"
+
 # Configuration
 NAMESPACE="truvag3-examples"
 APP_NAME="registry-viewer"
@@ -87,12 +91,15 @@ check_prerequisites() {
     fi
     log_success "Go installed: $(go version)"
 
-    # Check Docker (optional)
-    if command -v docker &> /dev/null; then
-        log_success "Docker installed"
+    # Container runtime (docker or podman) — resolved by the shared lib at source
+    # time. Check the resolved runtime, not docker specifically, so a podman-only
+    # host isn't wrongly flagged as having no runtime.
+    local runtime="${TRUVAG3_CONTAINER_RUNTIME:-docker}"
+    if command -v "$runtime" &> /dev/null; then
+        log_success "$runtime installed"
         DOCKER_AVAILABLE=true
     else
-        log_warn "Docker not found (required for K8s deployment)"
+        log_warn "$runtime not found (required for K8s deployment)"
         DOCKER_AVAILABLE=false
     fi
 
@@ -155,7 +162,7 @@ build_docker() {
     # Build from truvag3 root using Dockerfile.workspace
     # This allows copying local modules (core, orchestration, telemetry) into the build context
     cd "$TRUVAG3_ROOT"
-    docker build $no_cache_flag \
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag \
         -f examples/registry-viewer-app/Dockerfile.workspace \
         -t "$IMAGE_NAME" .
 
@@ -407,7 +414,7 @@ status() {
 
     echo ""
     echo "Docker:"
-    if docker image inspect "$IMAGE_NAME" &>/dev/null 2>&1; then
+    if "${TRUVAG3_CONTAINER_RUNTIME:-docker}" image inspect "$IMAGE_NAME" &>/dev/null 2>&1; then
         echo "  Image: EXISTS"
     else
         echo "  Image: NOT FOUND"
@@ -516,13 +523,13 @@ docker_run() {
     fi
 
     # Build if image doesn't exist
-    if ! docker image inspect "$IMAGE_NAME" &>/dev/null 2>&1; then
+    if ! "${TRUVAG3_CONTAINER_RUNTIME:-docker}" image inspect "$IMAGE_NAME" &>/dev/null 2>&1; then
         build_docker
     fi
 
     # Stop existing container
-    docker stop $APP_NAME 2>/dev/null || true
-    docker rm $APP_NAME 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop $APP_NAME 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm $APP_NAME 2>/dev/null || true
 
     local redis_arg=""
     if [ "$1" = "redis" ]; then
@@ -538,7 +545,7 @@ docker_run() {
     echo "Press Ctrl+C to stop"
     echo ""
 
-    docker run --rm -p $APP_PORT:$APP_PORT --name $APP_NAME "$IMAGE_NAME" $redis_arg
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" run --rm -p $APP_PORT:$APP_PORT --name $APP_NAME "$IMAGE_NAME" $redis_arg
 }
 
 # Handle arguments

--- a/examples/scheduled-executor/setup.sh
+++ b/examples/scheduled-executor/setup.sh
@@ -62,9 +62,9 @@ setup_redis() {
 
     if [ "${DOCKER_AVAILABLE:-false}" = true ]; then
         print_info "Starting Redis via Docker..."
-        docker stop truvag3-redis 2>/dev/null || true
-        docker rm truvag3-redis 2>/dev/null || true
-        docker run -d \
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" run -d \
             --name truvag3-redis \
             -p 6379:6379 \
             redis:7-alpine

--- a/examples/tool-example/setup.sh
+++ b/examples/tool-example/setup.sh
@@ -101,7 +101,7 @@ cmd_docker_build() {
     # Build from truvag3 root using Dockerfile.workspace (local modules)
     local truvag3_root="$(dirname "$(dirname "$SCRIPT_DIR")")"
     print_info "Building from truvag3 root: $truvag3_root"
-    docker build $no_cache_flag \
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" build $no_cache_flag \
         -f "$SCRIPT_DIR/Dockerfile.workspace" \
         -t $APP_NAME:latest \
         "$truvag3_root"

--- a/examples/travel-chat-agent/setup.sh
+++ b/examples/travel-chat-agent/setup.sh
@@ -59,11 +59,11 @@ setup_redis() {
         log_info "Starting Redis via Docker..."
 
         # Stop existing container if any
-        docker stop truvag3-redis 2>/dev/null || true
-        docker rm truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
         # Start Redis
-        docker run -d \
+        "${TRUVAG3_CONTAINER_RUNTIME:-docker}" run -d \
             --name truvag3-redis \
             -p 6379:6379 \
             redis:7-alpine
@@ -245,7 +245,7 @@ build_docker() {
 # Load images to Kind
 load_to_kind() {
     truvag3_load_to_kind "travel-chat-agent:latest"
-    if docker image inspect chat-ui:latest &>/dev/null; then
+    if "${TRUVAG3_CONTAINER_RUNTIME:-docker}" image inspect chat-ui:latest &>/dev/null; then
         truvag3_load_to_kind "chat-ui:latest"
     fi
 }
@@ -550,8 +550,8 @@ cleanup() {
     kubectl delete -f "$SCRIPT_DIR/k8-deployment.yaml" --ignore-not-found 2>/dev/null || true
 
     # Stop local Redis
-    docker stop truvag3-redis 2>/dev/null || true
-    docker rm truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" stop truvag3-redis 2>/dev/null || true
+    "${TRUVAG3_CONTAINER_RUNTIME:-docker}" rm truvag3-redis 2>/dev/null || true
 
     # Remove local binary
     rm -f "$SCRIPT_DIR/travel-chat-agent"


### PR DESCRIPTION
## What & why

The example `setup.sh` scripts and the shared `setup-env-lib.sh` hard-coded `docker`, so a **podman-only host failed before any runtime support could kick in**. This makes the whole setup path detect and use either runtime, so podman becomes the drop-in the docs already claim it is.

## Changes

**Runtime detection — `examples/k8-deployment/setup-env-lib.sh`** (resolved once, exported as `TRUVAG3_CONTAINER_RUNTIME`, every script keys off it):
- Prefers `docker` when its daemon is reachable, falls back to `podman` when its machine is running, and warns clearly when a runtime is installed but its daemon/machine is down. The same health check + warnings apply to an explicitly pinned `TRUVAG3_CONTAINER_RUNTIME`; an unsupported pin exits 1.
- A `kind()` wrapper transparently rewrites `kind load docker-image` to `podman save | kind load image-archive` (retagged to `docker.io/library/<name>` so containerd matches the manifest) — the `docker-image` path is unreliable under podman.
- Exports `KIND_EXPERIMENTAL_PROVIDER=podman` when podman is selected.
- Per-script prerequisite gates that hard-required docker now check the resolved runtime; `chat-ui` and `registry-viewer-app` (which didn't source the lib) now do.

**Build fix:** bumps the generated `go.work` directive `1.26.2 → 1.26.3` in three `Dockerfile.workspace` files, which otherwise fail `go mod download` against framework modules that now require 1.26.3.

**Docs:**
- New `docs/reference/PODMAN_TROUBLESHOOTING.md` (rootful machine, image loading, gvproxy ingress flakiness, machine sizing), linked from `GETTING_STARTED.md` and `README.md`.
- `GETTING_STARTED.md` podman section: drops `alias docker=podman` (aliases don't reach non-interactive `setup.sh`) in favor of `export TRUVAG3_CONTAINER_RUNTIME=podman`, removes the compose reference (k8s-only), and adds `scheduler-tool` to the travel quickstart's no-key tool set.
- `.gitignore`: ignore `.claude/`.

## Testing

Verified end-to-end on **podman** and **Docker/OrbStack**:
- travel-chat-agent quickstart (`full-deploy` + tools) comes up clean on **both** runtimes — agent discovers its tools, streaming chat returns live results.
- devops-chat-agent quickstart verified on **podman** (agent answers via `devops-tool`/kubectl).

## Note for reviewers

`github-tool` and `github-pr-review-agent` `setup.sh` received the same mechanical `docker → ${TRUVAG3_CONTAINER_RUNTIME}` sweep for consistency but were **not** deployment-tested (they need credentials and were out of scope). They pass `bash -n` and contain only the sweep changes.
