### PR TITLE
chore: drop framework replaces + tidy for v0.2.0 (final publish step)

### DIFF
--- a/ai/go.mod
+++ b/ai/go.mod
@@ -2,10 +2,6 @@ module github.com/truvaagents/truva-g3/ai
 
 go 1.26.4
 
-replace github.com/truvaagents/truva-g3/core => ../core
-
-replace github.com/truvaagents/truva-g3/telemetry => ../telemetry
-
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.25

--- a/ai/go.sum
+++ b/ai/go.sum
@@ -75,6 +75,10 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/truvaagents/truva-g3/core v0.2.0 h1:EStsfUSsoMRWKyspFvN1Csg7W5H6HWmr8DLJMA1PHlc=
+github.com/truvaagents/truva-g3/core v0.2.0/go.mod h1:htx9LSkj39jVTDhE8e/i5C3+xOrkzCsXYgbdMEcBhEg=
+github.com/truvaagents/truva-g3/telemetry v0.2.0 h1:7nJirE9DFUH1c3Vps7LA1u0v/fYwizmZajfTRP3pwFE=
+github.com/truvaagents/truva-g3/telemetry v0.2.0/go.mod h1:Z7c1KDUeYBqzP2m9k8hPvoAZsZPXOpflRZHX2ewstC4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.26.4
 
 require github.com/truvaagents/truva-g3/core v0.2.0
 
-replace github.com/truvaagents/truva-g3/core => ./core
-
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/truvaagents/truva-g3/core v0.2.0 h1:EStsfUSsoMRWKyspFvN1Csg7W5H6HWmr8DLJMA1PHlc=
+github.com/truvaagents/truva-g3/core v0.2.0/go.mod h1:htx9LSkj39jVTDhE8e/i5C3+xOrkzCsXYgbdMEcBhEg=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=

--- a/memory/go.mod
+++ b/memory/go.mod
@@ -2,10 +2,6 @@ module github.com/truvaagents/truva-g3/memory
 
 go 1.26.4
 
-replace github.com/truvaagents/truva-g3/core => ../core
-
-replace github.com/truvaagents/truva-g3/telemetry => ../telemetry
-
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/go-redis/redis/v8 v8.11.5

--- a/memory/go.sum
+++ b/memory/go.sum
@@ -45,6 +45,10 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/truvaagents/truva-g3/core v0.2.0 h1:EStsfUSsoMRWKyspFvN1Csg7W5H6HWmr8DLJMA1PHlc=
+github.com/truvaagents/truva-g3/core v0.2.0/go.mod h1:htx9LSkj39jVTDhE8e/i5C3+xOrkzCsXYgbdMEcBhEg=
+github.com/truvaagents/truva-g3/telemetry v0.2.0 h1:7nJirE9DFUH1c3Vps7LA1u0v/fYwizmZajfTRP3pwFE=
+github.com/truvaagents/truva-g3/telemetry v0.2.0/go.mod h1:Z7c1KDUeYBqzP2m9k8hPvoAZsZPXOpflRZHX2ewstC4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/orchestration/go.mod
+++ b/orchestration/go.mod
@@ -2,10 +2,6 @@ module github.com/truvaagents/truva-g3/orchestration
 
 go 1.26.4
 
-replace github.com/truvaagents/truva-g3/core => ../core
-
-replace github.com/truvaagents/truva-g3/telemetry => ../telemetry
-
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/go-redis/redis/v8 v8.11.5

--- a/orchestration/go.sum
+++ b/orchestration/go.sum
@@ -45,6 +45,10 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/truvaagents/truva-g3/core v0.2.0 h1:EStsfUSsoMRWKyspFvN1Csg7W5H6HWmr8DLJMA1PHlc=
+github.com/truvaagents/truva-g3/core v0.2.0/go.mod h1:htx9LSkj39jVTDhE8e/i5C3+xOrkzCsXYgbdMEcBhEg=
+github.com/truvaagents/truva-g3/telemetry v0.2.0 h1:7nJirE9DFUH1c3Vps7LA1u0v/fYwizmZajfTRP3pwFE=
+github.com/truvaagents/truva-g3/telemetry v0.2.0/go.mod h1:Z7c1KDUeYBqzP2m9k8hPvoAZsZPXOpflRZHX2ewstC4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/resilience/go.mod
+++ b/resilience/go.mod
@@ -36,7 +36,3 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
-
-replace github.com/truvaagents/truva-g3/core => ../core
-
-replace github.com/truvaagents/truva-g3/telemetry => ../telemetry

--- a/resilience/go.sum
+++ b/resilience/go.sum
@@ -37,6 +37,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/truvaagents/truva-g3/core v0.2.0 h1:EStsfUSsoMRWKyspFvN1Csg7W5H6HWmr8DLJMA1PHlc=
+github.com/truvaagents/truva-g3/core v0.2.0/go.mod h1:htx9LSkj39jVTDhE8e/i5C3+xOrkzCsXYgbdMEcBhEg=
+github.com/truvaagents/truva-g3/telemetry v0.2.0 h1:7nJirE9DFUH1c3Vps7LA1u0v/fYwizmZajfTRP3pwFE=
+github.com/truvaagents/truva-g3/telemetry v0.2.0/go.mod h1:Z7c1KDUeYBqzP2m9k8hPvoAZsZPXOpflRZHX2ewstC4=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
## Phase 2 · final step — publish `ai`, `orchestration`, `resilience`, `memory`, root

`core/v0.2.0` and `telemetry/v0.2.0` are now live on `proxy.golang.org`, so every remaining module can depend on them as real, published modules. This PR drops the last of the relative replaces:

- for `ai`, `orchestration`, `resilience`, `memory`, and root: `go mod edit -dropreplace …/core …/telemetry`
- `go mod tidy` (`GOWORK=off`) → each `go.sum` gains the published `core@v0.2.0` / `telemetry@v0.2.0` hashes

**Diff:** 5 `go.mod` (only `replace`-line removals — no external dep changes) + 5 `go.sum` (`+18` internal hash lines). No `.go` changes.

**Local validation:** all five build **standalone** (`GOWORK=off`, external-consumer resolution); the **whole workspace** still builds (all framework replaces are now gone — `go.work` + the published `v0.2.0` requires resolve cleanly).

After this merges, **no framework module has any relative `replace` left** — every one requires the real published `v0.2.0`.

### After merge
Tag `ai/v0.2.0`, `orchestration/v0.2.0`, `resilience/v0.2.0`, `memory/v0.2.0`, and `v0.2.0` (root) at the merge commit and warm each — completing the multi-module publish of the framework to pkg.go.dev / deps.dev.

(Example modules keep their relative replaces by design — they serve the default `Dockerfile.workspace` build and are never published.)
