### PR TITLE
chore: bump inter-module requires to v0.2.0 + retract v0.1.0 (publish prep)

### DIFF
--- a/ai/go.mod
+++ b/ai/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.24
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.5
 	github.com/stretchr/testify v1.11.1
-	github.com/truvaagents/truva-g3/core v0.8.2
-	github.com/truvaagents/truva-g3/telemetry v0.8.2
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/agent-example/go.mod
+++ b/examples/agent-example/go.mod
@@ -4,9 +4,9 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 )
 
 // Use local workspace modules for development

--- a/examples/agent-with-async/go.mod
+++ b/examples/agent-with-async/go.mod
@@ -4,10 +4,10 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 )
 
 require (

--- a/examples/agent-with-human-approval/go.mod
+++ b/examples/agent-with-human-approval/go.mod
@@ -5,10 +5,10 @@ go 1.26.4
 require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/agent-with-orchestration/go.mod
+++ b/examples/agent-with-orchestration/go.mod
@@ -4,10 +4,10 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/agent-with-resilience/go.mod
+++ b/examples/agent-with-resilience/go.mod
@@ -4,10 +4,10 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/resilience v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/resilience v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 )
 
 // Use local workspace modules for development

--- a/examples/agent-with-telemetry/go.mod
+++ b/examples/agent-with-telemetry/go.mod
@@ -4,9 +4,9 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/agentic-memory-tool/go.mod
+++ b/examples/agentic-memory-tool/go.mod
@@ -4,10 +4,10 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/memory v0.0.0-00010101000000-000000000000
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/memory v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/arxiv-tool/go.mod
+++ b/examples/arxiv-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/arxiv-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/clinical-trials-tool/go.mod
+++ b/examples/clinical-trials-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/clinical-trials-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/confluence-tool/go.mod
+++ b/examples/confluence-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/confluence-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/country-info-tool/go.mod
+++ b/examples/country-info-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/country-info-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/currency-global-tool/go.mod
+++ b/examples/currency-global-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/currency-global-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/currency-tool/go.mod
+++ b/examples/currency-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/currency-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 )

--- a/examples/demographics-tool/go.mod
+++ b/examples/demographics-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/demographics-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/devops-chat-agent/go.mod
+++ b/examples/devops-chat-agent/go.mod
@@ -5,11 +5,11 @@ go 1.26.4
 require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/memory v0.0.0-00010101000000-000000000000
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/memory v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/devops-observability-tool/go.mod
+++ b/examples/devops-observability-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/devops-observability-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/devops-tool/go.mod
+++ b/examples/devops-tool/go.mod
@@ -4,8 +4,8 @@ go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/economic-data-tool/go.mod
+++ b/examples/economic-data-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/economic-data-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/event-driven-agent/go.mod
+++ b/examples/event-driven-agent/go.mod
@@ -4,11 +4,11 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/memory v0.0.0-00010101000000-000000000000
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/memory v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 )

--- a/examples/fiscal-data-tool/go.mod
+++ b/examples/fiscal-data-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/fiscal-data-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/flight-tool/go.mod
+++ b/examples/flight-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/flight-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/geocoding-tool/go.mod
+++ b/examples/geocoding-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/geocoding-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 )

--- a/examples/github-pr-review-agent/go.mod
+++ b/examples/github-pr-review-agent/go.mod
@@ -5,11 +5,11 @@ go 1.26.4
 require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/memory v0.9.1
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/memory v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 )

--- a/examples/github-tool/go.mod
+++ b/examples/github-tool/go.mod
@@ -4,8 +4,8 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/grocery-tool/go.mod
+++ b/examples/grocery-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/grocery-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/hotel-tool/go.mod
+++ b/examples/hotel-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/hotel-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/jira-tool/go.mod
+++ b/examples/jira-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/jira-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/my-async-agent/go.mod
+++ b/examples/my-async-agent/go.mod
@@ -3,10 +3,10 @@ module github.com/truvaagents/truva-g3/examples/my-async-agent
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 )
 
 // Use local workspace modules for development

--- a/examples/my-streaming-agent/go.mod
+++ b/examples/my-streaming-agent/go.mod
@@ -3,10 +3,10 @@ module github.com/truvaagents/truva-g3/examples/my-streaming-agent
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 )
 
 // Use local workspace modules for development

--- a/examples/my-tool/go.mod
+++ b/examples/my-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/my-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 )
 
 // Use local workspace modules for development

--- a/examples/news-tool/go.mod
+++ b/examples/news-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/news-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 )

--- a/examples/openclaw-tool/go.mod
+++ b/examples/openclaw-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/openclaw-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/openfda-tool/go.mod
+++ b/examples/openfda-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/openfda-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/places-tool/go.mod
+++ b/examples/places-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/places-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/playwright-tool/go.mod
+++ b/examples/playwright-tool/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/prometheus-query-tool/go.mod
+++ b/examples/prometheus-query-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/prometheus-query-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/pubmed-tool/go.mod
+++ b/examples/pubmed-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/pubmed-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 	golang.org/x/time v0.9.0
 )

--- a/examples/qa-agent/go.mod
+++ b/examples/qa-agent/go.mod
@@ -4,11 +4,11 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/memory v0.0.0-00010101000000-000000000000
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/memory v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/registry-viewer-app/go.mod
+++ b/examples/registry-viewer-app/go.mod
@@ -4,9 +4,9 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/memory v0.0.0
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/memory v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
 	golang.org/x/sync v0.20.0
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/qdrant/go-client v1.18.2 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
-	github.com/truvaagents/truva-g3/telemetry v0.8.2 // indirect
+	github.com/truvaagents/truva-g3/telemetry v0.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect

