### PR TITLE
chore(telemetry): drop core replace + tidy for telemetry/v0.2.0

### DIFF
--- a/telemetry/go.mod
+++ b/telemetry/go.mod
@@ -2,8 +2,6 @@ module github.com/truvaagents/truva-g3/telemetry
 
 go 1.26.4
 
-replace github.com/truvaagents/truva-g3/core => ../core
-
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/go-redis/redis/v8 v8.11.5

--- a/telemetry/go.sum
+++ b/telemetry/go.sum
@@ -37,6 +37,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/truvaagents/truva-g3/core v0.2.0 h1:EStsfUSsoMRWKyspFvN1Csg7W5H6HWmr8DLJMA1PHlc=
+github.com/truvaagents/truva-g3/core v0.2.0/go.mod h1:htx9LSkj39jVTDhE8e/i5C3+xOrkzCsXYgbdMEcBhEg=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
## Phase 2 · step 2/7 — publish `telemetry/v0.2.0`

`core/v0.2.0` is now live on `proxy.golang.org`, so `telemetry` can depend on it as a real, published module. This PR:

- drops `telemetry`'s relative `replace … => ../core`
- `go mod tidy` (`GOWORK=off`) → `go.sum` gains the published `core v0.2.0` hashes

**Diff:** `telemetry/go.mod` (−1 `replace` line), `telemetry/go.sum` (+2 lines). No `.go` changes.

**Local validation:** `telemetry` builds standalone (`GOWORK=off`, external-consumer resolution) and in the workspace; `go vet` + `go test -race` green; a dependent (`ai`) still builds.

`main` stays green — the `core` version `telemetry` now requires already exists on the proxy.

### After merge
`telemetry/v0.2.0` gets tagged at the merge commit and warmed. This is a prerequisite for the next PR (`ai`, `orchestration`, `resilience`, `memory`, and root all require `telemetry@v0.2.0`).

Part of the multi-module publish of the framework to pkg.go.dev / deps.dev.