--- a/examples/scheduled-executor/go.mod
+++ b/examples/scheduled-executor/go.mod
@@ -4,9 +4,9 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/scheduler-tool/go.mod
+++ b/examples/scheduler-tool/go.mod
@@ -4,10 +4,10 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/memory v0.9.1
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/memory v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 )
 
 require (

--- a/examples/semantic-scholar-tool/go.mod
+++ b/examples/semantic-scholar-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/semantic-scholar-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/slack-tool/go.mod
+++ b/examples/slack-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/slack-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/stock-market-tool/go.mod
+++ b/examples/stock-market-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/stock-market-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/system-utilities-tool/go.mod
+++ b/examples/system-utilities-tool/go.mod
@@ -4,8 +4,8 @@ go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/tool-example/go.mod
+++ b/examples/tool-example/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/tool-example
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/travel-advisory-tool/go.mod
+++ b/examples/travel-advisory-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/travel-advisory-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/travel-chat-agent/go.mod
+++ b/examples/travel-chat-agent/go.mod
@@ -5,11 +5,11 @@ go 1.26.4
 require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/ai v0.9.1
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/memory v0.9.1
-	github.com/truvaagents/truva-g3/orchestration v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/ai v0.2.0
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/memory v0.2.0
+	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/weather-tool-v2/go.mod
+++ b/examples/weather-tool-v2/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/weather-tool-v2
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 )

--- a/examples/web-search-tool/go.mod
+++ b/examples/web-search-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/web-search-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/world-health-tool/go.mod
+++ b/examples/world-health-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/world-health-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.9.1
-	github.com/truvaagents/truva-g3/telemetry v0.9.1
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/truvaagents/truva-g3
 
 go 1.26.4
 
-require github.com/truvaagents/truva-g3/core v0.0.0-00010101000000-000000000000
+require github.com/truvaagents/truva-g3/core v0.2.0
 
 replace github.com/truvaagents/truva-g3/core => ./core
 
@@ -13,3 +13,8 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 )
+
+// v0.1.0 was published from a workspace with relative replace directives and an
+// unresolvable core requirement, so external consumers cannot build it. It is
+// superseded by v0.2.0.
+retract v0.1.0

--- a/memory/go.mod
+++ b/memory/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/qdrant/go-client v1.18.2
 	github.com/stretchr/testify v1.11.1
-	github.com/truvaagents/truva-g3/core v0.8.2
-	github.com/truvaagents/truva-g3/telemetry v0.0.0-00010101000000-000000000000
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0

--- a/orchestration/go.mod
+++ b/orchestration/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
-	github.com/truvaagents/truva-g3/core v0.8.2
-	github.com/truvaagents/truva-g3/telemetry v0.8.2
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0

--- a/resilience/go.mod
+++ b/resilience/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/resilience
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.8.2
-	github.com/truvaagents/truva-g3/telemetry v0.8.2
+	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/telemetry v0.2.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/metric v1.44.0
 )

--- a/telemetry/go.mod
+++ b/telemetry/go.mod
@@ -7,7 +7,7 @@ replace github.com/truvaagents/truva-g3/core => ../core
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/core v0.8.2
+	github.com/truvaagents/truva-g3/core v0.2.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0


### PR DESCRIPTION
## Phase 1 of publishing the framework Go modules to pkg.go.dev / deps.dev

This is the **prep** step. It makes every module's `go.mod` release-ready and CI-green, but **publishes nothing** — no tags are pushed here. Tagging (`core/v0.2.0` → … → `v0.2.0`) is a separate Phase 2, done after this merges.

### What this changes (57 `go.mod`s, zero `.go` files)
- **Framework modules** (`core`, `telemetry`, `ai`, `orchestration`, `resilience`, `memory`, root): point all inter-module `require`s at **`v0.2.0`** and add **`retract v0.1.0`** to the root module. The published `v0.1.0` carries a relative `replace` + an unresolvable `core` require, so external consumers cannot build it.
- **Examples** (51): normalize framework `require`s from the phantom `v0.9.1` to `v0.2.0`.

### Why the relative `replace` directives are intentionally KEPT
Go 1.17+ module-graph pruning must read each *required* module's `go.mod`. A `replace` redirects that read to local disk; `go.work use` does **not** (it only redirects package resolution). So removing the replaces before the `v0.2.0` tags exist breaks `go build` / `go test` / `go vet` with `unknown revision core/v0.2.0`.

The replaces are therefore load-bearing until tagging, and are dropped **per-module at tag time** in Phase 2 (`go mod edit -dropreplace` → `go mod tidy` → tag, bottom-up). Example replaces stay **permanently** — the default `Dockerfile.workspace` build resolves the framework from local source through them.

### Why `v0.2.0`
Honest successor to the burned `v0.1.0`; keeps runway before the `v1.0.0` / `/v2` semantic-import-versioning commitment. All seven modules are co-versioned.

### Validation
Full local run of the CI jobs (mirrors `.github/workflows/ci.yml`, on go1.26.5), all green across every module:
- **test** — `go build ./...` + `go test -race ./...`
- **lint** — golangci-lint v2.11.4 `run ./...`
- **vuln** — govulncheck v1.1.4 `./...`
- **examples** — `GOWORK=off`, `go mod tidy && go build ./...`

Rebased onto the latest `main` (including the `x/net v0.55.0` and `go.work → go1.26.5` security fixes); the example dep bumps were merged and only our `v0.2.0` normalization re-applied on top.
