### PR TITLE
feat(conversation): correlate multi-turn executions and add Registry Viewer timeline

### DIFF
--- a/core/ARCHITECTURE.md
+++ b/core/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # TruvaG3 Core Module Architecture
 
-**Version**: 1.0  
+**Version**: 1.1
 **Module**: `github.com/truvaagents/truva-g3/core`  
 **Purpose**: Foundation module architecture, contracts, and design principles  
 **Audience**: Core maintainers, module implementers, LLM coding agents
@@ -19,6 +19,7 @@ The **core module** is the foundation of the TruvaG3 framework. It defines all f
 4. **Configuration Intelligence**: Smart configuration with environment awareness and auto-injection
 5. **Service Discovery Abstraction**: Platform-agnostic discovery with Redis and mock implementations
 6. **Deployment Abstractions**: Kubernetes-aware address resolution and health checks
+7. **Opaque Correlation Carriers**: Validate and transport request-scoped identifiers without owning application session semantics
 
 ---
 
@@ -182,6 +183,43 @@ func WithDiscovery(enabled bool, provider string) Option {
 2. Standard environment variables (`REDIS_URL`, `OPENAI_API_KEY`)
 3. TruvaG3-specific variables (`TRUVAG3_REDIS_URL`, etc.)
 4. Sensible defaults (lowest)
+
+---
+
+## Conversation Correlation Context Contract
+
+Core owns the transport-safe representation of a multi-turn conversation
+identifier; it does not decide what an application session means. An
+application may deliberately use the same opaque value for `session_id` and
+`conversation_id`, but that mapping belongs to the application. Core never
+loads sessions, groups executions, or derives conversation identity from
+history, timestamps, users, or agents.
+
+The public contract in `request_context.go` is:
+
+- `ValidateConversationID` accepts an opaque, non-empty identifier of at most
+  `MaxConversationIDLength` (512 bytes). Its allowed visible-ASCII ranges are a
+  protocol invariant chosen so the value can be propagated exactly as W3C
+  baggage. It returns a bounded `ConversationIDValidationReason` and never
+  includes the rejected value.
+- `WithConversationID` records a programmatic candidate.
+  `ExtractRequestContext` records a separate
+  `X-TruvaG3-Conversation-ID` header candidate. Keeping the two slots separate
+  makes effective precedence independent of call order.
+- A present explicit-header candidate has precedence over a programmatic
+  candidate, including when the header is invalid. Therefore an invalid
+  higher-precedence value cannot reveal or inherit a lower-precedence value.
+- `GetConversationIDCandidate` preserves source, presence, and bounded
+  rejection reason for the orchestration ingress resolver.
+  `GetConversationID` exposes only the effective validated value.
+- Invalid candidates are represented without retaining their raw value.
+  `WithoutConversationID` shadows both candidate slots and the effective value
+  while preserving every unrelated context value. This is the supported
+  defense against identity leakage when a context is reused.
+
+This is intentionally a small value/helper API rather than a new interface or
+session abstraction. It keeps core dependency-free and leaves resolution,
+storage, telemetry, and UI behavior to the modules that own those concerns.
 
 ---
 
@@ -879,6 +917,7 @@ func NewRedisRegistry(redisURL string) (*RedisRegistry, error) {
 - Kubernetes-aware address resolution
 - CORS support for web integration
 - Framework dependency injection (fixed September 2025)
+- Opaque, bounded, call-order-independent conversation correlation context
 
 ### ⚠️ **Needs Review/Refinement**
 - Performance optimization for high-throughput scenarios
@@ -895,5 +934,12 @@ func NewRedisRegistry(redisURL string) (*RedisRegistry, error) {
 ---
 
 **Core Module Philosophy**: *"Provide everything other modules need, depend on nothing they provide. Enable architectural correctness through type system constraints, not documentation."*
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.1 | 2026-07-27 | Established the pre-release opaque conversation-correlation context and validation contract |
+| 1.0 | 2025-09-28 | Initial architecture documentation |
 
 **Remember**: Every change to core affects all other modules. Prioritize backward compatibility, interface stability, and architectural consistency above implementation convenience.

--- a/core/README.md
+++ b/core/README.md
@@ -2225,6 +2225,32 @@ productionAgents, _ := agent.Discover(ctx, core.DiscoveryFilter{
 })
 ```
 
+### Conversation Correlation Context
+
+Core carries an opaque multi-turn correlation ID without assigning meaning to
+an application's `session_id`:
+
+```go
+if reason := core.ValidateConversationID(conversationID); reason != core.ConversationIDValidationNone {
+    return fmt.Errorf("invalid conversation ID: %s", reason)
+}
+
+ctx = core.WithConversationID(ctx, conversationID)
+validatedID := core.GetConversationID(ctx)
+candidate := core.GetConversationIDCandidate(ctx) // source/presence/rejection
+
+// Before reusing a context for an unrelated conversation:
+ctx = core.WithoutConversationID(ctx)
+```
+
+Valid IDs are 1–512 bytes and use the visible-ASCII subset documented by
+`ValidateConversationID`, allowing exact W3C baggage propagation. The explicit
+`X-TruvaG3-Conversation-ID` header has precedence over a programmatic
+candidate, regardless of whether extraction happens before or after
+`WithConversationID`. Invalid raw values are not retained. The orchestration
+module performs final source resolution and storage; core remains a
+dependency-free context/header carrier.
+
 ## 10. Best Practices
 
 ### 1. Choose the Right Component Type

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -681,11 +682,15 @@ func ExampleNewConfig_production() {
 
 // mockMetricsRegistry is a minimal mock for testing getContextBaggage
 type mockMetricsRegistry struct {
-	baggage map[string]string
+	baggage       map[string]string
+	emittedName   string
+	emittedLabels []string
 }
 
 func (m *mockMetricsRegistry) Counter(name string, labels ...string) {}
 func (m *mockMetricsRegistry) EmitWithContext(ctx context.Context, name string, value float64, labels ...string) {
+	m.emittedName = name
+	m.emittedLabels = append([]string(nil), labels...)
 }
 func (m *mockMetricsRegistry) Gauge(name string, value float64, labels ...string)     {}
 func (m *mockMetricsRegistry) Histogram(name string, value float64, labels ...string) {}
@@ -729,6 +734,49 @@ func TestGetContextBaggage(t *testing.T) {
 		assert.NotNil(t, result)
 		assert.Empty(t, result)
 	})
+}
+
+func TestProductionLogger_ContextConversationIsLoggedButNotExplicitMetricLabel(t *testing.T) {
+	originalRegistry := globalMetricsRegistry
+	t.Cleanup(func() {
+		globalMetricsRegistry = originalRegistry
+	})
+
+	registry := &mockMetricsRegistry{
+		baggage: map[string]string{
+			"conversation_id": "conversation-log",
+		},
+	}
+	globalMetricsRegistry = registry
+
+	var output strings.Builder
+	logger := &ProductionLogger{
+		level:          LogLevelInfo,
+		serviceName:    "logger-test",
+		component:      "framework/orchestration",
+		format:         "json",
+		output:         &output,
+		metricsEnabled: true,
+	}
+	logger.InfoWithContext(context.Background(), "conversation log", map[string]interface{}{
+		"operation": "conversation_test",
+	})
+
+	var entry map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output.String())), &entry); err != nil {
+		t.Fatalf("log output is not valid JSON: %v", err)
+	}
+	if got := entry["conversation_id"]; got != "conversation-log" {
+		t.Fatalf("conversation_id log field = %v", got)
+	}
+	if registry.emittedName != "truvag3.framework.operations" {
+		t.Fatalf("emitted metric = %q", registry.emittedName)
+	}
+	for i := 0; i < len(registry.emittedLabels)-1; i += 2 {
+		if registry.emittedLabels[i] == "conversation_id" {
+			t.Fatalf("conversation_id was added as an explicit metric label: %v", registry.emittedLabels)
+		}
+	}
 }
 
 // =============================================================================

--- a/core/request_context.go
+++ b/core/request_context.go
@@ -4,19 +4,87 @@ import (
 	"context"
 	"net/http"
 	"strconv"
+	"unicode/utf8"
 )
 
 type contextKey string
 
 const (
-	contextKeyRequestID             contextKey = "truvag3_request_id"
-	contextKeyStepID                contextKey = "truvag3_step_id"
-	contextKeyPhaseNumber           contextKey = "truvag3_phase_number"
-	contextKeyPlanID                contextKey = "truvag3_plan_id"
-	contextKeyOriginalRequestID     contextKey = "truvag3_original_request_id"
-	contextKeyAgentName             contextKey = "truvag3_agent_name"
-	contextKeyTokenUsageAccumulator contextKey = "truvag3_token_usage_accumulator" // #nosec G101 -- context key for LLM token-usage accounting, not a credential
+	contextKeyRequestID                         contextKey = "truvag3_request_id"
+	contextKeyStepID                            contextKey = "truvag3_step_id"
+	contextKeyPhaseNumber                       contextKey = "truvag3_phase_number"
+	contextKeyPlanID                            contextKey = "truvag3_plan_id"
+	contextKeyOriginalRequestID                 contextKey = "truvag3_original_request_id"
+	contextKeyConversationID                    contextKey = "truvag3_conversation_id"
+	contextKeyConversationProgrammaticCandidate contextKey = "truvag3_conversation_programmatic_candidate"
+	contextKeyConversationHeaderCandidate       contextKey = "truvag3_conversation_header_candidate"
+	contextKeyAgentName                         contextKey = "truvag3_agent_name"
+	contextKeyTokenUsageAccumulator             contextKey = "truvag3_token_usage_accumulator" // #nosec G101 -- context key for LLM token-usage accounting, not a credential
 )
+
+// MaxConversationIDLength is the maximum byte length of a conversation ID.
+// It is a protocol invariant aligned with the telemetry baggage value limit.
+const MaxConversationIDLength = 512
+
+// ConversationIDValidationReason is a bounded classification for a rejected
+// conversation ID. It never contains the rejected value.
+type ConversationIDValidationReason string
+
+const (
+	ConversationIDValidationNone             ConversationIDValidationReason = ""
+	ConversationIDValidationEmpty            ConversationIDValidationReason = "empty"
+	ConversationIDValidationInvalidType      ConversationIDValidationReason = "invalid_type"
+	ConversationIDValidationTooLong          ConversationIDValidationReason = "too_long"
+	ConversationIDValidationInvalidUTF8      ConversationIDValidationReason = "invalid_utf8"
+	ConversationIDValidationInvalidCharacter ConversationIDValidationReason = "invalid_character"
+)
+
+// ConversationIDCandidateSource identifies the core source of a conversation
+// ID candidate.
+type ConversationIDCandidateSource string
+
+const (
+	ConversationIDSourceCoreContext ConversationIDCandidateSource = "core_context"
+	ConversationIDSourceCoreHeader  ConversationIDCandidateSource = "core_header"
+)
+
+// ConversationIDCandidate records source and presence separately from
+// validity. Value is populated only for a valid candidate.
+type ConversationIDCandidate struct {
+	Present         bool
+	Value           string
+	Source          ConversationIDCandidateSource
+	RejectionReason ConversationIDValidationReason
+}
+
+// ValidateConversationID validates an opaque conversation ID for exact W3C
+// baggage propagation. Valid values contain 1-512 bytes from these visible
+// ASCII ranges: 0x21, 0x23-0x2B, 0x2D-0x3A, 0x3C-0x5B, or 0x5D-0x7E.
+func ValidateConversationID(id string) ConversationIDValidationReason {
+	if id == "" {
+		return ConversationIDValidationEmpty
+	}
+	if len(id) > MaxConversationIDLength {
+		return ConversationIDValidationTooLong
+	}
+	if !utf8.ValidString(id) {
+		return ConversationIDValidationInvalidUTF8
+	}
+	for i := 0; i < len(id); i++ {
+		if !isConversationIDByteAllowed(id[i]) {
+			return ConversationIDValidationInvalidCharacter
+		}
+	}
+	return ConversationIDValidationNone
+}
+
+func isConversationIDByteAllowed(value byte) bool {
+	return value == 0x21 ||
+		(value >= 0x23 && value <= 0x2b) ||
+		(value >= 0x2d && value <= 0x3a) ||
+		(value >= 0x3c && value <= 0x5b) ||
+		(value >= 0x5d && value <= 0x7e)
+}
 
 func WithRequestID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, contextKeyRequestID, id)
@@ -73,6 +141,125 @@ func GetOriginalRequestID(ctx context.Context) string {
 		return v
 	}
 	return ""
+}
+
+// WithConversationID records a programmatic conversation ID candidate.
+// Explicit-header candidates, when present, retain precedence independent of
+// the order in which the two sources are applied.
+func WithConversationID(ctx context.Context, id string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	candidate := ConversationIDCandidate{
+		Present: true,
+		Source:  ConversationIDSourceCoreContext,
+	}
+	if reason := ValidateConversationID(id); reason != ConversationIDValidationNone {
+		candidate.RejectionReason = reason
+		return withConversationIDProgrammaticCandidate(ctx, candidate)
+	}
+	candidate.Value = id
+	return withConversationIDProgrammaticCandidate(ctx, candidate)
+}
+
+// GetConversationID returns the effective validated conversation ID.
+func GetConversationID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if value, ok := ctx.Value(contextKeyConversationID).(string); ok {
+		return value
+	}
+	return ""
+}
+
+// GetConversationIDCandidate returns the effective core candidate: an
+// explicit-header candidate when present, otherwise the programmatic one.
+func GetConversationIDCandidate(ctx context.Context) ConversationIDCandidate {
+	if ctx == nil {
+		return ConversationIDCandidate{}
+	}
+	if candidate, ok := ctx.Value(contextKeyConversationHeaderCandidate).(ConversationIDCandidate); ok && candidate.Present {
+		return candidate
+	}
+	if candidate, ok := ctx.Value(contextKeyConversationProgrammaticCandidate).(ConversationIDCandidate); ok {
+		return candidate
+	}
+	return ConversationIDCandidate{}
+}
+
+// WithoutConversationID shadows inherited conversation identity while
+// preserving unrelated context values.
+func WithoutConversationID(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx = withConversationIDValue(ctx, "")
+	ctx = context.WithValue(
+		ctx,
+		contextKeyConversationProgrammaticCandidate,
+		ConversationIDCandidate{},
+	)
+	return context.WithValue(
+		ctx,
+		contextKeyConversationHeaderCandidate,
+		ConversationIDCandidate{},
+	)
+}
+
+func withConversationIDProgrammaticCandidate(
+	ctx context.Context,
+	candidate ConversationIDCandidate,
+) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	candidate = normalizeConversationIDCandidate(candidate)
+	ctx = context.WithValue(ctx, contextKeyConversationProgrammaticCandidate, candidate)
+	return refreshConversationIDValue(ctx)
+}
+
+func withConversationIDHeaderCandidate(
+	ctx context.Context,
+	candidate ConversationIDCandidate,
+) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	candidate = normalizeConversationIDCandidate(candidate)
+	ctx = context.WithValue(ctx, contextKeyConversationHeaderCandidate, candidate)
+	return refreshConversationIDValue(ctx)
+}
+
+func withoutConversationIDHeaderCandidate(ctx context.Context) context.Context {
+	return withConversationIDHeaderCandidate(ctx, ConversationIDCandidate{})
+}
+
+func normalizeConversationIDCandidate(candidate ConversationIDCandidate) ConversationIDCandidate {
+	if !candidate.Present {
+		return ConversationIDCandidate{}
+	}
+	if candidate.RejectionReason != ConversationIDValidationNone {
+		candidate.Value = ""
+		return candidate
+	}
+	if reason := ValidateConversationID(candidate.Value); reason != ConversationIDValidationNone {
+		candidate.Value = ""
+		candidate.RejectionReason = reason
+	}
+	return candidate
+}
+
+func refreshConversationIDValue(ctx context.Context) context.Context {
+	candidate := GetConversationIDCandidate(ctx)
+	if candidate.Present && candidate.RejectionReason == ConversationIDValidationNone {
+		return withConversationIDValue(ctx, candidate.Value)
+	}
+	return withConversationIDValue(ctx, "")
+}
+
+func withConversationIDValue(ctx context.Context, value string) context.Context {
+	return context.WithValue(ctx, contextKeyConversationID, value)
 }
 
 // WithAgentName / GetAgentName carry the calling agent identity to tool spans.

--- a/core/request_context.go
+++ b/core/request_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strconv"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -274,9 +275,9 @@ func GetAgentName(ctx context.Context) string {
 }
 
 // ExtractRequestContext extracts TruvaG3 orchestration context from HTTP headers.
-// This is the primary mechanism for receiving request_id and step_id from the orchestrator
-// (Issue 18: executor's httpClient does not use otelhttp transport).
-// Agents using telemetry.NewTracedHTTPHandler may also get OTel baggage as a bonus.
+// This is the telemetry-independent fallback for receiving framework request
+// context. W3C baggage may also carry the same correlation values when
+// OpenTelemetry HTTP propagation is installed.
 //
 // Issue 11 fix: No componentName parameter — the component identity is set at
 // InstrumentedAIClient construction time via WithComponentName(), not per-request.
@@ -302,7 +303,53 @@ func ExtractRequestContext(ctx context.Context, r *http.Request) context.Context
 	if agentName := r.Header.Get("X-TruvaG3-Agent-Name"); agentName != "" {
 		ctx = WithAgentName(ctx, agentName)
 	}
+
+	rawConversationID, present := explicitHeaderValue(
+		r.Header,
+		"X-TruvaG3-Conversation-ID",
+	)
+	if present {
+		candidate := ConversationIDCandidate{
+			Present: true,
+			Source:  ConversationIDSourceCoreHeader,
+		}
+		if reason := ValidateConversationID(rawConversationID); reason != ConversationIDValidationNone {
+			candidate.RejectionReason = reason
+		} else {
+			candidate.Value = rawConversationID
+		}
+		ctx = withConversationIDHeaderCandidate(ctx, candidate)
+	} else {
+		// A reused parent context must not retain header provenance from an
+		// earlier request. Clearing only the header candidate reveals any
+		// separately supplied programmatic candidate.
+		ctx = withoutConversationIDHeaderCandidate(ctx)
+	}
 	return ctx
+}
+
+// explicitHeaderValue distinguishes an absent header from an explicitly empty
+// one. It also tolerates non-canonical map keys supplied by custom transports
+// or tests instead of Header.Set.
+func explicitHeaderValue(header http.Header, name string) (string, bool) {
+	canonicalName := http.CanonicalHeaderKey(name)
+	values, present := header[canonicalName]
+	if !present {
+		for headerName, headerValues := range header {
+			if strings.EqualFold(headerName, name) {
+				values = headerValues
+				present = true
+				break
+			}
+		}
+	}
+	if !present {
+		return "", false
+	}
+	if len(values) == 0 {
+		return "", true
+	}
+	return values[0], true
 }
 
 // WithTokenUsageAccumulator injects a new AggregatedTokenUsage into the context.

--- a/core/request_context_test.go
+++ b/core/request_context_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,4 +100,232 @@ func TestExtractRequestContext_AllHeaders(t *testing.T) {
 	assert.Equal(t, "req-123", GetRequestID(ctx))
 	assert.Equal(t, "step-5", GetStepID(ctx))
 	assert.Equal(t, 2, GetPhaseNumber(ctx))
+}
+
+func TestValidateConversationID(t *testing.T) {
+	t.Parallel()
+
+	maxLengthValue := strings.Repeat("a", MaxConversationIDLength)
+	tests := []struct {
+		name   string
+		value  string
+		reason ConversationIDValidationReason
+	}{
+		{
+			name:   "opaque orchestration ID",
+			value:  "conversation:orch-1784984026261441029",
+			reason: ConversationIDValidationNone,
+		},
+		{
+			name:   "all allowed visible ASCII ranges",
+			value:  "!#$%&'()*+-./09:<=>?@AZ[]^_az{|}~",
+			reason: ConversationIDValidationNone,
+		},
+		{
+			name:   "maximum length",
+			value:  maxLengthValue,
+			reason: ConversationIDValidationNone,
+		},
+		{
+			name:   "empty",
+			value:  "",
+			reason: ConversationIDValidationEmpty,
+		},
+		{
+			name:   "too long",
+			value:  maxLengthValue + "a",
+			reason: ConversationIDValidationTooLong,
+		},
+		{
+			name:   "invalid UTF-8",
+			value:  string([]byte{0xff}),
+			reason: ConversationIDValidationInvalidUTF8,
+		},
+		{
+			name:   "space",
+			value:  "conversation id",
+			reason: ConversationIDValidationInvalidCharacter,
+		},
+		{
+			name:   "double quote",
+			value:  `conversation"id`,
+			reason: ConversationIDValidationInvalidCharacter,
+		},
+		{
+			name:   "comma",
+			value:  "conversation,id",
+			reason: ConversationIDValidationInvalidCharacter,
+		},
+		{
+			name:   "semicolon",
+			value:  "conversation;id",
+			reason: ConversationIDValidationInvalidCharacter,
+		},
+		{
+			name:   "backslash",
+			value:  `conversation\id`,
+			reason: ConversationIDValidationInvalidCharacter,
+		},
+		{
+			name:   "valid non-ASCII UTF-8",
+			value:  "conversation-é",
+			reason: ConversationIDValidationInvalidCharacter,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.reason, ValidateConversationID(tt.value))
+		})
+	}
+}
+
+func TestValidateConversationIDVisibleASCIIContract(t *testing.T) {
+	t.Parallel()
+
+	for value := 0; value < 128; value++ {
+		value := byte(value)
+		allowed := value == 0x21 ||
+			(value >= 0x23 && value <= 0x2b) ||
+			(value >= 0x2d && value <= 0x3a) ||
+			(value >= 0x3c && value <= 0x5b) ||
+			(value >= 0x5d && value <= 0x7e)
+
+		reason := ValidateConversationID(string([]byte{value}))
+		if allowed {
+			assert.Equalf(t, ConversationIDValidationNone, reason, "byte 0x%02x should be allowed", value)
+			continue
+		}
+		assert.NotEqualf(t, ConversationIDValidationNone, reason, "byte 0x%02x should be rejected", value)
+	}
+}
+
+func TestConversationIDContextHelpersHandleNilAndUnset(t *testing.T) {
+	t.Parallel()
+
+	var nilContext context.Context
+	assert.Empty(t, GetConversationID(nilContext))
+	assert.Equal(t, ConversationIDCandidate{}, GetConversationIDCandidate(nilContext))
+	assert.Empty(t, GetConversationID(context.Background()))
+	assert.Equal(t, ConversationIDCandidate{}, GetConversationIDCandidate(context.Background()))
+
+	ctx := WithConversationID(nilContext, "conversation-from-nil")
+	assert.Equal(t, "conversation-from-nil", GetConversationID(ctx))
+
+	ctx = withConversationIDProgrammaticCandidate(nilContext, ConversationIDCandidate{
+		Value:   "programmatic-from-nil",
+		Source:  ConversationIDSourceCoreContext,
+		Present: true,
+	})
+	assert.Equal(t, "programmatic-from-nil", GetConversationID(ctx))
+
+	ctx = withConversationIDHeaderCandidate(nilContext, ConversationIDCandidate{
+		Value:   "header-from-nil",
+		Source:  ConversationIDSourceCoreHeader,
+		Present: true,
+	})
+	assert.Equal(t, "header-from-nil", GetConversationID(ctx))
+
+	assert.NotNil(t, WithoutConversationID(nilContext))
+	assert.Empty(t, GetConversationID(WithoutConversationID(ctx)))
+}
+
+func TestNormalizeConversationIDCandidate(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, ConversationIDCandidate{}, normalizeConversationIDCandidate(ConversationIDCandidate{
+		Value:  "ignored",
+		Source: ConversationIDSourceCoreHeader,
+	}))
+
+	invalid := normalizeConversationIDCandidate(ConversationIDCandidate{
+		Value:   "contains space",
+		Source:  ConversationIDSourceCoreHeader,
+		Present: true,
+	})
+	assert.Empty(t, invalid.Value)
+	assert.Equal(t, ConversationIDValidationInvalidCharacter, invalid.RejectionReason)
+}
+
+func TestConversationIDCandidatePrecedenceIsCallOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	headerCandidate := ConversationIDCandidate{
+		Present: true,
+		Value:   "header-conversation",
+		Source:  ConversationIDSourceCoreHeader,
+	}
+
+	programmaticThenHeader := WithConversationID(context.Background(), "programmatic-conversation")
+	programmaticThenHeader = withConversationIDHeaderCandidate(programmaticThenHeader, headerCandidate)
+	programmaticThenHeader = WithConversationID(programmaticThenHeader, "replacement-programmatic")
+
+	headerThenProgrammatic := withConversationIDHeaderCandidate(context.Background(), headerCandidate)
+	headerThenProgrammatic = WithConversationID(headerThenProgrammatic, "programmatic-conversation")
+
+	for name, ctx := range map[string]context.Context{
+		"programmatic then header": programmaticThenHeader,
+		"header then programmatic": headerThenProgrammatic,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, "header-conversation", GetConversationID(ctx))
+			assert.Equal(t, headerCandidate, GetConversationIDCandidate(ctx))
+		})
+	}
+
+	revealed := withoutConversationIDHeaderCandidate(programmaticThenHeader)
+	assert.Equal(t, "replacement-programmatic", GetConversationID(revealed))
+	assert.Equal(t, ConversationIDSourceCoreContext, GetConversationIDCandidate(revealed).Source)
+}
+
+func TestInvalidConversationIDCandidatesDoNotRetainRawValues(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithConversationID(context.Background(), "invalid programmatic")
+	candidate := GetConversationIDCandidate(ctx)
+	assert.True(t, candidate.Present)
+	assert.Empty(t, candidate.Value)
+	assert.Equal(t, ConversationIDSourceCoreContext, candidate.Source)
+	assert.Equal(t, ConversationIDValidationInvalidCharacter, candidate.RejectionReason)
+	assert.Empty(t, GetConversationID(ctx))
+
+	invalidHeader := ConversationIDCandidate{
+		Present:         true,
+		Value:           "invalid header",
+		Source:          ConversationIDSourceCoreHeader,
+		RejectionReason: ConversationIDValidationInvalidCharacter,
+	}
+	ctx = withConversationIDHeaderCandidate(
+		WithConversationID(context.Background(), "programmatic-conversation"),
+		invalidHeader,
+	)
+	candidate = GetConversationIDCandidate(ctx)
+	assert.True(t, candidate.Present)
+	assert.Empty(t, candidate.Value)
+	assert.Equal(t, ConversationIDSourceCoreHeader, candidate.Source)
+	assert.Equal(t, ConversationIDValidationInvalidCharacter, candidate.RejectionReason)
+	assert.Empty(t, GetConversationID(ctx))
+
+	ctx = WithConversationID(ctx, "replacement-programmatic")
+	assert.Empty(t, GetConversationID(ctx), "invalid header must retain precedence")
+	assert.Equal(t, ConversationIDSourceCoreHeader, GetConversationIDCandidate(ctx).Source)
+}
+
+func TestWithoutConversationIDClearsAllConversationState(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithRequestID(context.Background(), "request-1")
+	ctx = WithConversationID(ctx, "programmatic-conversation")
+	ctx = withConversationIDHeaderCandidate(ctx, ConversationIDCandidate{
+		Present: true,
+		Value:   "header-conversation",
+		Source:  ConversationIDSourceCoreHeader,
+	})
+
+	ctx = WithoutConversationID(ctx)
+
+	assert.Empty(t, GetConversationID(ctx))
+	assert.Equal(t, ConversationIDCandidate{}, GetConversationIDCandidate(ctx))
+	assert.Equal(t, "request-1", GetRequestID(ctx))
 }

--- a/core/request_context_test.go
+++ b/core/request_context_test.go
@@ -329,3 +329,129 @@ func TestWithoutConversationIDClearsAllConversationState(t *testing.T) {
 	assert.Equal(t, ConversationIDCandidate{}, GetConversationIDCandidate(ctx))
 	assert.Equal(t, "request-1", GetRequestID(ctx))
 }
+
+func TestExtractRequestContext_ConversationIDCandidateStates(t *testing.T) {
+	tests := []struct {
+		name        string
+		setHeader   func(http.Header)
+		want        string
+		wantReason  ConversationIDValidationReason
+		wantSource  ConversationIDCandidateSource
+		wantPresent bool
+	}{
+		{
+			name: "valid",
+			setHeader: func(header http.Header) {
+				header.Set("X-TruvaG3-Conversation-ID", "conversation-header")
+			},
+			want:        "conversation-header",
+			wantSource:  ConversationIDSourceCoreHeader,
+			wantPresent: true,
+		},
+		{
+			name: "invalid",
+			setHeader: func(header http.Header) {
+				header.Set("X-TruvaG3-Conversation-ID", "invalid conversation")
+			},
+			wantReason:  ConversationIDValidationInvalidCharacter,
+			wantSource:  ConversationIDSourceCoreHeader,
+			wantPresent: true,
+		},
+		{
+			name: "explicitly empty",
+			setHeader: func(header http.Header) {
+				header["X-Truvag3-Conversation-Id"] = []string{""}
+			},
+			wantReason:  ConversationIDValidationEmpty,
+			wantSource:  ConversationIDSourceCoreHeader,
+			wantPresent: true,
+		},
+		{
+			name: "present with no values",
+			setHeader: func(header http.Header) {
+				header["x-truvag3-conversation-id"] = nil
+			},
+			wantReason:  ConversationIDValidationEmpty,
+			wantSource:  ConversationIDSourceCoreHeader,
+			wantPresent: true,
+		},
+		{
+			name:      "absent",
+			setHeader: func(http.Header) {},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodPost, "/execute", nil)
+			test.setHeader(request.Header)
+
+			ctx := ExtractRequestContext(context.Background(), request)
+			candidate := GetConversationIDCandidate(ctx)
+
+			assert.Equal(t, test.wantPresent, candidate.Present)
+			assert.Equal(t, test.want, candidate.Value)
+			assert.Equal(t, test.wantReason, candidate.RejectionReason)
+			assert.Equal(t, test.wantSource, candidate.Source)
+			assert.Equal(t, test.want, GetConversationID(ctx))
+			if test.wantReason != ConversationIDValidationNone {
+				assert.NotContains(t, candidate.Value, "invalid conversation")
+			}
+		})
+	}
+}
+
+func TestExtractRequestContext_ConversationHeaderPrecedenceIsCallOrderIndependent(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "/execute", nil)
+	request.Header.Set("X-TruvaG3-Conversation-ID", "conversation-header")
+
+	beforeExtraction := WithConversationID(context.Background(), "conversation-programmatic")
+	beforeExtraction = ExtractRequestContext(beforeExtraction, request)
+
+	afterExtraction := ExtractRequestContext(context.Background(), request)
+	afterExtraction = WithConversationID(afterExtraction, "conversation-programmatic")
+
+	for name, ctx := range map[string]context.Context{
+		"programmatic before extraction": beforeExtraction,
+		"programmatic after extraction":  afterExtraction,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, "conversation-header", GetConversationID(ctx))
+			candidate := GetConversationIDCandidate(ctx)
+			assert.True(t, candidate.Present)
+			assert.Equal(t, ConversationIDSourceCoreHeader, candidate.Source)
+		})
+	}
+}
+
+func TestExtractRequestContext_AbsentHeaderClearsOnlyHeaderCandidate(t *testing.T) {
+	withHeader := httptest.NewRequest(http.MethodPost, "/execute", nil)
+	withHeader.Header.Set("X-TruvaG3-Conversation-ID", "conversation-header")
+
+	ctx := WithConversationID(context.Background(), "conversation-programmatic")
+	ctx = ExtractRequestContext(ctx, withHeader)
+	assert.Equal(t, "conversation-header", GetConversationID(ctx))
+
+	withoutHeader := httptest.NewRequest(http.MethodPost, "/execute", nil)
+	ctx = ExtractRequestContext(ctx, withoutHeader)
+
+	assert.Equal(t, "conversation-programmatic", GetConversationID(ctx))
+	candidate := GetConversationIDCandidate(ctx)
+	assert.True(t, candidate.Present)
+	assert.Equal(t, ConversationIDSourceCoreContext, candidate.Source)
+}
+
+func TestExtractRequestContext_InvalidHeaderBlocksProgrammaticFallback(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "/execute", nil)
+	request.Header.Set("X-TruvaG3-Conversation-ID", "invalid conversation")
+
+	ctx := WithConversationID(context.Background(), "conversation-programmatic")
+	ctx = ExtractRequestContext(ctx, request)
+
+	assert.Empty(t, GetConversationID(ctx))
+	candidate := GetConversationIDCandidate(ctx)
+	assert.True(t, candidate.Present)
+	assert.Empty(t, candidate.Value)
+	assert.Equal(t, ConversationIDSourceCoreHeader, candidate.Source)
+	assert.Equal(t, ConversationIDValidationInvalidCharacter, candidate.RejectionReason)
+}

--- a/docs/building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md
+++ b/docs/building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md
@@ -316,14 +316,24 @@ func addConversationHistoryMetadata(
     if metadata == nil {
         metadata = make(map[string]interface{})
     }
+    // This application maps one chat session to one conversation. Establish
+    // identity independently of history so turn 1 is correlated.
+    if sessionID != "" {
+        metadata[orchestration.MetadataConversationID] = sessionID
+    }
     if len(turns) == 0 {
         return metadata
     }
     metadata[orchestration.MetadataConversationTurns] = turns
-    metadata[orchestration.MetadataConversationSessionKey] = sessionID
     return metadata
 }
 ```
+
+`sessionID` is application state; `MetadataConversationID` is framework
+correlation. Reusing the value is an explicit one-session-to-one-conversation
+mapping in this example, not a framework assumption. Keep the identity
+assignment outside the history guard so the first turn and delegation paths
+with empty history still carry it.
 
 If your integration cannot pass raw turns in metadata and only has a memory backend, `ConversationHistoryHook` remains available as a thin adapter:
 

--- a/docs/building/AGENT_DEVELOPMENT_GUIDE.md
+++ b/docs/building/AGENT_DEVELOPMENT_GUIDE.md
@@ -847,6 +847,8 @@ For streaming agents, the orchestration logic lives in the agent struct (not in 
 // addConversationHistoryMetadata passes raw turns to orchestration.
 // The framework builds <conversation_history> before planning and reuses
 // the prepared value across continuation and synthesis phases.
+// This example intentionally maps its application session UUID to the
+// framework conversation ID; applications may choose a different mapping.
 func (a *YourChatAgent) addConversationHistoryMetadata(
     metadata map[string]interface{},
     sessionID string,
@@ -854,6 +856,10 @@ func (a *YourChatAgent) addConversationHistoryMetadata(
 ) map[string]interface{} {
     if metadata == nil {
         metadata = make(map[string]interface{})
+    }
+    // This example deliberately maps one session UUID to one conversation.
+    if sessionID != "" {
+        metadata[orchestration.MetadataConversationID] = sessionID
     }
     if len(history) == 0 {
         return metadata
@@ -868,9 +874,11 @@ func (a *YourChatAgent) addConversationHistoryMetadata(
     }
 
     metadata[orchestration.MetadataConversationTurns] = turns
-    metadata[orchestration.MetadataConversationSessionKey] = sessionID
     return metadata
 }
+
+// Conversation identity is set before the history guard so the first turn is
+// correlated even when no earlier messages exist.
 
 // ProcessWithStreaming processes a query and streams progress via SSE callback.
 func (a *YourChatAgent) ProcessWithStreaming(
@@ -1979,11 +1987,12 @@ func (a *MyAgent) handleResume(w http.ResponseWriter, r *http.Request) {
     }
 
     // 2. Build resume context — single call handles the full contract
-    resumeCtx, err := orchestration.BuildResumeContext(ctx, checkpoint)
+    resumeCtx, endResumeSpan, err := orchestration.BuildResumeContext(ctx, checkpoint)
     if err != nil {
         http.Error(w, err.Error(), http.StatusBadRequest)
         return
     }
+    defer endResumeSpan()
 
     // 3. Re-enter the orchestrator with the original request
     result, err := a.orchestrator.ProcessRequest(resumeCtx, checkpoint.OriginalRequest, checkpoint.UserContext)
@@ -2000,6 +2009,8 @@ func (a *MyAgent) handleResume(w http.ResponseWriter, r *http.Request) {
 | `WithCompletedSteps(ctx, results)` | Skips already-executed steps |
 | `WithPreResolvedParams(ctx, params, stepID)` | Uses the human-approved parameter values |
 | `WithRequestMode(ctx, mode)` | Preserves streaming/non-streaming expiry behavior |
+| Linked `hitl.resume` span | Links the resumed execution to the original trace; the returned cleanup function must be called |
+| Validated conversation context | Restores canonical `conversation_id` to core context, checkpoint metadata, and metric-ineligible W3C Baggage when present |
 | `WithMetadata(ctx, userContext)` | Preserves session metadata (session ID, user info, etc.) |
 
 It also validates that the checkpoint has a resumable status (`approved`, `edited`, or `expired_approved`), returning an error for terminal or pending checkpoints.

--- a/docs/memory-and-chat/CHAT_AGENT_GUIDE.md
+++ b/docs/memory-and-chat/CHAT_AGENT_GUIDE.md
@@ -685,6 +685,10 @@ func (t *TravelChatAgent) addConversationHistoryMetadata(
     if metadata == nil {
         metadata = make(map[string]interface{})
     }
+    // This reference agent maps one chat session to one conversation.
+    if sessionID != "" {
+        metadata[orchestration.MetadataConversationID] = sessionID
+    }
     if len(history) == 0 {
         return metadata
     }
@@ -698,7 +702,6 @@ func (t *TravelChatAgent) addConversationHistoryMetadata(
     }
 
     metadata[orchestration.MetadataConversationTurns] = turns
-    metadata[orchestration.MetadataConversationSessionKey] = sessionID
     return metadata
 }
 ```
@@ -706,11 +709,16 @@ func (t *TravelChatAgent) addConversationHistoryMetadata(
 **What the framework does with that metadata:**
 ```
 metadata[orchestration.MetadataConversationTurns] = []core.ConversationTurn{...}
-metadata[orchestration.MetadataConversationSessionKey] = "session-123"
+metadata[orchestration.MetadataConversationID] = "session-123" // explicit app mapping
 orchestrator.ProcessRequestStreaming(ctx, "What's the population?", metadata, ...)
 ```
 
 The shared conversation-history preparer then builds the `<conversation_history>` enrichment before planning, so the LLM still understands that "the population" refers to Paris without you having to bake old turns into the query text yourself.
+
+The canonical ID is assigned before checking `history`, so a new session's
+first turn is correlated even when no previous messages exist. The example
+uses the session UUID as its conversation ID by design; `session_id` and
+`conversation_id` remain distinct concepts.
 
 If you want the full Tier 1 / Tier 2 / Layer 3 story in one place, see [CONVERSATION_HISTORY_GUIDE.md](CONVERSATION_HISTORY_GUIDE.md).
 

--- a/docs/memory-and-chat/CHAT_SESSION_MANAGEMENT_GUIDE.md
+++ b/docs/memory-and-chat/CHAT_SESSION_MANAGEMENT_GUIDE.md
@@ -87,7 +87,7 @@ Chat Agent
   | convert []Message -> []ConversationTurn
   | attach metadata:
   |   - conversation_turns
-  |   - conversation_session_key
+  |   - conversation_id
   v
 Orchestrator
   |
@@ -157,9 +157,11 @@ If you are skimming, this is the behavior today:
 5. `POST /chat/stream` can also create a session automatically if no `session_id` is provided.
 6. Each incoming user message is saved before orchestration begins.
 7. The full retained message list is converted into `ConversationTurn` values and passed into orchestration metadata.
-8. The orchestration layer prepares prompt-safe `conversation_history` from those turns.
-9. The assistant response is saved back into the same session.
-10. The DevOps example also carries session context across HITL interruption and resume.
+8. The session UUID is deliberately mapped to canonical `conversation_id`,
+   including on the first turn when no prior history exists.
+9. The orchestration layer prepares prompt-safe `conversation_history` from those turns.
+10. The assistant response is saved back into the same session.
+11. The DevOps example also carries session and conversation context across HITL interruption and resume.
 
 If you want the deeper version, keep going.
 
@@ -341,7 +343,13 @@ Inside `ProcessWithStreaming()`, both agents do the same core work:
 The metadata keys are:
 
 - `orchestration.MetadataConversationTurns`
-- `orchestration.MetadataConversationSessionKey`
+- `orchestration.MetadataConversationID`
+
+These examples deliberately use the same UUID for the application session and
+framework conversation. They are not synonyms: `session_id` addresses the
+Redis transcript and TTL lifecycle; `conversation_id` correlates framework
+executions, traces, logs, and debug records. An application with different
+session semantics can use different values.
 
 Both agents also populate:
 
@@ -376,9 +384,13 @@ This is where [`CONVERSATION_HISTORY_GUIDE.md`](CONVERSATION_HISTORY_GUIDE.md) t
 The orchestrator sees metadata like:
 
 - `conversation_turns`
-- `conversation_session_key`
+- `conversation_id`
 
 and feeds it into the shared `ConversationHistoryPreparer`.
+
+The agent assigns `conversation_id` before checking whether history is empty.
+This is why a first turn or delegation path with a valid session is correlated
+even when there are no stored prior messages.
 
 Both example agents explicitly inject a preparer built with:
 
@@ -570,7 +582,8 @@ When the DevOps chat agent enters orchestration, it stores session-related conte
 If orchestration gets interrupted for approval:
 
 - the SSE flow emits a `checkpoint` event
-- the checkpoint carries user context, including `session_id`
+- the checkpoint carries framework-owned `conversation_id` plus application
+  metadata such as `session_id`
 
 Later, when execution resumes through:
 
@@ -581,19 +594,25 @@ the handler:
 
 1. loads the checkpoint
 2. rebuilds resume context
-3. reads `session_id` from `checkpoint.UserContext`
-4. reuses that session if it exists
-5. creates a new session only if no session ID is available
+3. reads a valid `conversation_id` from `checkpoint.UserContext`, with
+   `session_id` as the compatibility fallback for older local checkpoints
+4. reuses that value as the session ID because this example maps the two
+   concepts one-to-one
+5. creates a new session only if neither identity is available
 6. calls `ProcessWithStreaming()` again using the original request
 
 This is the crucial point:
 
-the DevOps agent does not treat resume as a brand-new chat. It tries to continue the same conversation thread by reusing the checkpoint's `session_id`.
+the DevOps agent does not treat resume as a brand-new chat. It continues the
+same correlated conversation and, because of the example's explicit mapping,
+reuses that value to load the chat session.
 
 There is one important edge case to know:
 
-- the resume handlers create a new session only when the checkpoint has no `session_id`
-- if the checkpoint does have a `session_id` but that session record has already expired, the handler still passes that same ID into `ProcessWithStreaming()`
+- the resume handlers create a new session only when the checkpoint has neither
+  a valid `conversation_id` nor a `session_id`
+- if the checkpoint identity exists but that session record has already
+  expired, the handler still passes that same ID into `ProcessWithStreaming()`
 - in that case the resumed execution keeps orchestration context from the checkpoint, but it does not recreate the expired session record automatically
 
 That is what keeps approval-driven workflows coherent from the user's point of view.
@@ -668,7 +687,8 @@ And if you want the slightly longer version:
 
 1. the app owns persistence, session IDs, TTLs, listing, and resume behavior
 2. the orchestration layer owns prompt preparation, budgeting, and compaction
-3. the two are connected by `conversation_turns` and `conversation_session_key`
+3. `conversation_turns` carries prompt history, while canonical
+   `conversation_id` correlates framework executions independently of history
 
 That separation is the design.
 

--- a/docs/memory-and-chat/CONVERSATION_HISTORY_GUIDE.md
+++ b/docs/memory-and-chat/CONVERSATION_HISTORY_GUIDE.md
@@ -179,7 +179,7 @@ Chat session turns
     │
     ▼
 metadata[orchestration.MetadataConversationTurns]
-metadata[orchestration.MetadataConversationSessionKey]
+metadata[orchestration.MetadataConversationID]
     │
     ▼
 ConversationHistoryPreparer
@@ -197,7 +197,15 @@ Planning → Continuation → Synthesis
 Two important details:
 
 - The preferred path is **raw turns in request metadata**.
+- `MetadataConversationID` is correlation identity, not history. Set it
+  whenever a conversation exists, including the first turn when
+  `MetadataConversationTurns` is empty.
 - `ConversationHistoryHook` still exists, but it is now an **adapter** for memory-backed integrations that cannot supply raw turns directly.
+
+An application may map one `session_id` to one `conversation_id`, as the
+reference chat agents do, but that is an application decision. Session IDs own
+transcript persistence and TTL semantics; conversation IDs join framework
+executions and provide the Tier 2 compaction-cache namespace.
 
 ---
 
@@ -210,7 +218,7 @@ If you are skimming, this is the recommended path for most teams:
 1. store conversation turns in your session store
 2. pass them in metadata using:
    - `orchestration.MetadataConversationTurns`
-   - `orchestration.MetadataConversationSessionKey`
+   - `orchestration.MetadataConversationID`
 3. create the orchestrator with `CreateOrchestrator(...)`
 
 That gives you **Tier 1** automatically.
@@ -269,7 +277,7 @@ If you want the shortest path:
 1. Store your chat history as `[]core.ConversationTurn`
 2. Pass it in request metadata under:
    - `orchestration.MetadataConversationTurns`
-   - `orchestration.MetadataConversationSessionKey`
+   - `orchestration.MetadataConversationID`
 3. Create the orchestrator normally with `CreateOrchestrator(...)`
 
 That gives you **Tier 1 automatically**.
@@ -339,6 +347,10 @@ func (a *YourChatAgent) addConversationHistoryMetadata(
     if metadata == nil {
         metadata = make(map[string]interface{})
     }
+    // This example maps one application session to one conversation.
+    if sessionID != "" {
+        metadata[orchestration.MetadataConversationID] = sessionID
+    }
     if len(history) == 0 {
         return metadata
     }
@@ -352,7 +364,6 @@ func (a *YourChatAgent) addConversationHistoryMetadata(
     }
 
     metadata[orchestration.MetadataConversationTurns] = turns
-    metadata[orchestration.MetadataConversationSessionKey] = sessionID
     return metadata
 }
 ```
@@ -377,7 +388,7 @@ It has the cleanest small example of:
 
 - converting `[]Message` to `[]core.ConversationTurn`
 - storing `MetadataConversationTurns`
-- storing `MetadataConversationSessionKey`
+- storing `MetadataConversationID` independently of history presence
 - keeping the legacy formatted-history fallback during rollout
 
 ---
@@ -966,7 +977,7 @@ Check these first:
 
 - Are you injecting `ConversationHistoryPreparer` explicitly with `BuildCompactionEnabledConversationHistoryPreparer(...)`?
 - Is `agent.AI` available when the preparer is built?
-- Are you passing `MetadataConversationTurns` and `MetadataConversationSessionKey`?
+- Are you passing `MetadataConversationTurns` and `MetadataConversationID`?
 
 If you are only passing `core.EnrichmentConversationHistory` as a formatted string, that is expected to stay on the Tier 1-style text path.
 

--- a/docs/observability/DISTRIBUTED_TRACING_GUIDE.md
+++ b/docs/observability/DISTRIBUTED_TRACING_GUIDE.md
@@ -8,6 +8,7 @@ Welcome to the complete guide on distributed tracing in TruvaG3! Think of this a
 2. [The Problem Without Tracing](#2-the-problem-without-tracing)
 3. [The Solution: Context Propagation](#3-the-solution-context-propagation)
 4. [Understanding Trace IDs, Span IDs, and Parent Spans](#4-understanding-trace-ids-span-ids-and-parent-spans)
+    - [Correlation Taxonomy](#correlation-taxonomy)
 5. [Trace-Log Correlation: The Magic Glue](#5-trace-log-correlation-the-magic-glue)
 6. [Implementation: Server-Side (TracingMiddleware)](#6-implementation-server-side-tracingmiddleware)
 7. [Implementation: Client-Side (TracedHTTPClient)](#7-implementation-client-side-tracedhttpclient)
@@ -116,7 +117,8 @@ Service C: "Returned response"       ← No idea!
 
 ## 3. The Solution: Context Propagation
 
-The solution is elegantly simple: **pass a unique identifier with every request**.
+The solution is elegantly simple: propagate the active trace plus the
+framework correlation identifiers needed to find related work.
 
 ### How It Works
 
@@ -152,11 +154,15 @@ The solution is elegantly simple: **pass a unique identifier with every request*
 └─────────────────┘ └─────────────────┘ └─────────────────┘
 ```
 
-### The W3C TraceContext Standard
+### The W3C Trace Context and Baggage Standards
 
-TruvaG3 uses the **W3C TraceContext** standard, which is supported by all major tracing systems (Jaeger, Zipkin, Datadog, etc.).
+TruvaG3 installs a composite OpenTelemetry propagator containing both
+**W3C Trace Context** and **W3C Baggage**:
 
-The magic happens through HTTP headers:
+- Trace Context carries `traceparent` and `tracestate`, preserving the
+  distributed trace.
+- Baggage carries framework and application correlation values such as
+  `request_id`, `original_request_id`, and the validated `conversation_id`.
 
 ```http
 # Outgoing request from agent to tool
@@ -164,7 +170,16 @@ POST /api/capabilities/get_weather HTTP/1.1
 Host: weather-tool:8080
 traceparent: 00-abc123def456789-span001-01
 tracestate: truvag3=research-agent
+baggage: request_id=orch-123,conversation_id=chat-456
+X-TruvaG3-Conversation-ID: chat-456
 ```
+
+The explicit `X-TruvaG3-*` headers are a telemetry-independent framework
+fallback used by orchestration receivers. They complement standard W3C
+propagation; they do not replace it. In particular,
+`X-TruvaG3-Conversation-ID` allows the canonical conversation identity to
+reach a framework receiver even when OpenTelemetry HTTP propagation is not
+initialized.
 
 **The `traceparent` header contains:**
 - `00` - Version (always 00)
@@ -229,6 +244,26 @@ research-agent: HTTP POST /api/research ─────────────�
 ```
 
 **Now you can instantly see:** The stock tool is the bottleneck (180ms vs 150ms for weather).
+
+### Correlation Taxonomy
+
+These identifiers answer different questions and must not be used
+interchangeably:
+
+| Identifier | Scope | Use it to answer |
+|------------|-------|------------------|
+| `request_id` | One orchestration execution/request. A top-level chat turn gets one ID; delegated and resumed executions get their own IDs. | “What happened in this execution?” |
+| `original_request_id` | One request family, such as an interrupt plus its resume or a parent plus delegated execution. | “Which related executions belong to this causal request family?” |
+| `conversation_id` | Multiple top-level turns in one application conversation. Related resume/delegation executions inherit it. | “What happened across this multi-turn conversation?” |
+| `trace_id` | One distributed trace. Synchronous delegation can remain in the same trace; a later HITL resume normally starts a new linked trace. | “Which spans participated in this distributed operation?” |
+
+`session_id` is application-defined and intentionally absent from this
+taxonomy. An application may map one chat-session UUID to
+`conversation_id`, as the reference chat agents do, but a session may instead
+represent authentication, browser state, or another lifecycle. The framework
+therefore does not infer conversation identity from `session_id`.
+Framework-created `conversation_id` baggage is metric-ineligible; existing
+unmarked `session_id` baggage retains the generic baggage metric behavior.
 
 ---
 
@@ -311,9 +346,11 @@ Now let's get practical. Here's how to add distributed tracing to your TruvaG3 t
 
 The `TracingMiddleware` wraps your HTTP handlers and automatically:
 1. **Extracts** trace context from incoming `traceparent` headers
-2. **Creates** a new span for this request
-3. **Records** HTTP metrics (status codes, latency)
-4. **Propagates** context to your handler code via `r.Context()`
+2. **Extracts** W3C baggage when the composite propagator is initialized
+3. **Creates** a new span for this request
+4. **Validates and stamps** supported `X-TruvaG3-*` correlation headers on the server span
+5. **Records** HTTP metrics (status codes, latency)
+6. **Propagates** context to your handler code via `r.Context()`
 
 ### Basic Usage (Recommended)
 
@@ -442,7 +479,7 @@ Server-side tracing is only half the story. When your **agent calls a tool**, yo
 ### What TracedHTTPClient Does
 
 The `NewTracedHTTPClient()` creates an HTTP client that automatically:
-1. **Injects** `traceparent` header into all outgoing requests
+1. **Injects** W3C Trace Context and W3C Baggage into outgoing requests
 2. **Creates** client-side spans for each HTTP call
 3. **Records** request/response metrics
 4. **Propagates** the trace context to downstream services
@@ -498,7 +535,7 @@ func (a *ResearchAgent) callWeatherTool(ctx context.Context, city string) (*Weat
     }
     req.Header.Set("Content-Type", "application/json")
 
-    // The traced client automatically adds traceparent header!
+    // The traced client automatically adds W3C trace and baggage headers.
     resp, err := a.httpClient.Do(req)
     if err != nil {
         return nil, err
@@ -529,8 +566,9 @@ Agent's httpClient.Do(req)
 │    Parent: span-001                                              │
 │    New span_id: span-002                                         │
 │                                                                  │
-│ 3. Inject traceparent header into request                       │
+│ 3. Inject W3C headers into request                              │
 │    traceparent: 00-abc123-span002-01                            │
+│    baggage: request_id=orch-123,...                             │
 │                                                                  │
 │ 4. Make the actual HTTP request                                 │
 │                                                                  │
@@ -538,7 +576,7 @@ Agent's httpClient.Do(req)
 └─────────────────────────────────────────────────────────────────┘
     │
     ▼
-Weather Tool receives request with traceparent header
+Weather Tool receives the request with W3C trace context and baggage
 ```
 
 ### Important: Always Pass Context!
@@ -696,7 +734,7 @@ func (r *ResearchAgent) callTool(ctx context.Context, url string, params interfa
     }
     req.Header.Set("Content-Type", "application/json")
 
-    // TracedHTTPClient adds traceparent header automatically
+    // TracedHTTPClient adds W3C trace and baggage headers automatically.
     resp, err := r.httpClient.Do(req)
     if err != nil {
         return nil, err
@@ -926,7 +964,7 @@ env:
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://otel-collector:4318"
   - name: APP_ENV
-    value: "production"  # or "development" for 100% sampling
+    value: "production"  # Selects safety/cardinality defaults, not trace sampling
 ```
 
 ### OTEL Collector Configuration
@@ -1044,7 +1082,7 @@ http://localhost:16686/trace/fee30b72efcbefd21fddf9cd56d2c8c9
    kubectl logs -n truvag3-examples deployment/stock-tool | grep "fee30b72efcbefd21fddf9cd56d2c8c9"
 
    # Or in Grafana Loki
-   {app="stock-tool"} |= "fee30b72efcbefd21fddf9cd56d2c8c9"
+   {service_name="stock-tool"} | json | trace_id="fee30b72efcbefd21fddf9cd56d2c8c9"
    ```
 
 ### Using request_id for Troubleshooting
@@ -1060,7 +1098,10 @@ When you make an orchestration request, the API response includes a `request_id`
 }
 ```
 
-**The `request_id` is your primary troubleshooting key** - it connects API responses to distributed traces and logs.
+**The `request_id` is the primary key for troubleshooting one execution.** It
+connects an API response to its execution record, distributed trace, and logs.
+Use `conversation_id` when the question spans multiple top-level turns, and
+`original_request_id` for an interrupt/resume or delegation family.
 
 #### How request_id Relates to Traces
 
@@ -1137,9 +1178,32 @@ Each span shows:
 | What You Have | How to Find the Trace |
 |---------------|----------------------|
 | `request_id` from API response | Search Jaeger by tag: `request_id=<value>` |
+| `conversation_id` from execution metadata | Search Jaeger by tag: `conversation_id=<value>` |
+| `original_request_id` from a resume/delegation | Search Jaeger by tag: `original_request_id=<value>` |
 | `trace_id` from logs | Direct URL: `http://localhost:16686/trace/<trace_id>` |
 | Time range of issue | Filter by service + time in Jaeger UI |
 | Error message | Search by tag: `error=true` |
+
+### Using `conversation_id` Across Turns
+
+When an application supplies a canonical `conversation_id`, orchestration
+validates and persists it from the first turn even when no prior history
+exists. It is available in execution metadata, LLM-debug metadata, validated
+structured logs, the explicit framework header, and instrumented span
+attributes. In the reference deployment, Registry Viewer reads the same value
+from execution DB 8 and LLM-debug DB 7.
+
+In Jaeger, search a service with:
+
+```
+conversation_id=chat-456
+```
+
+A recording server span created by `TracingMiddleware` carries the explicit
+conversation header as an attribute when the value is valid. Meaningful
+framework child spans that call the common enrichment helpers also carry it,
+but the framework does not promise identical attributes on every internal or
+third-party span.
 
 ---
 
@@ -1152,7 +1216,6 @@ This section documents the **required patterns** used throughout the TruvaG3 fra
 **Always check for nil before logging.** This ensures graceful degradation when logging is not configured.
 
 ```go
-// From orchestration/orchestrator.go:573-580
 if o.logger != nil {
     o.logger.InfoWithContext(ctx, "Starting request processing", map[string]interface{}{
         "operation":      "process_request",
@@ -1172,7 +1235,6 @@ if o.logger != nil {
 **Every log entry MUST include an `operation` field.** This enables filtering and analysis across distributed systems.
 
 ```go
-// From orchestration/orchestrator.go:598-604
 if o.logger != nil {
     o.logger.ErrorWithContext(ctx, "Plan generation failed", map[string]interface{}{
         "operation":   "plan_generation",  // REQUIRED
@@ -1195,8 +1257,6 @@ if o.logger != nil {
 **Generate request_id early and propagate via context baggage.** This enables end-to-end request tracking.
 
 ```go
-// From orchestration/orchestrator.go:567-571
-
 // Step 1: Generate unique request_id
 requestID := generateRequestID()
 
@@ -1227,9 +1287,73 @@ if baggage := telemetry.GetBaggage(ctx); baggage != nil {
 }
 ```
 
+### Framework Header Inventory
+
+Header names are case-insensitive on the wire; documentation and new code use
+the canonical `X-TruvaG3-*` spelling below. The executor sends these headers
+when their source value is present:
+
+| Header | Source | `core.ExtractRequestContext` | Tool-side server-span attribute |
+|--------|--------|------------------------------|---------------------------------|
+| `X-TruvaG3-Request-ID` | W3C baggage `request_id` | `core.GetRequestID` | `request_id` |
+| `X-TruvaG3-Original-Request-ID` | W3C baggage `original_request_id` | `core.GetOriginalRequestID` | `original_request_id` |
+| `X-TruvaG3-Conversation-ID` | validated canonical core context | validated conversation candidate | validated `conversation_id` |
+| `X-TruvaG3-Step-ID` | core step context | `core.GetStepID` | `step_id` |
+| `X-TruvaG3-Phase-Number` | W3C baggage `phase_number` | `core.GetPhaseNumber` | `phase_number` |
+| `X-TruvaG3-Plan-ID` | W3C baggage `plan_id` | `core.GetPlanID` | `plan_id` |
+| `X-TruvaG3-Agent-Name` | W3C baggage `agent_name` | `core.GetAgentName` | `caller_agent_name` |
+| `X-TruvaG3-Investigation-Owner` | W3C baggage `investigation_owner` | not extracted by this helper | not stamped by tracing middleware |
+
+HITL webhook delivery separately uses `X-TruvaG3-Event`,
+`X-TruvaG3-Checkpoint-ID`, and `X-TruvaG3-Request-ID`. Those webhook-control
+headers are not the executor’s normal agent/tool call inventory.
+
+### Conversation Correlation Is Optional and Fail-Open
+
+`resolveConversationContext` is the orchestration-ingress authority. It
+validates the selected identity and promotes it to metadata, core context, and
+exact W3C baggage. The baggage member is marked with
+`telemetry.WithMetricLabelEligibility(false)`.
+
+If correlation is rejected, business execution continues without a
+conversation identity. The framework increments the bounded
+`orchestration.conversation_id.rejected.total` diagnostic counter using only
+bounded `source`, `reason`, and `module` labels. Rejection does not record a
+span exception, set error status, or require a DEBUG log.
+
+### Common Span Attributes
+
+The common span helpers mirror these baggage members when present:
+`request_id`, `original_request_id`, `conversation_id`, `agent_name`,
+`user_id`, `session_id`, and `ai.purpose`.
+
+HTTP middleware validates the explicit conversation header before stamping the
+server span. Baggage-sourced helpers propagate members as provided; normal
+framework flows are safe because orchestration validates `conversation_id`
+before adding it to baggage. Applications using generic baggage APIs are
+responsible for validating values they add themselves.
+
+Common enrichment is best-effort for meaningful framework child spans. Do not
+require attribute parity on every third-party or internal span.
+
+### Baggage Construction Limits
+
+Both construction paths enforce 64 members, 128-byte keys, 512-byte values,
+and an 8192-byte complete serialized W3C baggage value. The total includes
+separators, encoding, and member properties.
+
+`telemetry.WithBaggage` accepts multiple pairs, enforces the member cap for
+each candidate as it is added, truncates overlong key/value input to the
+per-item limits, and silently skips invalid or over-limit candidates.
+`telemetry.WithBaggageExact` adds or replaces one member without truncation and
+returns the original context plus a typed `BaggageExactError` if the complete
+update is invalid or over limit.
+
 ### Pattern 4: telemetry.RecordSpanError for All Errors
 
-**Always record errors on the span for trace visibility.** This makes errors visible in Jaeger.
+**Record business-operation errors on the span for trace visibility.** This
+makes failures visible in Jaeger. Optional correlation rejection is not a
+business-operation failure and follows the fail-open rule above.
 
 At an external-service or AI-provider boundary, record a sanitized derivative
 when the original error may contain response bodies, endpoints, credential
@@ -1239,7 +1363,6 @@ caller-visible error chain. The AI module uses
 exception and bounded `ai.error_type` while still marking the span as failed.
 
 ```go
-// From orchestration/executor.go:1228-1235
 agentInfo := e.findAgentByName(step.AgentName)
 if agentInfo == nil {
     err := fmt.Errorf("agent %s not found in catalog", step.AgentName)
@@ -1264,7 +1387,6 @@ if agentInfo == nil {
 **Include the `module` label in all counter metrics.** This enables per-module metric analysis.
 
 ```go
-// From orchestration/orchestrator.go:1123-1124
 telemetry.Counter("plan_generation.total",
     "module", telemetry.ModuleOrchestration,  // REQUIRED
     "status", "error",
@@ -1288,7 +1410,6 @@ telemetry.Counter("orchestration.hybrid_resolution.success",
 **When calling `telemetry.AddSpanEvent()`, always put `request_id` as the first attribute.** This ensures consistent attribute ordering in Jaeger.
 
 ```go
-// From orchestration/orchestrator.go:1092-1099
 telemetry.AddSpanEvent(ctx, "llm.plan_generation.request",
     attribute.String("request_id", requestID),  // FIRST attribute
     attribute.String("prompt", truncateString(prompt, 2000)),
@@ -1530,13 +1651,17 @@ log.Printf("Processing request trace_id=%s span_id=%s", tc.TraceID, tc.SpanID)
 
 **Symptoms:** Millions of traces, hard to find important ones.
 
-**Fix 1: Reduce sampling rate for production**
-```go
-// In telemetry initialization
-config := telemetry.UseProfile(telemetry.ProfileProduction)  // 0.1% sampling
-```
+**Current behavior:** The built-in tracer provider uses
+`sdktrace.AlwaysSample()` for every telemetry profile. Selecting
+`ProfileProduction` changes endpoint, cardinality, circuit-breaker, and
+redaction defaults; it does not reduce trace sampling.
 
-**Fix 2: Exclude health endpoints**
+If trace-volume reduction is required, treat it as an explicit deployment or
+framework design decision and validate that it preserves the investigation and
+HITL traces your operators need. There is currently no sampling-rate field in
+`telemetry.Config`.
+
+**Reduce noise by excluding health endpoints:**
 ```go
 config := &telemetry.TracingMiddlewareConfig{
     ExcludedPaths: []string{"/health", "/metrics", "/ready", "/live"},
@@ -1595,7 +1720,7 @@ log.Printf("Message trace_id=%s span_id=%s", tc.TraceID, tc.SpanID)
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTEL Collector endpoint | `http://otel-collector:4318` |
-| `APP_ENV` | Environment (affects sampling) | `production`, `development` |
+| `APP_ENV` | Application profile selection used by example initialization code | `production`, `development` |
 
 ### Key Types and Functions
 
@@ -1614,11 +1739,14 @@ log.Printf("Message trace_id=%s span_id=%s", tc.TraceID, tc.SpanID)
 
 ### Telemetry Profiles
 
-| Profile | Sampling | Use Case |
-|---------|----------|----------|
-| `ProfileDevelopment` | 100% | Local development, see everything |
-| `ProfileStaging` | 10% | Testing environments |
-| `ProfileProduction` | 0.1% | High-traffic production |
+All profiles currently use 100% trace sampling through
+`sdktrace.AlwaysSample()`. Their differences are operational defaults:
+
+| Profile | Trace sampling | Other defaults |
+|---------|----------------|----------------|
+| `ProfileDevelopment` | 100% | Local endpoint, high cardinality limit, no circuit breaker, no PII redaction |
+| `ProfileStaging` | 100% | Staging endpoint, lower cardinality limit, circuit breaker and PII redaction |
+| `ProfileProduction` | 100% | Production endpoint, strictest cardinality limits, circuit breaker and PII redaction |
 
 ---
 
@@ -1919,21 +2047,16 @@ This automatic visibility into AI decision-making makes debugging orchestration 
 
 ## 16. HITL Cross-Trace Correlation
 
-Human-in-the-Loop (HITL) flows present a unique distributed tracing challenge: the original request trace ends when execution pauses for human approval, and a completely new trace begins when the user resumes. Without special handling, these traces appear disconnected in Jaeger, making it difficult to understand the full request lifecycle.
+Human-in-the-Loop (HITL) flows cross an asynchronous boundary: the interrupt
+trace normally ends while a human reviews the checkpoint, and a later resume
+request starts a new trace. TruvaG3 links those traces while retaining two
+different forms of correlation:
 
-### The Problem: Disconnected Traces
+- `original_request_id` identifies the interrupt/resume request family.
+- `conversation_id` identifies the broader multi-turn conversation and remains
+  the same across unrelated top-level turns in that conversation.
 
-```
-Request A: User sends query → Plan generated → HITL pauses (trace ends)
-                          [minutes/hours pass - human reviews]
-Request B: User approves → Resume → Execution continues (new trace)
-
-In Jaeger, these appear as TWO UNRELATED traces:
-- Trace A: "chat.process_request" (stops at checkpoint)
-- Trace B: "hitl.resume" (starts fresh, no connection to Trace A)
-```
-
-### The Solution: Linked Spans with Baggage
+### Framework-Owned Resume Contract
 
 TruvaG3 uses **trace links** (not parent-child relationships) to connect resume traces to their original requests. This is the correct semantic model because:
 
@@ -1941,93 +2064,59 @@ TruvaG3 uses **trace links** (not parent-child relationships) to connect resume 
 2. The original trace may have already ended
 3. Resume can happen long after the original request
 
-#### How It Works
+The HITL controller stores `OriginalTraceID`, `OriginalSpanID`, and
+`OriginalRequestID` in `ExecutionCheckpoint`. Its framework-owned shallow
+metadata copy also carries a valid canonical `conversation_id` when one is
+present.
 
-**Step 1: Store Trace Context in Checkpoint**
-
-When HITL creates a checkpoint, it automatically stores the current trace context:
-
-```go
-// orchestration/hitl_controller.go (lines 797-800)
-tc := telemetry.GetTraceContext(ctx)
-if tc.TraceID != "" {
-    userContext["original_trace_id"] = tc.TraceID
-    userContext["original_span_id"] = tc.SpanID
-}
-```
-
-**Step 2: Create Linked Span on Resume**
-
-When execution resumes, create a linked span that references the original trace:
+Applications resume through `orchestration.BuildResumeContext`. They must not
+duplicate trace-link creation or manually reconstruct the resume baggage:
 
 ```go
-// examples/agent-with-human-approval/handlers.go (lines 330-358)
-// Extract trace context from checkpoint
-originalTraceID := ""
-originalSpanID := ""
-originalRequestID := checkpoint.RequestID
-
-if checkpoint.UserContext != nil {
-    if tid, ok := checkpoint.UserContext["original_trace_id"].(string); ok {
-        originalTraceID = tid
-    }
-    if sid, ok := checkpoint.UserContext["original_span_id"].(string); ok {
-        originalSpanID = sid
-    }
+checkpoint, err := checkpointStore.LoadCheckpoint(ctx, checkpointID)
+if err != nil {
+    return err
 }
 
-// Create linked span (NOT a child span)
-ctx, endLinkedSpan := telemetry.StartLinkedSpan(
-    ctx,
-    "hitl.resume",
-    originalTraceID,
-    originalSpanID,
-    map[string]string{
-        "checkpoint_id":       checkpointID,
-        "request_id":          checkpoint.RequestID,
-        "original_request_id": originalRequestID,
-        "link.type":           "hitl_resume",
-    },
+resumeCtx, endResumeSpan, err :=
+    orchestration.BuildResumeContext(ctx, checkpoint)
+if err != nil {
+    return err
+}
+defer endResumeSpan()
+
+_, err = orchestrator.ProcessRequest(
+    resumeCtx,
+    checkpoint.OriginalRequest,
+    nil,
 )
-defer endLinkedSpan()
+return err
 ```
 
-**Step 3: Propagate Original Request ID**
+`BuildResumeContext`:
 
-Use W3C Baggage to propagate the original request ID through all downstream spans:
+1. validates that the checkpoint is resumable;
+2. resolves `original_request_id`, falling back from
+   `checkpoint.OriginalRequestID` to `checkpoint.RequestID`;
+3. scrubs inherited conversation identity and restores only a valid
+   checkpoint `conversation_id`;
+4. places that conversation ID into exact, metric-ineligible W3C baggage
+   before the resume span starts;
+5. creates the linked `hitl.resume` span using the stored original trace/span;
+6. sets `checkpoint_id`, `interrupt_point`, `request_id`,
+   `original_request_id`, `link.type=hitl_resume`, and the validated
+   `conversation_id` on that span;
+7. propagates `original_request_id` and restores resume mode, plan, completed
+   steps, pre-resolved parameters, request mode, and sanitized metadata.
 
-```go
-// Propagate original_request_id through all downstream operations
-ctx = telemetry.WithBaggage(ctx, "original_request_id", originalRequestID)
-```
+An invalid or capacity-rejected checkpoint conversation ID is omitted and
+increments the bounded rejection counter. It does not fail the resume or mark
+the span as failed.
 
-This ensures that every span created during the resumed execution has access to `original_request_id`, making correlation searches possible.
-
-### Frontend Integration for Trace Correlation
-
-The frontend should send the original request ID on resume calls:
-
-```javascript
-// examples/chat-ui/hitl.html
-// Store original request_id from first checkpoint
-if (data.request_id && !originalRequestId) {
-    originalRequestId = data.request_id;
-}
-
-// Send on all resume requests
-const headers = {
-    'Content-Type': 'application/json',
-    'Accept': 'text/event-stream'
-};
-if (originalRequestId) {
-    headers['X-Truvag3-Original-Request-ID'] = originalRequestId;
-}
-
-fetch(`${backendUrl}/hitl/resume/${checkpointId}`, {
-    method: 'POST',
-    headers: headers
-});
-```
+If an application accepts a trusted
+`X-TruvaG3-Original-Request-ID` override, apply it to
+`checkpoint.OriginalRequestID` before calling `BuildResumeContext`. The helper
+still owns link and baggage construction.
 
 ### Understanding Trace Links vs Parent-Child
 
@@ -2049,6 +2138,7 @@ Jaeger View:
 │ Tags:                                                           │
 │   checkpoint_id: cp-abc123                                      │
 │   original_request_id: req-xyz789                               │
+│   conversation_id: chat-456                                     │
 │   link.type: hitl_resume                                        │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -2067,7 +2157,13 @@ Service: agent-with-human-approval
 Tags: checkpoint_id=cp-abc123
 ```
 
-**Method 3: Follow Links from Original Trace**
+**Method 3: Search the Whole Conversation**
+```
+Service: agent-with-human-approval
+Tags: conversation_id=chat-456
+```
+
+**Method 4: Follow Links from Original Trace**
 1. Find the original trace that created the checkpoint
 2. Look for spans with `hitl_checkpoint_created` events
 3. Note the `checkpoint_id`
@@ -2082,6 +2178,8 @@ Tags: checkpoint_id=cp-abc123
 
 TRACE A: Original Request (trace_id: aaa111)
 ├── chat.process_request (span_id: bbb222)
+│   conversation_id: chat-456
+│   request_id: req-xyz789
 │   ├── orchestrator.process_request
 │   │   ├── orchestrator.generate_plan
 │   │   └── [HITL checkpoint created]
@@ -2096,8 +2194,10 @@ TRACE B: Resume Request (trace_id: ccc333)
 │   │   References: FOLLOWS_FROM trace_id=aaa111, span_id=bbb222
 │   │   Tags: original_request_id=req-xyz789
 │   │         checkpoint_id=cp-abc123
+│   │         conversation_id=chat-456
 │   │         link.type=hitl_resume
 │   │   Baggage: original_request_id=req-xyz789
+│   │            conversation_id=chat-456 (metric-ineligible)
 │   │
 │   ├── orchestrator.process_request  ← Baggage propagated
 │   │   ├── HTTP POST → weather-tool  ← Baggage propagated
@@ -2109,36 +2209,34 @@ In Jaeger:
 - Find Trace A by request_id or time
 - See "hitl_checkpoint_created" event with checkpoint_id
 - Search for Trace B using checkpoint_id or original_request_id
+- Search all turns and related executions using conversation_id
 - Click "References" in Trace B to jump to Trace A
 ```
 
 ### Key Functions for HITL Tracing
 
-| Function | Purpose | Location |
-|----------|---------|----------|
-| `telemetry.StartLinkedSpan` | Create span with trace link to another trace | `telemetry/async_span.go:84` |
-| `telemetry.WithBaggage` | Propagate key-value through all downstream spans | `telemetry/context.go:76` |
-| `telemetry.GetTraceContext` | Extract current trace/span IDs for storage | `telemetry/trace_context.go:78` |
+| Function | Purpose |
+|----------|---------|
+| `orchestration.BuildResumeContext` | Validate the checkpoint, restore correlation/resume state, and create the linked resume span |
+| `telemetry.StartLinkedSpan` | Low-level linked-span primitive used by the framework helper |
+| `telemetry.GetTraceContext` | Capture the active trace/span IDs when creating a checkpoint |
 
 ### Best Practices for HITL Tracing
 
-1. **Always store trace context in checkpoints** - The controller does this automatically via `userContext`
+1. **Use the controller-created checkpoint** — It captures typed trace and
+   request-lineage fields automatically.
 
-2. **Use linked spans, not child spans** - Resume operations are semantically "follows from", not "child of"
+2. **Always call `BuildResumeContext`** — Call its cleanup function and use the
+   returned context for resumed processing.
 
-3. **Propagate original_request_id via baggage** - This enables searching by the user-visible request ID
+3. **Do not duplicate link or baggage setup** — The framework helper owns both.
 
-4. **Include checkpoint_id in all HITL spans** - Essential for correlating approval commands with execution
+4. **Choose the correct search key** — Use `checkpoint_id` or
+   `original_request_id` for one resume family; use `conversation_id` across
+   top-level turns.
 
-5. **Log cross-trace correlation in span events** - Add events when creating links for debugging:
-   ```go
-   import "go.opentelemetry.io/otel/attribute"
-
-   telemetry.AddSpanEvent(ctx, "hitl.trace_link_created",
-       attribute.String("original_trace_id", originalTraceID),
-       attribute.String("checkpoint_id", checkpointID),
-   )
-   ```
+5. **Treat missing trace context as graceful degradation** — The helper creates
+   an unlinked root span when the stored original trace/span is absent.
 
 ---
 
@@ -2267,7 +2365,9 @@ If you don't see `ai.generate`, provider execution, or `ai.http_attempt` spans:
 1. **Check initialization order**: Telemetry MUST be initialized before creating the AI client
 2. **Verify telemetry is enabled**: Check your logs for "Telemetry initialized successfully"
 3. **Confirm AI client has telemetry**: Ensure you pass `ai.WithTelemetry(telemetry.GetTelemetryProvider())`
-4. **Check sampling rate**: In production profile (0.1% sampling), most traces won't be captured
+4. **Check exporter and collector health**: All built-in profiles currently
+   use `sdktrace.AlwaysSample()`, so a missing span is not explained by profile
+   sampling
 
 ### Framework-Driven Logger Propagation
 
@@ -2317,11 +2417,13 @@ See these examples for production-ready AI telemetry patterns:
 Distributed tracing transforms debugging from guesswork into science. Here's what you've learned:
 
 1. **The Problem:** Without tracing, logs from different services have no common identifier
-2. **The Solution:** Trace IDs propagate through HTTP headers (W3C TraceContext)
+2. **The Solution:** Trace IDs propagate through HTTP headers (W3C Trace Context)
 3. **Server-Side:** `TracingMiddleware` extracts/creates traces for incoming requests
-4. **Client-Side:** `TracedHTTPClient` propagates traces to downstream services
+4. **Client-Side:** `TracedHTTPClient` propagates W3C Trace Context and Baggage to downstream services
 5. **Log Correlation:** Extract trace IDs from context to include in your logs
-6. **Infrastructure:** OTEL Collector + Jaeger + Grafana for collection and visualization
+6. **Conversation Correlation:** Use `conversation_id` across turns and `original_request_id` only for a resume/delegation family
+7. **HITL Ownership:** Resume through `BuildResumeContext`; the framework creates the trace link and restores validated correlation
+8. **Infrastructure:** OTEL Collector + Jaeger + Grafana for collection and visualization
 
 **Remember:** Tracing is like having GPS for your requests. You always know where they are, where they've been, and why they're stuck in traffic!
 

--- a/docs/observability/LOGGING_IMPLEMENTATION_GUIDE.md
+++ b/docs/observability/LOGGING_IMPLEMENTATION_GUIDE.md
@@ -656,7 +656,7 @@ The `WithContext` methods enable trace-log correlation. Here's how it works:
 
 1. **TracingMiddleware** extracts/creates trace context from incoming requests
 2. **Context** carries the trace ID and span ID through your code
-3. **WithContext methods** extract and include these IDs in log output
+3. **WithContext methods** enrich telemetry-enabled logs from that context
 
 > **Source**: Trace context extraction is handled by [`telemetry/trace_context.go`](https://github.com/truvaagents/truva-g3/blob/main/telemetry/trace_context.go) and [`telemetry/framework_integration.go`](https://github.com/truvaagents/truva-g3/blob/main/telemetry/framework_integration.go)
 
@@ -696,17 +696,47 @@ When using JSON format (production), trace context appears as **top-level fields
 
 > **Design Principle**: TruvaG3 uses standard OpenTelemetry field names (`trace_id`, `span_id`) at the root level for vendor-agnostic compatibility with any OTel-compliant observability backend (SigNoz, Grafana Loki, Datadog, Elastic, etc.).
 
+For a telemetry-enabled `ProductionLogger`, context-aware JSON output includes
+the W3C baggage map plus `trace_id` and `span_id`. That is how a validated
+`conversation_id` becomes a top-level structured field without every call
+site adding it manually. Explicit log fields are applied afterward and may
+override an automatically enriched key, so framework code should not reuse
+reserved correlation names for unrelated values.
+
+Text output intentionally retains its existing request-oriented prefix and
+adds only `[req=<request_id>]`; it does not render the complete baggage map.
+Detached or non-context logging cannot depend on automatic enrichment and must
+carry any captured correlation fields explicitly.
+
 ---
 
 ## 9. HITL (Human-in-the-Loop) Request Tracing
 
-HITL workflows present a unique logging challenge: a single user conversation may span **multiple HTTP requests** with **different `request_id` values**. This section explains how to correlate logs across the entire HITL conversation.
+HITL workflows present a unique logging challenge: one interrupted execution
+and its later resume span multiple HTTP requests with different `request_id`
+values. That request family is narrower than a multi-turn conversation.
 
-### The Challenge: Multiple Requests, One Conversation
+### Correlation Taxonomy
+
+| Identifier | Scope | Logging use |
+|------------|-------|-------------|
+| `request_id` | One orchestration execution/request | Required on request-scoped framework logs |
+| `original_request_id` | One interrupt/resume or delegation request family | Follow causally related execution siblings |
+| `conversation_id` | Multiple top-level turns in one application conversation | Troubleshoot the complete multi-turn interaction |
+| `trace_id` | One distributed trace | Join logs to the span waterfall |
+
+`checkpoint_id` narrows an HITL investigation to one checkpoint. An
+application `session_id` remains generic: a reference chat agent may map its
+session UUID to `conversation_id`, but the framework does not assign that
+meaning to every session. Registry Viewer reads the validated conversation
+value from execution DB 8 and LLM-debug DB 7; it does not infer the value from
+session metadata.
+
+### The Challenge: Multiple Requests, One Request Family
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ HITL CONVERSATION FLOW                                                   │
+│ HITL REQUEST FAMILY                                                      │
 ├─────────────────────────────────────────────────────────────────────────┤
 │                                                                          │
 │  Request 1 (Parent)         Request 2 (Child/Resume)                    │
@@ -726,111 +756,62 @@ HITL workflows present a unique logging challenge: a single user conversation ma
 │                                                                          │
 │  HOW DO WE CORRELATE THESE TWO REQUESTS?                                │
 │  Answer: original_request_id = "req-abc123" (same for both!)            │
+│  Broader thread: conversation_id = "chat-456"                           │
 │                                                                          │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-### The Solution: `original_request_id`
+### The Two Correlation Axes
 
-TruvaG3 uses `original_request_id` to link all requests in a HITL conversation:
-
-| Field | Initial Request | Resume Request | Purpose |
+| Field | Initial request | Resume request | Purpose |
 |-------|-----------------|----------------|---------|
-| `request_id` | `req-abc123` | `req-def456` | Unique per HTTP request |
-| `original_request_id` | `req-abc123` | `req-abc123` | Same across conversation |
+| `request_id` | `req-abc123` | `req-def456` | Unique per execution |
+| `original_request_id` | `req-abc123` | `req-abc123` | Same within this request family |
+| `conversation_id` | `chat-456` | `chat-456` | Same across this and other turns in the conversation |
 | `trace_id` | `trace-111` | `trace-222` | Unique per distributed trace |
-| `checkpoint_id` | `cp-xyz789` | `cp-xyz789` | Links interrupt to resume |
+| `checkpoint_id` | `cp-xyz789` | `cp-xyz789` | Identifies the checkpoint |
 
-**Key insight**: `original_request_id` is the **correlation key** for the entire HITL conversation.
+Use `original_request_id` to troubleshoot the interrupt and resume together.
+Use `conversation_id` when the investigation spans other top-level turns.
 
-### How `original_request_id` Flows Through the System
+### Framework-Owned Resume Correlation
 
-#### 1. Initial Request (Parent)
+The HITL controller stores the original request, trace, and span IDs in
+`ExecutionCheckpoint`, together with a framework-owned shallow metadata copy.
+`orchestration.BuildResumeContext` is the single resume authority: it restores
+`original_request_id`, validates and restores `conversation_id`, marks that
+baggage member metric-ineligible, creates the linked `hitl.resume` span, and
+restores plan/resume state.
 
-```go
-// orchestrator.go - ProcessRequest
-requestID := generateRequestID()  // e.g., "req-abc123"
-
-// For initial requests, original_request_id == request_id
-ctx = telemetry.WithBaggage(ctx, "request_id", requestID)
-// original_request_id defaults to request_id when not set in baggage
-```
-
-When a HITL checkpoint is created, `hitl_controller.go` captures:
+Application handlers load the checkpoint and call the helper. They do not
+manually call `StartLinkedSpan` or rebuild baggage:
 
 ```go
-// hitl_controller.go - createCheckpoint
-originalRequestID := requestID  // Default to current request_id
-if bag := telemetry.GetBaggage(ctx); bag != nil {
-    if origID := bag["original_request_id"]; origID != "" {
-        originalRequestID = origID  // Use preserved original for resume
-    }
+checkpoint, err := checkpointStore.LoadCheckpoint(ctx, checkpointID)
+if err != nil {
+    return err
 }
 
-checkpoint := &ExecutionCheckpoint{
-    RequestID:         requestID,          // "req-abc123"
-    OriginalRequestID: originalRequestID,  // "req-abc123" (same for initial)
-    // ...
+resumeCtx, endResumeSpan, err :=
+    orchestration.BuildResumeContext(ctx, checkpoint)
+if err != nil {
+    return err
 }
+defer endResumeSpan()
+
+_, err = orchestrator.ProcessRequest(
+    resumeCtx,
+    checkpoint.OriginalRequest,
+    nil,
+)
+return err
 ```
 
-#### 2. Resume Request (Child)
-
-When the agent resumes from a checkpoint, it **must** set `original_request_id` in baggage. The reference implementation in `agent-with-human-approval` uses this priority logic:
-
-```go
-// handlers.go - handleResumeSSE (from agent-with-human-approval)
-checkpoint, _ := checkpointStore.LoadCheckpoint(ctx, checkpointID)
-
-// Determine original_request_id for trace correlation across HITL conversation
-// Priority: 1) Header from UI, 2) Checkpoint's OriginalRequestID, 3) Checkpoint's RequestID (fallback)
-// NOTE: For step checkpoints, RequestID is the resume request's ID, not the original.
-// OriginalRequestID preserves the first request's ID across the entire HITL conversation.
-originalRequestID := originalRequestIDFromHeader  // From X-Original-Request-ID header
-if originalRequestID == "" {
-    if checkpoint.OriginalRequestID != "" {
-        originalRequestID = checkpoint.OriginalRequestID
-    } else {
-        originalRequestID = checkpoint.RequestID  // Fallback for legacy checkpoints
-    }
-}
-
-// Log the trace correlation setup
-t.Logger.InfoWithContext(ctx, "Trace correlation IDs determined", map[string]interface{}{
-    "operation":                       "hitl_resume_trace_setup",
-    "checkpoint_id":                   checkpointID,
-    "checkpoint_request_id":           checkpoint.RequestID,
-    "checkpoint_original_request_id":  checkpoint.OriginalRequestID,
-    "original_request_id_used":        originalRequestID,
-})
-
-// Set in baggage BEFORE calling orchestrator
-ctx = telemetry.WithBaggage(ctx, "original_request_id", originalRequestID)
-
-// Now call orchestrator - it will generate a NEW request_id
-// but original_request_id will be preserved via baggage
-result, err := orchestrator.ProcessRequestStreaming(ctx, checkpoint.OriginalRequest, ...)
-```
-
-#### 3. Execution Storage
-
-The `storeExecutionAsync` helper extracts `original_request_id` from baggage:
-
-```go
-// orchestrator.go - storeExecutionAsync
-originalRequestID := requestID  // Default
-if bag != nil {
-    if origID, ok := bag["original_request_id"]; ok && origID != "" {
-        originalRequestID = origID  // Links to parent request
-    }
-}
-
-stored := &StoredExecution{
-    RequestID:         requestID,          // "req-def456" (new)
-    OriginalRequestID: originalRequestID,  // "req-abc123" (preserved)
-    // ...
-}
-```
+The helper falls back from `checkpoint.OriginalRequestID` to
+`checkpoint.RequestID`. If an application accepts a trusted
+`X-TruvaG3-Original-Request-ID` override, it may update the typed checkpoint
+field before calling the helper; link and baggage setup remain
+framework-owned.
 
 ### Logging Fields for HITL
 
@@ -838,9 +819,10 @@ When logging in HITL-related code, include these fields:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `request_id` | **YES** | Current request's unique ID |
-| `original_request_id` | For HITL | Links to the conversation's first request |
-| `checkpoint_id` | For HITL | Links interrupt to resume |
+| `request_id` | **YES** for request-scoped logs | Current execution's unique ID |
+| `original_request_id` | For HITL/delegation | Links one causal request family |
+| `conversation_id` | When validated conversation context exists | Links multiple top-level turns |
+| `checkpoint_id` | For HITL | Identifies the interrupt/resume checkpoint |
 | `interrupted` | For HITL | Boolean indicating if this request was interrupted |
 
 **Example: HITL checkpoint creation log** (from orchestrator.go)
@@ -856,7 +838,9 @@ if o.logger != nil {
 }
 ```
 
-> **Note**: The `original_request_id` is captured in the `ExecutionCheckpoint` struct and persisted to the checkpoint store. The checkpoint's `OriginalRequestID` field is then used during resume to correlate the conversation.
+> **Note**: `ExecutionCheckpoint.OriginalRequestID` preserves request-family
+> lineage. The validated `conversation_id` is carried independently in the
+> checkpoint’s framework-owned metadata.
 
 **Example: Resume execution log**
 
@@ -866,6 +850,7 @@ if a.Logger != nil {
         "operation":           "hitl_resume",
         "request_id":          newRequestID,        // New request_id
         "original_request_id": originalRequestID,  // Preserved from parent
+        "conversation_id":     conversationID,     // Preserved across turns
         "checkpoint_id":       checkpoint.CheckpointID,
         "checkpoint_status":   checkpoint.Status,
     })
@@ -874,44 +859,53 @@ if a.Logger != nil {
 
 ### Filtering Logs by `original_request_id`
 
-To see the **entire HITL conversation** across all requests:
+Use this field to see one HITL request family:
 
 #### JSON Format (with jq)
 
 ```bash
-# Find all logs for a HITL conversation
+# Find all logs for one interrupt/resume family
 kubectl logs -n truvag3-examples -l app=agent-with-human-approval | \
   jq 'select(.original_request_id == "req-abc123" or .request_id == "req-abc123")'
 
-# Show the conversation timeline
+# Show the request-family timeline
 kubectl logs -n truvag3-examples -l app=agent-with-human-approval | \
   jq 'select(.original_request_id == "req-abc123")' | \
   jq -s 'sort_by(.timestamp) | .[] | {timestamp, operation, request_id, message}'
+
+# Show every logged turn in the broader conversation
+kubectl logs -n truvag3-examples -l app=agent-with-human-approval | \
+  jq 'select(.conversation_id == "chat-456")'
 ```
 
 #### Grafana Loki (LogQL)
 
 ```logql
-# All logs in a HITL conversation
-{namespace="truvag3-examples", app="agent-with-human-approval"}
+# One HITL request family
+{service_name="agent-with-human-approval"}
   | json
   | original_request_id="req-abc123"
 
+# All top-level turns and related executions in the conversation
+{service_name="agent-with-human-approval"}
+  | json
+  | conversation_id="chat-456"
+
 # HITL interrupts only
-{namespace="truvag3-examples"}
+{k8s_namespace_name="truvag3-examples"}
   | json
   | interrupted="true"
 
 # Correlation: find resume logs for a checkpoint
-{namespace="truvag3-examples"}
+{k8s_namespace_name="truvag3-examples"}
   | json
   | checkpoint_id="cp-xyz789"
   | operation="hitl_resume"
 ```
 
-### Example: Complete HITL Conversation Logs
+### Example: Complete HITL Request-Family Logs
 
-Here's what a full HITL conversation looks like in logs:
+Here is an interrupt and resume within conversation `chat-456`:
 
 ```json
 // === INITIAL REQUEST (Parent) ===
@@ -922,6 +916,8 @@ Here's what a full HITL conversation looks like in logs:
   "message": "Starting request processing",
   "operation": "process_request",
   "request_id": "req-abc123",
+  "original_request_id": "req-abc123",
+  "conversation_id": "chat-456",
   "request_length": 45
 }
 
@@ -943,6 +939,8 @@ Here's what a full HITL conversation looks like in logs:
   "message": "Plan execution interrupted for human approval",
   "operation": "hitl_plan_approval",
   "request_id": "req-abc123",
+  "original_request_id": "req-abc123",
+  "conversation_id": "chat-456",
   "plan_id": "plan-001",
   "checkpoint_id": "cp-xyz789"
 }
@@ -967,6 +965,7 @@ Here's what a full HITL conversation looks like in logs:
   "operation": "hitl_resume",
   "request_id": "req-def456",
   "original_request_id": "req-abc123",
+  "conversation_id": "chat-456",
   "checkpoint_id": "cp-xyz789"
 }
 
@@ -988,78 +987,111 @@ Here's what a full HITL conversation looks like in logs:
   "message": "Plan execution completed",
   "operation": "plan_execution",
   "request_id": "req-def456",
+  "original_request_id": "req-abc123",
+  "conversation_id": "chat-456",
   "plan_id": "plan-001",
   "success": true,
   "duration_ms": 3000
 }
 ```
 
-**Observation**: Notice how `original_request_id: "req-abc123"` appears in both the initial interrupt log and the resume logs, allowing you to trace the entire conversation.
+**Observation**: `original_request_id` joins the interrupt and resume.
+`conversation_id` can also find other turns that are not part of this request
+family.
 
-### DAG Visualization and `original_request_id`
+### DAG Visualization: Conversation vs Request Family
 
-The DAG visualization in the Registry Viewer uses `original_request_id` to group related executions:
+Registry Viewer uses the two keys at different levels:
+
+- `conversation_id` groups top-level turns into a conversation unit and powers
+  the chronological timeline.
+- `original_request_id` nests resume/delegation executions beneath the
+  appropriate top-level turn.
+
+```
+Conversation chat-456
+├─ Turn 1: req-abc123 (interrupted)
+│  └─ Related resume: req-def456 (original_request_id=req-abc123)
+└─ Turn 2: req-ghi789
+```
+
+### Detached Execution-Storage Logging
+
+`storeExecutionAsync` captures correlation before launching the goroutine,
+retains context values with `context.WithoutCancel`, applies a bounded timeout,
+and uses a non-context logger with explicit captured fields:
 
 ```go
-// ExecutionSummary in redis_execution_store.go
-type ExecutionSummary struct {
-    RequestID         string    `json:"request_id"`
-    OriginalRequestID string    `json:"original_request_id,omitempty"`
-    Interrupted       bool      `json:"interrupted,omitempty"`
-    // ...
+bag := telemetry.GetBaggage(ctx)
+traceID := telemetry.GetTraceContext(ctx).TraceID
+conversationID := core.GetConversationID(ctx)
+if core.ValidateConversationID(conversationID) !=
+    core.ConversationIDValidationNone {
+    conversationID = ""
 }
-```
+originalRequestID := requestID
+if bag != nil && bag["original_request_id"] != "" {
+    originalRequestID = bag["original_request_id"]
+}
 
-In the UI, executions with the same `original_request_id` are grouped as parent-child:
+go func() {
+    storeCtx, cancel := context.WithTimeout(
+        context.WithoutCancel(ctx),
+        5*time.Second,
+    )
+    defer cancel()
 
-```
-Execution DAG
-├─ req-abc123 (Parent, Interrupted: true)
-│  └─ Checkpoint: cp-xyz789 (Plan Approval)
-│
-└─ req-def456 (Child, OriginalRequestID: req-abc123)
-   └─ Steps: weather → currency → response
-```
-
-### Background Goroutine Logging for HITL
-
-When storing HITL executions asynchronously, use **non-context logging methods** since the goroutine runs with `context.Background()`:
-
-```go
-// orchestrator.go - storeExecutionAsync
-// This runs in a goroutine with context.Background()
-// so we use o.logger.Warn() NOT o.logger.WarnWithContext()
-
-if storeErr := store.Store(storeCtx, stored); storeErr != nil {
-    if o.logger != nil {
-        logFields := map[string]interface{}{
-            "operation":   "execution_store",
-            "request_id":  requestID,
-            "interrupted": checkpoint != nil,
-            "error":       storeErr.Error(),
-        }
-        if traceID != "" {
-            logFields["trace_id"] = traceID
-        }
-        if checkpoint != nil && checkpoint.CheckpointID != "" {
-            logFields["checkpoint_id"] = checkpoint.CheckpointID
-        }
-        o.logger.Warn("Failed to store execution for DAG visualization", logFields)
+    stored := &StoredExecution{
+        RequestID:         requestID,
+        OriginalRequestID: originalRequestID,
+        TraceID:           traceID,
+        // ... immutable values captured before the goroutine
     }
-}
+
+    if storeErr := store.Store(storeCtx, stored); storeErr != nil {
+        if o.logger != nil {
+            fields := map[string]interface{}{
+                "operation":   "execution_store",
+                "request_id":  requestID,
+                "interrupted": checkpoint != nil,
+                "error_type":  "store_write",
+                "error":       safeExecutionStoreError(storeErr),
+            }
+            if traceID != "" {
+                fields["trace_id"] = traceID
+            }
+            if conversationID != "" {
+                fields["conversation_id"] = conversationID
+            }
+            o.logger.Warn(
+                "Failed to store execution for DAG visualization",
+                fields,
+            )
+        }
+    }
+}()
 ```
 
-**Why non-context method?** The parent HTTP request context may be canceled after the handler returns, but we still want the async storage to complete. Using `context.Background()` ensures the operation isn't canceled prematurely.
+`safeExecutionStoreError` emits a bounded message and never exposes a Redis
+URL, credentials, payload, or raw backend error. The non-context logger avoids
+depending on a canceled request while the explicitly captured correlation
+fields retain troubleshooting value.
+
+Execution-store index and TTL failures use the same sanitized-error rule with
+bounded `error_type=index_write` and `error_type=ttl_update`. Observation error
+text must not include Redis connection material, payloads, or raw conversation
+identifiers.
 
 ### HITL Logging Checklist
 
 When implementing HITL-related logging:
 
 - [ ] Include `request_id` in all logs (current request's unique ID)
-- [ ] Include `original_request_id` when in a HITL flow (links to conversation start)
+- [ ] Include `original_request_id` for the interrupt/resume request family
+- [ ] Preserve validated `conversation_id` independently across turns
 - [ ] Include `checkpoint_id` when creating or resuming from checkpoints
 - [ ] Include `interrupted: true` when storing interrupted executions
-- [ ] Set `original_request_id` in baggage **before** calling orchestrator during resume
+- [ ] Call `BuildResumeContext` and use its returned context and cleanup function
 - [ ] Use non-context logging methods in background goroutines
 - [ ] Log both the interrupt (parent) and resume (child) with matching `original_request_id`
 
@@ -1069,22 +1101,22 @@ The [`examples/agent-with-human-approval`](https://github.com/truvaagents/truva-
 
 | File | Purpose |
 |------|---------|
-| [`handlers.go`](https://github.com/truvaagents/truva-g3/blob/main/examples/agent-with-human-approval/handlers.go) | `handleResumeSSE` - Shows complete trace correlation setup with priority-based `original_request_id` resolution |
-| [`handlers_auto_resume.go`](https://github.com/truvaagents/truva-g3/blob/main/examples/agent-with-human-approval/handlers_auto_resume.go) | `handleAutoResumeSSE` - Expiry-triggered auto-resume with same trace correlation patterns |
+| [`handlers.go`](https://github.com/truvaagents/truva-g3/blob/main/examples/agent-with-human-approval/handlers.go) | Manual and synchronous resume handlers using `BuildResumeContext` |
+| [`handlers_auto_resume.go`](https://github.com/truvaagents/truva-g3/blob/main/examples/agent-with-human-approval/handlers_auto_resume.go) | Expiry-triggered resume using the same helper |
 | [`hitl_setup.go`](https://github.com/truvaagents/truva-g3/blob/main/examples/agent-with-human-approval/hitl_setup.go) | HITL controller and checkpoint store setup with expiry callbacks |
 
 **Key patterns demonstrated:**
 
-1. **Trace correlation setup** with `StartLinkedSpan` for Jaeger trace linking
-2. **Priority-based `original_request_id`** resolution (header → checkpoint → fallback)
-3. **Detailed logging** of trace correlation decisions for debugging
-4. **Baggage propagation** before orchestrator calls
+1. **Single-call resume setup** with `BuildResumeContext`
+2. **Typed checkpoint lineage** with an optional trusted header override
+3. **Framework-owned linked span and validated conversation restoration**
+4. **Direct logging of bounded correlation fields**
 
 To run the example and observe the logging:
 
 ```bash
 cd examples/agent-with-human-approval
-./setup.sh  # Deploys to Kubernetes
+./setup.sh deploy
 
 # Port forward and test
 kubectl port-forward -n truvag3-examples svc/agent-with-human-approval 8352:8352
@@ -1159,6 +1191,22 @@ metadata — filterable with `| key="value"` pipe syntax, not `{key="value"}`):
 |-----------|--------|---------|
 | `k8s_node_name` | pod metadata | `truvag3-demo-kind-control-plane` |
 
+Application JSON fields such as `request_id`, `original_request_id`,
+`conversation_id`, `checkpoint_id`, `operation`, and `level` are not Loki
+stream labels in the repository’s reference deployment. Parse and filter them
+after selecting a bounded stream:
+
+```logql
+{service_name="travel-chat-agent"}
+  | json
+  | conversation_id="chat-456"
+```
+
+This description is specific to
+`examples/k8-deployment/otel-collector-logs.yaml` and the supplied Loki
+configuration. External deployments may choose a different label policy, but
+high-cardinality correlation values should not be promoted to stream labels.
+
 ### Standard Field Names
 
 Use these field names across all your services:
@@ -1166,9 +1214,15 @@ Use these field names across all your services:
 | Field Name | Type | Description | Example |
 |------------|------|-------------|---------|
 | `operation` | string | The operation being performed | "research_topic", "get_weather" |
+| `request_id` | string | One orchestration execution/request | "orch-1785207229452819002" |
+| `original_request_id` | string | HITL/delegation request-family root | "orch-1785207229452819002" |
+| `conversation_id` | string | Optional validated multi-turn conversation identity; high-cardinality and metric-ineligible in framework flows | "chat-456" |
+| `trace_id` | string | Active W3C trace identity | "5b54aa1e7925acb809e77479b5797f5d" |
+| `span_id` | string | Active W3C span identity | "e75ad960517fa8fe" |
+| `checkpoint_id` | string | HITL checkpoint identity | "cp-abc123" |
 | `status` | string | Result status | "success", "error", "retry" |
 | `error` | string | Error message safe for structured logging; sanitize external/provider errors | "connection refused" |
-| `error_type` | string | Error classification for filtering and alerting | "timeout", "validation", "network", "marshal", "stream_write", "index_read", "episodic_read", "episodic_recent_read", "episodic_write", "embedding", "llm_unavailable", "parse_failure", "knowledge_store", "claim", "claim_release", "release", "session_read", "cache_read", "cache_write", "cache_unmarshal", "activity_announce", "activity_discover", "activity_complete", "summarizer_error", "debug_recording", "lock_acquire", "entity_discovery", "count_tokens", "compaction", "watermark_mismatch", "preparation", "route", "runnable_exit", "runnable_drain_timeout", "plan_validation_exhausted" |
+| `error_type` | string | Bounded error classification for filtering and alerting | "timeout", "validation", "network", "marshal", "stream_write", "store_write", "index_write", "ttl_update", "index_read", "episodic_read", "episodic_recent_read", "episodic_write", "embedding", "llm_unavailable", "parse_failure", "knowledge_store", "claim", "claim_release", "release", "session_read", "cache_read", "cache_write", "cache_unmarshal", "activity_announce", "activity_discover", "activity_complete", "summarizer_error", "debug_recording", "lock_acquire", "entity_discovery", "count_tokens", "compaction", "watermark_mismatch", "preparation", "route", "runnable_exit", "runnable_drain_timeout", "plan_validation_exhausted" |
 | `duration_ms` | number | Operation duration in milliseconds | 125 |
 | `method` | string | HTTP method | "GET", "POST" |
 | `path` | string | Request path | "/api/capabilities/get_weather" |
@@ -1347,7 +1401,10 @@ if o.logger != nil {
 // In any component that receives the context
 func (c *Component) doWork(ctx context.Context) error {
     // Retrieve request_id from context baggage
-    requestID := telemetry.GetBaggage(ctx, "request_id")
+    requestID := ""
+    if baggage := telemetry.GetBaggage(ctx); baggage != nil {
+        requestID = baggage["request_id"]
+    }
 
     if c.logger != nil {
         c.logger.InfoWithContext(ctx, "Doing work", map[string]interface{}{
@@ -1542,25 +1599,68 @@ func initTelemetry(serviceName string) {
 
 ### Metric Emission from Logs
 
-When telemetry is enabled, logs automatically emit metrics. Only specific low-cardinality fields are used as metric labels to prevent metric explosion:
+When telemetry is enabled, framework logs emit
+`truvag3.framework.operations`. Labels have two sources:
 
-**Allowed label fields** (defined in [`core/config.go`](https://github.com/truvaagents/truva-g3/blob/main/core/config.go)):
-- `operation`
-- `status`
-- `error_type`
-- `service_type`
-- `provider`
+1. `ProductionLogger.emitFrameworkMetric` always adds `level`, `service`, and
+   `component`, then allowlists only these explicit log fields:
+   `operation`, `status`, `error_type`, `service_type`, and `provider`.
+2. Context-aware emission appends every W3C baggage member that is
+   metric-eligible.
+
+The five explicit fields are therefore not a closed list of all possible
+labels. Generic baggage is metric-eligible unless the member carries the
+framework’s exclusion property. Existing unmarked `request_id`, `user_id`, and
+`session_id` behavior is tracked separately for a broader cardinality cleanup.
 
 ```go
-// This log statement...
-agent.Logger.Error("Request failed", map[string]interface{}{
+// Canonical conversation correlation remains available to logs, spans, and
+// propagation but is excluded from metric labels.
+ctx, err := telemetry.WithBaggageExact(
+    ctx,
+    "conversation_id",
+    conversationID,
+    telemetry.WithMetricLabelEligibility(false),
+)
+if err != nil {
+    // Treat optional correlation rejection as fail-open.
+}
+
+agent.Logger.ErrorWithContext(ctx, "Request failed", map[string]interface{}{
     "operation": "get_weather",
     "error_type": "timeout",
 })
 
-// ...also emits this metric (automatically):
+// The emitted metric includes operation and error_type, but not conversation_id:
 // truvag3.framework.operations{level="ERROR", service="my-agent", operation="get_weather", error_type="timeout"}
 ```
+
+The orchestration ingress performs this exact construction after validating
+the canonical ID. A rejected optional conversation ID increments the bounded
+`orchestration.conversation_id.rejected.total` counter; it does not require a
+DEBUG log, record a span error, or change the business result.
+
+### Baggage Construction Limits
+
+Both baggage construction paths enforce the same limits:
+
+| Limit | Value |
+|-------|------:|
+| Members | 64 |
+| Key length | 128 bytes |
+| Value length | 512 bytes |
+| Complete serialized W3C baggage value | 8192 bytes |
+
+The total is the serialized wire value, including separators, encoding, and
+member properties.
+
+- `telemetry.WithBaggage` accepts multiple key/value pairs. It applies the
+  64-member cap to each candidate as it is added, truncates overlong key/value
+  input to its per-item limits, and silently skips invalid or over-limit
+  candidates.
+- `telemetry.WithBaggageExact` adds or replaces one member without truncation.
+  It either returns the updated context or returns the original context plus a
+  typed `BaggageExactError`.
 
 ---
 
@@ -1914,15 +2014,25 @@ If using Grafana Loki for log aggregation:
 # Trace a request across all components using trace_id
 {k8s_namespace_name="truvag3-examples"} | json | trace_id="abc123def456"
 
-# All logs for a given orchestration request_id (finds the tool side too)
-{k8s_namespace_name="truvag3-examples"} |= "orch-1776904450804389754"
+# One orchestration execution
+{k8s_namespace_name="truvag3-examples"} | json | request_id="orch-1776904450804389754"
+
+# All turns and related executions in a conversation
+{k8s_namespace_name="truvag3-examples"} | json | conversation_id="chat-456"
+
+# One interrupt/resume or delegation request family
+{k8s_namespace_name="truvag3-examples"} | json | original_request_id="orch-1776904450804389754"
+
+# One HITL checkpoint
+{service_name="agent-with-human-approval"} | json | checkpoint_id="cp-abc123"
 ```
 
 **Why `{service_name="…"}` and `{k8s_namespace_name="…"}`?** These are the indexed
 stream labels Loki actually exposes for this pipeline. `service_name` comes from the
 pod's `app:` label (set per-record by `k8sattributes`), and `k8s_namespace_name` comes
 from pod metadata. Filtering by either is cheap. The old `{namespace="…"}` idiom does
-not work — that label is not indexed.
+not work — that label is not indexed. Correlation fields after `| json` are
+parsed application fields, not stream selectors.
 
 ### Identifying Log Origins
 
@@ -2047,23 +2157,36 @@ logger.Info("API call", map[string]interface{}{
 })
 ```
 
-### Mistake 3: High-Cardinality Fields
+### Mistake 3: Turning Correlation Fields into Metric Labels
 
 ```go
-// BAD - creates too many unique metric labels
-logger.Info("Request", map[string]interface{}{
-    "user_id": "user-12345",     // High cardinality
-    "request_id": uuid.New(),    // Unique every time
-    "timestamp": time.Now(),     // Always different
-})
+// BAD - explicitly creates one metric series per conversation
+telemetry.Counter(
+    "conversation.request",
+    "conversation_id", conversationID,
+)
 
-// GOOD - low cardinality fields as labels
-logger.Info("Request", map[string]interface{}{
-    "operation": "get_weather",  // Fixed set of values
-    "status": "success",         // Fixed set of values
-    "duration_ms": 125,          // Not a label, just a value
+// GOOD - preserve correlation for context-aware JSON logs and spans while
+// excluding it from context-aware metric labels.
+ctx, err := telemetry.WithBaggageExact(
+    ctx,
+    "conversation_id",
+    conversationID,
+    telemetry.WithMetricLabelEligibility(false),
+)
+if err != nil {
+    // Optional correlation is fail-open.
+}
+
+logger.InfoWithContext(ctx, "Request", map[string]interface{}{
+    "operation":   "get_weather",
+    "status":      "success",
+    "duration_ms": 125,
 })
 ```
+
+High-cardinality identifiers are useful structured log fields. The problem is
+promoting them to metric or Loki stream labels.
 
 ### Mistake 4: Not Logging Errors Properly
 
@@ -2154,6 +2277,10 @@ func (r *Agent) handleRequest(w http.ResponseWriter, req *http.Request) {
 |-------|----------|---------|
 | `operation` | **YES** | What action is being performed (MUST be in every log) |
 | `request_id` | **YES** | Request identifier (for request-scoped logs) |
+| `original_request_id` | HITL/delegation | One causal request family |
+| `conversation_id` | When available | Multiple top-level turns; validated and metric-ineligible in framework flows |
+| `trace_id` / `span_id` | Automatic in context-aware JSON | Log-to-trace correlation |
+| `checkpoint_id` | HITL | One checkpoint |
 | `error` | On errors | Error message; sanitize external/provider errors before logging |
 | `duration_ms` | Recommended | How long it took |
 | `status` | Recommended | success, error, retry |
@@ -2219,7 +2346,10 @@ For complete distributed tracing setup including infrastructure (Jaeger, OTEL Co
 2. **Always use `WithContext` methods** in HTTP handlers for trace correlation
 3. **Be consistent with field names** across all services
 4. **Log both success and failure** with duration metrics
-5. **Initialize telemetry first** to enable all three observability layers
+5. **Use the right correlation scope**: request, request family, conversation, or trace
+6. **Keep `conversation_id` out of metrics and Loki stream labels** while retaining it in structured logs and spans
+7. **Resume HITL through `BuildResumeContext`** instead of rebuilding links or baggage in handlers
+8. **Initialize telemetry first** to enable all three observability layers
 
 Following these guidelines ensures your logs are useful in production, easy to search, and properly correlated across your distributed system.
 

--- a/docs/orchestration/ASYNC_ORCHESTRATION_GUIDE.md
+++ b/docs/orchestration/ASYNC_ORCHESTRATION_GUIDE.md
@@ -2498,10 +2498,11 @@ func (a *MyAgent) HandleHITLResume(ctx context.Context, checkpointID string) err
     }
 
     // 2. Build resume context — single call, full contract
-    resumeCtx, err := orchestration.BuildResumeContext(ctx, checkpoint)
+    resumeCtx, endResumeSpan, err := orchestration.BuildResumeContext(ctx, checkpoint)
     if err != nil {
         return fmt.Errorf("invalid checkpoint state: %w", err)
     }
+    defer endResumeSpan()
 
     // 3. Re-enter the orchestrator with the original request
     result, err := a.orchestrator.ProcessRequest(
@@ -2519,7 +2520,13 @@ func (a *MyAgent) HandleHITLResume(ctx context.Context, checkpointID string) err
 - **Restores plan** — the stored plan with matching step IDs, so the orchestrator skips re-planning
 - **Restores completed steps** — already-executed step results, so the executor skips them
 - **Restores parameters** — human-approved parameter values for step-level resume
-- **Preserves metadata** — request mode, session info, user context
+- **Preserves metadata** — request mode, application session info, and user
+  context
+- **Restores conversation correlation** — validates any canonical
+  `conversation_id`, scrubs rejected identity, and restores accepted identity
+  to core context, checkpoint metadata, and metric-ineligible W3C Baggage
+- **Links traces** — starts `hitl.resume` linked to the original trace; callers
+  must invoke the returned cleanup function
 
 **Do not manually call individual `With*` helpers** (`WithResumeMode`, `WithPlanOverride`, `WithCompletedSteps`, etc.) in your resume handler. The resume contract has grown from 3 to 6 context values, and missing any one of them causes the orchestrator to replay the entire pipeline from scratch. `BuildResumeContext` is the single source of truth and will automatically include new helpers as the framework evolves.
 

--- a/docs/orchestration/HUMAN_IN_THE_LOOP_USER_GUIDE.md
+++ b/docs/orchestration/HUMAN_IN_THE_LOOP_USER_GUIDE.md
@@ -161,6 +161,11 @@ The checkpoint includes:
 - **Current step**: What we're pausing before (for step-level approval)
 - **Resolved parameters**: The actual values that will be sent to tools
 - **Original request**: The user's query (needed to re-process on resume)
+- **User context**: Application metadata needed by the resume handler, including
+  `session_id` and the canonical `conversation_id` when the request belongs to
+  a multi-turn conversation
+- **Trace lineage**: Original request, trace, and span identifiers used to link
+  the resumed execution
 - **Expiration time**: When the checkpoint times out
 
 Checkpoints are stored in Redis and automatically expire after the configured timeout.
@@ -845,11 +850,12 @@ func (a *MyAgent) handleResume(w http.ResponseWriter, r *http.Request) {
     }
 
     // 2. Build resume context (handles all the plumbing)
-    resumeCtx, err := orchestration.BuildResumeContext(ctx, checkpoint)
+    resumeCtx, endResumeSpan, err := orchestration.BuildResumeContext(ctx, checkpoint)
     if err != nil {
         http.Error(w, err.Error(), http.StatusBadRequest)
         return
     }
+    defer endResumeSpan()
 
     // 3. Re-process the original request
     err = a.ProcessRequest(resumeCtx, checkpoint.OriginalRequest, callback)
@@ -872,6 +878,10 @@ func (a *MyAgent) handleResume(w http.ResponseWriter, r *http.Request) {
 - Injects completed step results (`WithCompletedSteps`)
 - Injects pre-resolved parameters for step-level resume (`WithPreResolvedParams`)
 - Preserves request mode and user context
+- Validates and restores canonical `conversation_id` to core context,
+  checkpoint metadata, and metric-ineligible W3C Baggage when present
+- Starts a `hitl.resume` span linked to the original trace; the caller must
+  invoke the returned cleanup function
 
 **Option 2: Manual Context Building**
 
@@ -910,7 +920,7 @@ if checkpoint.RequestMode != "" {
 
 | Helper | Purpose |
 |--------|---------|
-| `BuildResumeContext(ctx, checkpoint)` | One-call context setup (recommended) |
+| `BuildResumeContext(ctx, checkpoint)` | Returns the resume context, linked-span cleanup function, and error (recommended) |
 | `WithResumeMode(ctx, checkpointID)` | Marks context as resume, prevents re-interrupt |
 | `WithPlanOverride(ctx, plan)` | Injects stored plan (critical for step ID matching) |
 | `WithCompletedSteps(ctx, results)` | Skips already-executed steps |
@@ -923,7 +933,7 @@ if checkpoint.RequestMode != "" {
 |--------|---------|
 | `WithRequestID(ctx, requestID)` | Sets request ID for trace correlation |
 | `GetRequestID(ctx)` | Retrieves request ID from context |
-| `WithMetadata(ctx, metadata)` | Attaches user context (session_id, user_id) to checkpoint |
+| `WithMetadata(ctx, metadata)` | Attaches application user context such as `session_id` and `user_id`; canonical multi-turn identity uses `conversation_id` |
 | `GetMetadata(ctx)` | Retrieves metadata from context |
 
 *Error Handling Helpers* ([hitl_errors.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/hitl_errors.go))

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1405,7 +1405,21 @@ func GetRequestID(ctx context.Context) string
 // Store and retrieve step ID in context
 func WithStepID(ctx context.Context, id string) context.Context
 func GetStepID(ctx context.Context) string
+
+// Validate and carry opaque multi-turn correlation.
+func ValidateConversationID(id string) ConversationIDValidationReason
+func WithConversationID(ctx context.Context, id string) context.Context
+func GetConversationID(ctx context.Context) string
+func GetConversationIDCandidate(ctx context.Context) ConversationIDCandidate
+func WithoutConversationID(ctx context.Context) context.Context
 ```
+
+`ValidateConversationID` accepts 1–512 bytes from the documented
+W3C-baggage-safe visible-ASCII subset and returns a bounded reason enum.
+`WithConversationID` records a programmatic candidate. An explicit
+`X-TruvaG3-Conversation-ID` candidate has precedence regardless of call order;
+invalid raw values are not retained. `WithoutConversationID` shadows inherited
+conversation identity while preserving unrelated context values.
 
 #### ExtractRequestContext
 
@@ -1421,6 +1435,7 @@ func ExtractRequestContext(ctx context.Context, r *http.Request) context.Context
 |--------|-------------|---------|
 | `X-TruvaG3-Request-ID` | `truvag3_request_id` | Correlates agent LLM calls to orchestration request |
 | `X-TruvaG3-Step-ID` | `truvag3_step_id` | Identifies which plan step triggered the call |
+| `X-TruvaG3-Conversation-ID` | validated conversation candidate | Correlates multiple top-level turns without assigning application session semantics |
 
 **Example — Agent HTTP Handler:**
 ```go
@@ -3338,7 +3353,29 @@ func GetBaggage(ctx context.Context) Baggage
 // WithBaggage attaches W3C baggage labels to the context. Pass flat
 // key-value pairs (variadic), not a map.
 func WithBaggage(ctx context.Context, labels ...string) context.Context
+
+// WithBaggageExact adds/replaces one untruncated member or returns a bounded
+// typed rejection while leaving ctx unchanged.
+func WithBaggageExact(
+    ctx context.Context,
+    key string,
+    rawValue string,
+    options ...BaggageMemberOption,
+) (context.Context, error)
+
+func WithMetricLabelEligibility(eligible bool) BaggageMemberOption
+func BaggageExactErrorReasonOf(err error) (BaggageExactErrorReason, bool)
+func WithoutBaggageMember(ctx context.Context, key string) context.Context
+func CopyBaggage(dst, src context.Context) context.Context
 ```
+
+Both baggage construction paths enforce 64 members, 128-byte keys, 512-byte
+values, and an 8192-byte complete serialized W3C baggage value (including
+separators, encoding, and member properties). `WithBaggage` keeps its
+truncation/silent-drop convenience behavior. `WithBaggageExact` never
+truncates. `WithMetricLabelEligibility(false)` preserves the member for
+propagation, traces, and structured logs while excluding it from automatic
+metric labels.
 
 Span creation is **not** a top-level function. Spans are started through a
 `core.Telemetry` instance — typically the one stored on your component
@@ -3884,7 +3921,21 @@ deps := orchestration.OrchestratorDependencies{
 }
 ```
 
-For chat agents, the preferred conversation-history path is request metadata, not a hook. Pass raw turns in `metadata[orchestration.MetadataConversationTurns]` plus the stable session key in `metadata[orchestration.MetadataConversationSessionKey]`, and let the shared `ConversationHistoryPreparer` build the `<conversation_history>` enrichment before planning. `ConversationHistoryHook` remains available as an adapter for memory-backed integrations that cannot supply raw turns directly. For Tier 2 recursive compaction, the ergonomic Layer 2 path is `BuildCompactionEnabledConversationHistoryPreparer(config, aiClient, ...options)`, which installs the default cache and LLM compactor while still allowing `WithConversationSummaryCache(...)` and `WithConversationCompactor(...)` overrides.
+For chat agents, the preferred conversation-history path is request metadata,
+not a hook. Pass raw turns in
+`metadata[orchestration.MetadataConversationTurns]` and the stable canonical
+identity in `metadata[orchestration.MetadataConversationID]`, then let the
+shared `ConversationHistoryPreparer` build the `<conversation_history>`
+enrichment before planning. Set `MetadataConversationID` on the first turn
+even when the turns slice is empty. Application `session_id` remains a separate
+concept, although an application may deliberately map the same opaque UUID to
+both. `ConversationHistoryHook` remains available as an adapter for
+memory-backed integrations that cannot supply raw turns directly. For Tier 2
+recursive compaction, the ergonomic Layer 2 path is
+`BuildCompactionEnabledConversationHistoryPreparer(config, aiClient,
+...options)`, which installs the default cache and LLM compactor while still
+allowing `WithConversationSummaryCache(...)` and
+`WithConversationCompactor(...)` overrides.
 
 For detailed pipeline hook implementation patterns, see [Adding Context to Your Agent](../building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md). For the conversation-history metadata path plus Tier 2 / Layer 3 reference implementations, see [Conversation History Guide](../memory-and-chat/CONVERSATION_HISTORY_GUIDE.md).
 
@@ -4866,6 +4917,59 @@ type LLMDebugRecordSummary struct {
 | `TRUVAG3_LLM_DEBUG_TTL` | `24h` | TTL for successful records |
 | `TRUVAG3_LLM_DEBUG_ERROR_TTL` | `168h` | TTL for error records (7 days) |
 | `TRUVAG3_LLM_DEBUG_REDIS_DB` | `7` | Redis database index |
+
+### Execution Debug Store
+
+`ExecutionStore` remains the required request-oriented persistence contract.
+Conversation lookup is additive capability discovery:
+
+```go
+type ConversationExecutionLister interface {
+    ListByConversationID(
+        ctx context.Context,
+        conversationID string,
+        limit int,
+    ) ([]ExecutionSummary, error)
+}
+
+type IndexTTLManager interface {
+    ExtendIndexTTL(
+        ctx context.Context,
+        indexKey string,
+        minTTL time.Duration,
+    ) error
+}
+```
+
+Use `lister, ok := store.(ConversationExecutionLister)`; the NoOp store does
+not advertise the capability. Provider-backed stores may implement
+`IndexTTLManager`, but its absence is supported through bounded lazy index
+cleanup.
+
+`StoredExecution.Metadata` and `ExecutionSummary.Metadata` carry the
+framework-owned `MetadataConversationID`. Read it with
+`ExecutionConversationID` or `ExecutionSummaryConversationID`. Record metadata
+is authoritative; the SHA-256 conversation index is an accelerator.
+
+```go
+type ExecutionStoreConfig struct {
+    Enabled                    bool
+    TTL                        time.Duration
+    ErrorTTL                   time.Duration
+    KeyPrefix                  string
+    ConversationQueryLimit     int // default 1000
+    ConversationIndexScanLimit int // default 5000
+}
+```
+
+Positive programmatic values are authoritative. Per-call result limits are
+clamped to `ConversationQueryLimit`, and stale-index work is bounded by
+`ConversationIndexScanLimit`.
+
+| Variable | Default |
+|---|---:|
+| `TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT` | `1000` |
+| `TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT` | `5000` |
 
 ### Human-in-the-Loop (HITL)
 

--- a/docs/reference/ENVIRONMENT_VARIABLES_GUIDE.md
+++ b/docs/reference/ENVIRONMENT_VARIABLES_GUIDE.md
@@ -1394,6 +1394,11 @@ Configure execution debug storage for DAG visualization and debugging. This feat
 | `TRUVAG3_EXECUTION_DEBUG_ERROR_TTL` | `168h` (7 days) | **Implemented** | Retention period for failed execution records (longer for troubleshooting) | [orchestration/redis_execution_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_execution_store.go) |
 | `TRUVAG3_EXECUTION_DEBUG_KEY_PREFIX` | `truvag3:execution:debug` | **Implemented** | Key prefix for all storage keys. Allows multi-tenant deployments or custom namespacing. | [orchestration/redis_execution_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_execution_store.go) |
 | `TRUVAG3_EXECUTION_DEBUG_REDIS_DB` | `8` | **Implemented** | Redis database number (uses `core.RedisDBExecutionDebug`) | [orchestration/redis_execution_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_execution_store.go) |
+| `TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT` | `1000` | **Implemented** | Maximum executions returned by one framework conversation lookup | [orchestration/interfaces.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/interfaces.go) |
+| `TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT` | `5000` | **Implemented** | Maximum conversation-index members scanned by one framework lookup, including stale members | [orchestration/interfaces.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/interfaces.go) |
+
+The two conversation limits accept only positive integers. Missing, malformed,
+zero, or negative values retain the safe defaults.
 
 ### Features (Same as LLM Debug Store)
 
@@ -1420,11 +1425,13 @@ The execution debug store uses configurable key patterns based on `TRUVAG3_EXECU
 | `{prefix}{request_id}` | Main execution record (plan + result) |
 | `{prefix}index` | Sorted index for listing recent executions |
 | `{prefix}trace:{trace_id}` | Trace ID → Request ID mapping |
+| `{prefix}conversation:{sha256(conversation_id)}` | Chronological execution membership for one conversation |
 
 With the default prefix `truvag3:execution:debug:`:
 - `truvag3:execution:debug:req-001` - Execution record
 - `truvag3:execution:debug:index` - Recent executions index
 - `truvag3:execution:debug:trace:abc123` - Trace mapping
+- `truvag3:execution:debug:conversation:<sha256>` - Conversation execution index
 
 ### Example: Enable Execution Debug Storage
 
@@ -1436,6 +1443,10 @@ export TRUVAG3_EXECUTION_DEBUG_STORE_ENABLED=true
 # Or customize retention:
 export TRUVAG3_EXECUTION_DEBUG_TTL=48h
 export TRUVAG3_EXECUTION_DEBUG_ERROR_TTL=336h  # 14 days
+
+# Optional bounded conversation lookup limits
+export TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT=1000
+export TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT=5000
 ```
 
 ### Example: Multi-Tenant Deployment
@@ -1465,6 +1476,10 @@ env:
   # Custom key prefix for namespace isolation (optional)
   - name: TRUVAG3_EXECUTION_DEBUG_KEY_PREFIX
     value: "myteam:execution:debug:"
+  - name: TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT
+    value: "1000"
+  - name: TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT
+    value: "5000"
 ```
 
 ### Viewing Execution Records

--- a/docs/reference/ENVIRONMENT_VARIABLES_GUIDE.md
+++ b/docs/reference/ENVIRONMENT_VARIABLES_GUIDE.md
@@ -1398,7 +1398,29 @@ Configure execution debug storage for DAG visualization and debugging. This feat
 | `TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT` | `5000` | **Implemented** | Maximum conversation-index members scanned by one framework lookup, including stale members | [orchestration/interfaces.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/interfaces.go) |
 
 The two conversation limits accept only positive integers. Missing, malformed,
-zero, or negative values retain the safe defaults.
+zero, or negative values retain the safe defaults. Environment values populate
+`DefaultOrchestratorConfig`. A positive programmatic value applied after
+default construction, or passed directly in `ExecutionStoreConfig`, is
+authoritative. The per-call `limit` passed to `ListByConversationID` is clamped
+to `ConversationQueryLimit`; stale-index work is independently bounded by
+`ConversationIndexScanLimit`.
+
+### Correlation and baggage protocol limits
+
+These limits are protocol constants rather than environment settings:
+
+| Value | Limit | Contract |
+|---|---:|---|
+| `conversation_id` | 1–512 bytes | Visible-ASCII W3C-safe subset validated by `core.ValidateConversationID` |
+| W3C baggage members | 64 | `telemetry.MaxBaggageItems` |
+| Baggage key | 128 bytes | `telemetry.MaxBaggageKeyLength` |
+| Baggage value | 512 bytes | `telemetry.MaxBaggageValueLength` |
+| Complete serialized W3C baggage value | 8192 bytes | Includes separators, encoding, and member properties |
+
+`conversation_id` is framework correlation metadata, not an application
+`session_id`. A chat application may deliberately use the same opaque value
+for both, but the framework does not infer that mapping. Conversation identity
+is established on the first turn even when `conversation_turns` is empty.
 
 ### Features (Same as LLM Debug Store)
 
@@ -1426,6 +1448,10 @@ The execution debug store uses configurable key patterns based on `TRUVAG3_EXECU
 | `{prefix}index` | Sorted index for listing recent executions |
 | `{prefix}trace:{trace_id}` | Trace ID → Request ID mapping |
 | `{prefix}conversation:{sha256(conversation_id)}` | Chronological execution membership for one conversation |
+
+The execution record's `metadata.conversation_id` is authoritative. The hashed
+conversation index is a bounded lookup accelerator and may be lazily cleaned
+when records expire; index maintenance never changes the execution record.
 
 With the default prefix `truvag3:execution:debug:`:
 - `truvag3:execution:debug:req-001` - Execution record

--- a/docs/reference/LIMITS_CHEATSHEET.md
+++ b/docs/reference/LIMITS_CHEATSHEET.md
@@ -375,6 +375,8 @@ Sweep interval for the in-process eviction sweeper used by `Framework.AutoRegist
 | Execution store enabled | false | `TRUVAG3_EXECUTION_DEBUG_STORE_ENABLED` | — |
 | Execution store TTL | 24h | `TRUVAG3_EXECUTION_DEBUG_TTL` | `WithExecutionStoreTTL(d)` |
 | Execution store error TTL | 7d | `TRUVAG3_EXECUTION_DEBUG_ERROR_TTL` | `WithExecutionStoreErrorTTL(d)` |
+| Conversation execution query limit | 1000 | `TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT` | `ExecutionStoreConfig.ConversationQueryLimit` |
+| Conversation index scan limit | 5000 | `TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT` | `ExecutionStoreConfig.ConversationIndexScanLimit` |
 
 ## Capability Provider (Service Mode)
 

--- a/docs/reference/LIMITS_CHEATSHEET.md
+++ b/docs/reference/LIMITS_CHEATSHEET.md
@@ -365,6 +365,22 @@ Sweep interval for the in-process eviction sweeper used by `Framework.AutoRegist
 | Max signals in prompt | 10 | `TRUVAG3_ACTIVITY_SIGNAL_MAX_IN_PROMPT` | — |
 | Query max length | 200 | `TRUVAG3_ACTIVITY_SIGNAL_QUERY_MAX_LEN` | `WithAnnouncementQueryMaxLen(n)` |
 
+## Correlation and W3C Baggage
+
+| What | Limit | Configuration |
+|------|------:|---------------|
+| Conversation ID | 512 bytes, non-empty visible-ASCII W3C-safe subset | Protocol invariant: `core.MaxConversationIDLength` |
+| Baggage members | 64 | `telemetry.MaxBaggageItems` |
+| Baggage key | 128 bytes | `telemetry.MaxBaggageKeyLength` |
+| Baggage value | 512 bytes | `telemetry.MaxBaggageValueLength` |
+| Complete serialized baggage header | 8192 bytes | `telemetry.MaxBaggageTotalSize` |
+
+The 8192-byte limit covers the complete serialized W3C baggage value,
+including separators, encoding, and member properties. `WithBaggage` applies
+member limits per candidate and keeps its truncation/silent-drop contract.
+`WithBaggageExact` never truncates and rejects the candidate atomically with a
+typed bounded reason.
+
 ## Debug Stores
 
 | What | Default | Env Var | `With*` Option |
@@ -377,6 +393,10 @@ Sweep interval for the in-process eviction sweeper used by `Framework.AutoRegist
 | Execution store error TTL | 7d | `TRUVAG3_EXECUTION_DEBUG_ERROR_TTL` | `WithExecutionStoreErrorTTL(d)` |
 | Conversation execution query limit | 1000 | `TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT` | `ExecutionStoreConfig.ConversationQueryLimit` |
 | Conversation index scan limit | 5000 | `TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT` | `ExecutionStoreConfig.ConversationIndexScanLimit` |
+
+Both conversation store limits accept positive integers. A request-level
+lookup limit is additionally clamped to `ConversationQueryLimit`; stale-member
+work never exceeds `ConversationIndexScanLimit`.
 
 ## Capability Provider (Service Mode)
 

--- a/examples/agent-with-human-approval/chat_agent.go
+++ b/examples/agent-with-human-approval/chat_agent.go
@@ -283,11 +283,17 @@ func hitlConversationTurnsFromMessages(history []Message) []core.ConversationTur
 }
 
 func (t *HITLChatAgent) addConversationHistoryMetadata(metadata map[string]interface{}, sessionID string, history []Message) {
-	if sessionID == "" || len(history) == 0 {
+	if sessionID == "" {
+		return
+	}
+
+	// This example maps one chat session to exactly one conversation.
+	metadata[orchestration.MetadataConversationID] = sessionID
+
+	if len(history) == 0 {
 		return
 	}
 	metadata[orchestration.MetadataConversationTurns] = hitlConversationTurnsFromMessages(history)
-	metadata[orchestration.MetadataConversationSessionKey] = sessionID
 	if formattedHistory := t.formatConversationHistory(history); formattedHistory != "" {
 		metadata[core.EnrichmentConversationHistory] = formattedHistory
 	}

--- a/examples/agent-with-human-approval/handlers.go
+++ b/examples/agent-with-human-approval/handlers.go
@@ -352,13 +352,8 @@ func (t *HITLChatAgent) handleResumeSSE(w http.ResponseWriter, r *http.Request) 
 	}
 	telemetry.AddSpanEvent(ctx, "hitl.checkpoint.loaded", loadedAttrs...)
 
-	// Extract session ID from checkpoint metadata
-	sessionID := ""
-	if checkpoint.UserContext != nil {
-		if sid, ok := checkpoint.UserContext["session_id"].(string); ok {
-			sessionID = sid
-		}
-	}
+	// This example maps its chat-session UUID to the canonical conversation ID.
+	sessionID := sessionIDFromCheckpoint(checkpoint.UserContext)
 	if sessionID == "" {
 		// Generate new session if not found
 		session := t.sessionStore.Create("", nil)
@@ -950,13 +945,8 @@ func (t *HITLChatAgent) handleResumeSyncJSON(w http.ResponseWriter, r *http.Requ
 	}
 	telemetry.AddSpanEvent(ctx, "hitl.checkpoint.loaded", loadedAttrs...)
 
-	// Extract session ID from checkpoint metadata
-	sessionID := ""
-	if checkpoint.UserContext != nil {
-		if sid, ok := checkpoint.UserContext["session_id"].(string); ok {
-			sessionID = sid
-		}
-	}
+	// This example maps its chat-session UUID to the canonical conversation ID.
+	sessionID := sessionIDFromCheckpoint(checkpoint.UserContext)
 	if sessionID == "" {
 		// Create new session if not found
 		session := t.sessionStore.Create("", nil)
@@ -1025,4 +1015,15 @@ func (t *HITLChatAgent) handleResumeSyncJSON(w http.ResponseWriter, r *http.Requ
 	response.OriginalRequestID = checkpoint.OriginalRequestID
 
 	writeJSON(w, http.StatusOK, response)
+}
+
+func sessionIDFromCheckpoint(metadata map[string]interface{}) string {
+	if conversationID, ok := metadata[orchestration.MetadataConversationID].(string); ok &&
+		core.ValidateConversationID(conversationID) == core.ConversationIDValidationNone {
+		return conversationID
+	}
+	if sessionID, ok := metadata["session_id"].(string); ok && sessionID != "" {
+		return sessionID
+	}
+	return ""
 }

--- a/examples/agent-with-human-approval/handlers_auto_resume.go
+++ b/examples/agent-with-human-approval/handlers_auto_resume.go
@@ -186,13 +186,8 @@ func (t *HITLChatAgent) handleAutoResumeSSE(w http.ResponseWriter, r *http.Reque
 	// 8. EXECUTE WITH STREAMING (matches handleResumeSSE)
 	// =========================================================================
 
-	// Extract session ID from checkpoint metadata
-	sessionID := ""
-	if checkpoint.UserContext != nil {
-		if sid, ok := checkpoint.UserContext["session_id"].(string); ok {
-			sessionID = sid
-		}
-	}
+	// This example maps its chat-session UUID to the canonical conversation ID.
+	sessionID := sessionIDFromCheckpoint(checkpoint.UserContext)
 	if sessionID == "" {
 		// Generate new session if not found
 		session := t.sessionStore.Create("", nil)

--- a/examples/devops-chat-agent/chat_agent.go
+++ b/examples/devops-chat-agent/chat_agent.go
@@ -394,11 +394,17 @@ func conversationTurnsFromMessages(history []Message) []core.ConversationTurn {
 }
 
 func (t *DevOpsChatAgent) addConversationHistoryMetadata(metadata map[string]interface{}, sessionID string, history []Message) {
-	if sessionID == "" || len(history) == 0 {
+	if sessionID == "" {
+		return
+	}
+
+	// This example maps one chat session to exactly one conversation.
+	metadata[orchestration.MetadataConversationID] = sessionID
+
+	if len(history) == 0 {
 		return
 	}
 	metadata[orchestration.MetadataConversationTurns] = conversationTurnsFromMessages(history)
-	metadata[orchestration.MetadataConversationSessionKey] = sessionID
 	if formattedHistory := t.formatConversationHistory(history); formattedHistory != "" {
 		metadata[core.EnrichmentConversationHistory] = formattedHistory
 	}

--- a/examples/devops-chat-agent/handlers_hitl.go
+++ b/examples/devops-chat-agent/handlers_hitl.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/truvaagents/truva-g3/core"
 	"github.com/truvaagents/truva-g3/orchestration"
 	"github.com/truvaagents/truva-g3/telemetry"
 	"go.opentelemetry.io/otel/attribute"
@@ -117,13 +118,8 @@ func (t *DevOpsChatAgent) handleResumeSSE(w http.ResponseWriter, r *http.Request
 	}
 	telemetry.AddSpanEvent(ctx, "hitl.checkpoint.loaded", loadedAttrs...)
 
-	// Extract session ID from checkpoint metadata
-	sessionID := ""
-	if checkpoint.UserContext != nil {
-		if sid, ok := checkpoint.UserContext["session_id"].(string); ok {
-			sessionID = sid
-		}
-	}
+	// This example maps its chat-session UUID to the canonical conversation ID.
+	sessionID := sessionIDFromCheckpoint(checkpoint.UserContext)
 	if sessionID == "" {
 		session := t.sessionStore.Create("", nil)
 		sessionID = session.ID
@@ -356,13 +352,8 @@ func (t *DevOpsChatAgent) handleAutoResumeSSE(w http.ResponseWriter, r *http.Req
 
 	callback.SendStatus("resuming", "Auto-approved - resuming execution...")
 
-	// Extract session ID
-	sessionID := ""
-	if checkpoint.UserContext != nil {
-		if sid, ok := checkpoint.UserContext["session_id"].(string); ok {
-			sessionID = sid
-		}
-	}
+	// This example maps its chat-session UUID to the canonical conversation ID.
+	sessionID := sessionIDFromCheckpoint(checkpoint.UserContext)
 	if sessionID == "" {
 		session := t.sessionStore.Create("", nil)
 		sessionID = session.ID
@@ -421,3 +412,14 @@ func (t *DevOpsChatAgent) handleAutoResumeSSE(w http.ResponseWriter, r *http.Req
 }
 
 // extractPathParam is defined in handlers.go
+
+func sessionIDFromCheckpoint(metadata map[string]interface{}) string {
+	if conversationID, ok := metadata[orchestration.MetadataConversationID].(string); ok &&
+		core.ValidateConversationID(conversationID) == core.ConversationIDValidationNone {
+		return conversationID
+	}
+	if sessionID, ok := metadata["session_id"].(string); ok && sessionID != "" {
+		return sessionID
+	}
+	return ""
+}

--- a/examples/registry-viewer-app/README.md
+++ b/examples/registry-viewer-app/README.md
@@ -164,6 +164,47 @@ REDIS_URL=redis://custom-redis:6379 ./setup.sh deploy
 | `GET /api/health` | Health check endpoint |
 | `GET /api/llm-debug` | List recent LLM debug records |
 | `GET /api/llm-debug/{request_id}` | Get full debug record by request ID |
+| `GET /api/executions` | List recent executions in the existing flat response shape |
+| `GET /api/executions?group_conversations=true` | List server-owned conversation groups; stable DB 8 sorts support filter-aware cursor pagination |
+| `GET /api/executions/{request_id}/unified` | Get the unified execution, DAG, LLM, HITL, trace, and conversation detail |
+| `GET /api/conversations?conversation_id={id}` | Get one verified chronological conversation timeline |
+
+The conversation endpoints read the existing framework-owned Redis DB 7 and
+DB 8 data. The Registry Viewer does not create, repair, expire, or otherwise
+mutate execution or conversation indexes, so read-only DB 7/8 credentials are
+sufficient.
+
+### Grouped execution safety bounds
+
+Grouped and timeline requests use named application-local limits so one
+diagnostic request cannot perform an unbounded Redis scan. These are Registry
+Viewer implementation limits, not `TRUVAG3_*` framework configuration:
+
+| Bound | Value |
+|------|------:|
+| Default groups per page | 50 |
+| Maximum groups per page | 200 |
+| Global execution-index members scanned | 5000 |
+| Distinct conversations expanded | 500 |
+| Execution records hydrated | 10000 |
+| Members read from one conversation index | 1000 |
+| Maximum encoded grouped cursor length | 2048 bytes |
+
+When a relevant bound is reached, the response sets `partial=true` and omits a
+grouped continuation cursor. The existing flat execution list remains
+available for request-by-request troubleshooting.
+
+Combined duration sorting (`sort=total_duration_ms`) includes LLM duration read
+from mutable DB 7 data. It is therefore a bounded point-in-time sort: when more
+groups exist than the requested limit, the response is partial and does not
+provide a continuation cursor. A supplied duration-sort cursor is rejected.
+Created and request-text sorts use immutable DB 8 values and retain grouped
+keyset pagination.
+
+If a DB 7 enrichment read fails, timeline and grouped responses set
+`llm_enrichment_incomplete=true`. Grouped responses also set `partial=true` and
+omit `next_cursor`; execution membership still comes from DB 8 and remains
+available.
 
 ## Service Data Structure
 

--- a/examples/registry-viewer-app/README.md
+++ b/examples/registry-viewer-app/README.md
@@ -188,11 +188,14 @@ Viewer implementation limits, not `TRUVAG3_*` framework configuration:
 | Distinct conversations expanded | 500 |
 | Execution records hydrated | 10000 |
 | Members read from one conversation index | 1000 |
+| Executions enriched from LLM Debug per response | 200 |
+| LLM Debug interactions accepted per execution | 100 |
+| LLM Debug interaction bytes accepted per execution | 4 MiB |
 | Maximum encoded grouped cursor length | 2048 bytes |
 
-When a relevant bound is reached, the response sets `partial=true` and omits a
-grouped continuation cursor. The existing flat execution list remains
-available for request-by-request troubleshooting.
+When a DB 8 membership or grouping bound is reached, the response sets
+`partial=true` and omits a grouped continuation cursor. The existing flat
+execution list remains available for request-by-request troubleshooting.
 
 Combined duration sorting (`sort=total_duration_ms`) includes LLM duration read
 from mutable DB 7 data. It is therefore a bounded point-in-time sort: when more
@@ -201,10 +204,13 @@ provide a continuation cursor. A supplied duration-sort cursor is rejected.
 Created and request-text sorts use immutable DB 8 values and retain grouped
 keyset pagination.
 
-If a DB 7 enrichment read fails, timeline and grouped responses set
-`llm_enrichment_incomplete=true`. Grouped responses also set `partial=true` and
-omit `next_cursor`; execution membership still comes from DB 8 and remains
-available.
+If a DB 7 enrichment read fails or reaches any enrichment bound, timeline and
+grouped responses set `llm_enrichment_incomplete=true`. Created and request-text
+sorts paginate from DB 8 first and enrich only the returned page, so incomplete
+optional DB 7 details do not suppress their valid `next_cursor`. Combined
+duration sorting sets `partial=true` when enrichment is incomplete because DB 7
+contributes to its ordering. The Viewer does not publish a partial per-execution
+LLM duration or call count as though it were complete.
 
 ## Service Data Structure
 

--- a/examples/registry-viewer-app/conversation_api.go
+++ b/examples/registry-viewer-app/conversation_api.go
@@ -397,7 +397,7 @@ func loadConversationTimeline(
 	for _, summary := range verified {
 		summaries = append(summaries, summary)
 	}
-	enrichment, enrichmentErr :=
+	enrichment, enrichmentIncomplete, enrichmentErr :=
 		enrichExecutionSummariesFromLLMDebug(ctx, summaries)
 	return buildConversationTimelineResponse(
 		conversationID,
@@ -405,7 +405,7 @@ func loadConversationTimeline(
 		enrichment,
 		reverseMore || globalMore || hydrationPartial,
 		indexIncomplete,
-		enrichmentErr != nil,
+		enrichmentIncomplete || enrichmentErr != nil,
 	), nil
 }
 
@@ -786,13 +786,21 @@ func loadGroupedExecutions(
 	for _, summary := range summariesByID {
 		summaries = append(summaries, summary)
 	}
-	enrichment, enrichmentErr :=
-		enrichExecutionSummariesFromLLMDebug(ctx, summaries)
-	if enrichmentErr != nil {
-		// DB 7 enrichment is fail-open, but an incomplete enrichment cannot
-		// support an atomic grouped continuation. Mark the response partial so
-		// pagination is suppressed and the UI can fall back to Flat mode.
-		partial = true
+
+	var (
+		enrichment           map[string]llmDebugEnrichment
+		enrichmentIncomplete bool
+		enrichmentErr        error
+	)
+	if query.Sort == "total_duration_ms" {
+		// Combined duration ordering depends on mutable DB 7 data, so it must
+		// be enriched before grouping. An incomplete read makes this bounded
+		// point-in-time result partial; duration cursors are rejected.
+		enrichment, enrichmentIncomplete, enrichmentErr =
+			enrichExecutionSummariesFromLLMDebug(ctx, summaries)
+		if enrichmentIncomplete || enrichmentErr != nil {
+			partial = true
+		}
 	}
 	groups := buildGroupedExecutionUnits(
 		summaries,
@@ -800,14 +808,28 @@ func loadGroupedExecutions(
 		indexIncomplete,
 		query,
 	)
-	return paginateGroupedExecutionUnits(
+	response := paginateGroupedExecutionUnits(
 		groups,
 		query,
 		snapshotScore,
 		snapshotMember,
 		partial,
-		enrichmentErr != nil,
-	), nil
+		enrichmentIncomplete || enrichmentErr != nil,
+	)
+	if query.Sort == "total_duration_ms" {
+		return response, nil
+	}
+
+	// Created-at and request-text ordering depend only on immutable DB 8
+	// fields. Paginate first, then enrich just the returned page so optional
+	// DB 7 bounds or failures cannot suppress a valid DB 8 continuation.
+	pageSummaries := groupedExecutionPageSummaries(response.Groups)
+	enrichment, enrichmentIncomplete, enrichmentErr =
+		enrichExecutionSummariesFromLLMDebug(ctx, pageSummaries)
+	applyGroupedExecutionEnrichment(response.Groups, enrichment)
+	response.LLMEnrichmentIncomplete =
+		enrichmentIncomplete || enrichmentErr != nil
+	return response, nil
 }
 
 func readGroupedGlobalSnapshot(
@@ -829,7 +851,7 @@ func readGroupedGlobalSnapshot(
 		&redis.ZRangeBy{
 			Min:   "-inf",
 			Max:   maxScore,
-			Count: int64(viewerGlobalExecutionScanLimit + 1),
+			Count: int64(viewerGlobalExecutionScanLimit) + 1,
 		},
 	).Result()
 	if err != nil {
@@ -1221,6 +1243,67 @@ func compareGroupedSortValue(left, right groupedSortValue) int {
 	}
 }
 
+func groupedExecutionPageSummaries(
+	groups []GroupedExecutionGroup,
+) []ExecutionSummary {
+	seen := make(map[string]struct{})
+	summaries := make([]ExecutionSummary, 0)
+	appendSummary := func(summary ExecutionSummary) {
+		if summary.RequestID == "" {
+			return
+		}
+		if _, exists := seen[summary.RequestID]; exists {
+			return
+		}
+		seen[summary.RequestID] = struct{}{}
+		summaries = append(summaries, summary)
+	}
+
+	for _, group := range groups {
+		for _, turn := range group.Turns {
+			appendSummary(turn.Execution)
+			for _, related := range turn.RelatedExecutions {
+				appendSummary(related)
+			}
+		}
+		for _, orphan := range group.Orphans {
+			appendSummary(orphan)
+		}
+	}
+	return summaries
+}
+
+func applyGroupedExecutionEnrichment(
+	groups []GroupedExecutionGroup,
+	enrichment map[string]llmDebugEnrichment,
+) {
+	applySummary := func(summary *ExecutionSummary) {
+		item, exists := enrichment[summary.RequestID]
+		if !exists {
+			return
+		}
+		summary.LLMTotalDurationMs = item.TotalDurationMs
+	}
+
+	for groupIndex := range groups {
+		group := &groups[groupIndex]
+		for turnIndex := range group.Turns {
+			turn := &group.Turns[turnIndex]
+			applySummary(&turn.Execution)
+			if item, exists := enrichment[turn.Execution.RequestID]; exists {
+				turn.LLMCallCount = item.CallCount
+				turn.HistoryStatus = item.HistoryStatus
+			}
+			for relatedIndex := range turn.RelatedExecutions {
+				applySummary(&turn.RelatedExecutions[relatedIndex])
+			}
+		}
+		for orphanIndex := range group.Orphans {
+			applySummary(&group.Orphans[orphanIndex])
+		}
+	}
+}
+
 func paginateGroupedExecutionUnits(
 	groups []GroupedExecutionGroup,
 	query *groupedExecutionQuery,
@@ -1297,60 +1380,122 @@ func encodeGroupedExecutionCursor(cursor groupedExecutionCursor) (string, error)
 func enrichExecutionSummariesFromLLMDebug(
 	ctx context.Context,
 	summaries []ExecutionSummary,
-) (map[string]llmDebugEnrichment, error) {
+) (map[string]llmDebugEnrichment, bool, error) {
 	enrichment := make(map[string]llmDebugEnrichment, len(summaries))
 	if len(summaries) == 0 || useMock {
-		return enrichment, nil
+		return enrichment, false, nil
 	}
 	client, err := getLLMDebugReadClient()
 	if err != nil {
-		return enrichment, err
+		return enrichment, false, err
+	}
+
+	// Prefer the newest executions when a bounded grouped/timeline request
+	// contains more candidates than the DB 7 enrichment budget. The DB 8
+	// membership remains complete up to its independent bounds, while callers
+	// receive an explicit incomplete signal for optional LLM-derived fields.
+	summaryIndexes := make([]int, len(summaries))
+	for i := range summaries {
+		summaryIndexes[i] = i
+	}
+	sort.SliceStable(summaryIndexes, func(i, j int) bool {
+		left := summaries[summaryIndexes[i]]
+		right := summaries[summaryIndexes[j]]
+		if left.CreatedAt.Equal(right.CreatedAt) {
+			return left.RequestID < right.RequestID
+		}
+		return left.CreatedAt.After(right.CreatedAt)
+	})
+	incomplete := len(summaryIndexes) > viewerLLMEnrichmentExecutionLimit
+	if incomplete {
+		summaryIndexes = summaryIndexes[:viewerLLMEnrichmentExecutionLimit]
 	}
 
 	pipe := client.Pipeline()
-	interactionCommands := make(map[string]*redis.StringSliceCmd, len(summaries))
-	metaCommands := make(map[string]*redis.IntCmd, len(summaries))
-	legacyCommands := make(map[string]*redis.StringCmd, len(summaries))
-	for _, summary := range summaries {
+	interactionCommands := make(map[string]*redis.StringSliceCmd, len(summaryIndexes))
+	metaCommands := make(map[string]*redis.IntCmd, len(summaryIndexes))
+	legacyCommands := make(map[string]*redis.StringCmd, len(summaryIndexes))
+	for _, summaryIndex := range summaryIndexes {
+		summary := summaries[summaryIndex]
 		requestID := summary.RequestID
 		interactionCommands[requestID] = pipe.LRange(
 			ctx,
 			viewerLLMDebugKeyPrefix+requestID+viewerLLMDebugInterSuffix,
 			0,
-			-1,
+			viewerLLMInteractionLimit,
 		)
 		metaCommands[requestID] = pipe.Exists(
 			ctx,
 			viewerLLMDebugKeyPrefix+requestID+viewerLLMDebugMetaSuffix,
 		)
-		legacyCommands[requestID] = pipe.Get(
+		legacyCommands[requestID] = pipe.GetRange(
 			ctx,
 			viewerLLMDebugKeyPrefix+requestID,
+			0,
+			viewerLLMInteractionBytesLimit,
 		)
 	}
 	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
-		return enrichment, err
+		return enrichment, incomplete, err
 	}
 
-	for i := range summaries {
-		requestID := summaries[i].RequestID
+	for _, summaryIndex := range summaryIndexes {
+		requestID := summaries[summaryIndex].RequestID
 		var interactions []orchestration.LLMInteraction
+		recordIncomplete := false
 		serialized, listErr := interactionCommands[requestID].Result()
 		if listErr == nil {
-			for _, raw := range serialized {
-				var interaction orchestration.LLMInteraction
-				if json.Unmarshal([]byte(raw), &interaction) == nil {
+			if len(serialized) > viewerLLMInteractionLimit {
+				incomplete = true
+				recordIncomplete = true
+			}
+			if !recordIncomplete {
+				serializedBytes := 0
+				for _, raw := range serialized {
+					if len(raw) > viewerLLMInteractionBytesLimit-serializedBytes {
+						incomplete = true
+						recordIncomplete = true
+						break
+					}
+					serializedBytes += len(raw)
+					var interaction orchestration.LLMInteraction
+					if json.Unmarshal([]byte(raw), &interaction) != nil {
+						incomplete = true
+						recordIncomplete = true
+						break
+					}
 					interactions = append(interactions, interaction)
 				}
 			}
 		}
-		if len(interactions) == 0 {
+		if len(interactions) == 0 && !recordIncomplete {
 			if legacy, legacyErr := legacyCommands[requestID].Bytes(); legacyErr == nil {
-				var record orchestration.LLMDebugRecord
-				if decodeViewerStoredJSON(legacy, &record) == nil {
-					interactions = record.Interactions
+				if len(legacy) > viewerLLMInteractionBytesLimit {
+					incomplete = true
+					recordIncomplete = true
+				} else if len(legacy) > 0 {
+					var record orchestration.LLMDebugRecord
+					if decodeViewerStoredJSON(
+						legacy,
+						&record,
+						viewerLLMInteractionBytesLimit,
+					) != nil {
+						incomplete = true
+						recordIncomplete = true
+					} else {
+						interactions = record.Interactions
+						if len(interactions) > viewerLLMInteractionLimit {
+							incomplete = true
+							recordIncomplete = true
+						}
+					}
 				}
 			}
+		}
+		if recordIncomplete {
+			// Do not publish partial duration/count values as exact enrichment.
+			// Callers still receive DB 8 membership plus the incomplete signal.
+			continue
 		}
 		if len(interactions) == 0 {
 			if metaCount, metaErr := metaCommands[requestID].Result(); metaErr == nil &&
@@ -1374,12 +1519,12 @@ func enrichExecutionSummariesFromLLMDebug(
 			}
 		}
 		enrichment[requestID] = item
-		summaries[i].LLMTotalDurationMs = item.TotalDurationMs
+		summaries[summaryIndex].LLMTotalDurationMs = item.TotalDurationMs
 	}
-	return enrichment, nil
+	return enrichment, incomplete, nil
 }
 
-func decodeViewerStoredJSON(data []byte, target interface{}) error {
+func decodeViewerStoredJSON(data []byte, target interface{}, maxBytes int) error {
 	if len(data) == 0 {
 		return fmt.Errorf("empty data")
 	}
@@ -1393,10 +1538,13 @@ func decodeViewerStoredJSON(data []byte, target interface{}) error {
 			return err
 		}
 		defer func() { _ = reader.Close() }()
-		payload, err = io.ReadAll(reader)
+		payload, err = io.ReadAll(io.LimitReader(reader, int64(maxBytes)+1))
 		if err != nil {
 			return err
 		}
+	}
+	if len(payload) > maxBytes {
+		return fmt.Errorf("decoded payload exceeds limit")
 	}
 	return json.Unmarshal(payload, target)
 }

--- a/examples/registry-viewer-app/conversation_api.go
+++ b/examples/registry-viewer-app/conversation_api.go
@@ -1,0 +1,1402 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/truvaagents/truva-g3/core"
+	"github.com/truvaagents/truva-g3/orchestration"
+)
+
+const (
+	viewerLLMDebugKeyPrefix   = "truvag3:llm:debug:"
+	viewerLLMDebugMetaSuffix  = ":meta"
+	viewerLLMDebugInterSuffix = ":interactions"
+	groupedCursorSchema       = 1
+)
+
+// ConversationTimelineTurn is one top-level user turn plus any related
+// HITL/delegated executions. Related executions are lineage, not independent
+// conversation turns.
+type ConversationTimelineTurn struct {
+	Execution         ExecutionSummary   `json:"execution"`
+	RelatedExecutions []ExecutionSummary `json:"related_executions"`
+	LLMCallCount      int                `json:"llm_call_count,omitempty"`
+	HistoryStatus     string             `json:"history_status,omitempty"`
+}
+
+// ConversationTimelineResponse is the focused chronological conversation view.
+type ConversationTimelineResponse struct {
+	ConversationID          string                     `json:"conversation_id"`
+	Turns                   []ConversationTimelineTurn `json:"turns"`
+	Orphans                 []ExecutionSummary         `json:"orphans"`
+	TurnCount               int                        `json:"turn_count"`
+	ExecutionCount          int                        `json:"execution_count"`
+	IndexIncomplete         bool                       `json:"index_incomplete"`
+	LLMEnrichmentIncomplete bool                       `json:"llm_enrichment_incomplete"`
+	Partial                 bool                       `json:"partial"`
+	Timestamp               time.Time                  `json:"timestamp"`
+}
+
+// GroupedExecutionGroup is one atomic unit in the grouped execution list.
+type GroupedExecutionGroup struct {
+	GroupKey          string                     `json:"group_key"`
+	ConversationID    string                     `json:"conversation_id,omitempty"`
+	AnchorCreatedAt   time.Time                  `json:"anchor_created_at"`
+	MatchingTurnCount int                        `json:"matching_turn_count"`
+	TotalTurnCount    int                        `json:"total_turn_count"`
+	Turns             []ConversationTimelineTurn `json:"turns"`
+	Orphans           []ExecutionSummary         `json:"orphans"`
+	IndexIncomplete   bool                       `json:"index_incomplete"`
+
+	sortValue groupedSortValue
+}
+
+// GroupedExecutionListResponse is the additive server-owned grouping shape.
+type GroupedExecutionListResponse struct {
+	Groups                  []GroupedExecutionGroup `json:"groups"`
+	NextCursor              string                  `json:"next_cursor,omitempty"`
+	QueryFingerprint        string                  `json:"query_fingerprint"`
+	LLMEnrichmentIncomplete bool                    `json:"llm_enrichment_incomplete"`
+	Partial                 bool                    `json:"partial"`
+	Timestamp               time.Time               `json:"timestamp"`
+}
+
+type groupedExecutionQuery struct {
+	Search      string
+	Status      string
+	Sort        string
+	Direction   string
+	Limit       int
+	Cursor      *groupedExecutionCursor
+	Fingerprint string
+}
+
+type groupedSortValue struct {
+	Kind   string `json:"kind"`
+	String string `json:"string,omitempty"`
+	Number int64  `json:"number,omitempty"`
+}
+
+type groupedExecutionCursor struct {
+	Version         int              `json:"version"`
+	Fingerprint     string           `json:"fingerprint"`
+	SnapshotScore   string           `json:"snapshot_score"`
+	SnapshotMember  string           `json:"snapshot_member"`
+	SortValue       groupedSortValue `json:"sort_value"`
+	AnchorCreatedAt int64            `json:"anchor_created_at"`
+	GroupKey        string           `json:"group_key"`
+}
+
+type indexedExecution struct {
+	RequestID string
+	Score     float64
+}
+
+type executionReadCache struct {
+	records  map[string]*StoredExecution
+	missing  map[string]struct{}
+	hydrated int
+}
+
+type llmDebugEnrichment struct {
+	CallCount       int
+	TotalDurationMs int64
+	HistoryStatus   string
+}
+
+var (
+	llmDebugReadClient   *redis.Client
+	llmDebugReadClientMu sync.Mutex
+)
+
+func getLLMDebugReadClient() (*redis.Client, error) {
+	llmDebugReadClientMu.Lock()
+	defer llmDebugReadClientMu.Unlock()
+
+	if llmDebugReadClient == nil {
+		opt, err := redis.ParseURL(redisURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid redis URL: %w", err)
+		}
+		opt.DB = core.RedisDBLLMDebug
+		llmDebugReadClient = redis.NewClient(opt)
+	}
+	return llmDebugReadClient, nil
+}
+
+func summarizeExecution(execution *StoredExecution) ExecutionSummary {
+	if execution == nil {
+		return ExecutionSummary{}
+	}
+	summary := ExecutionSummary{
+		RequestID:         execution.RequestID,
+		OriginalRequestID: execution.OriginalRequestID,
+		ConversationID:    execution.Metadata[orchestration.MetadataConversationID],
+		TraceID:           execution.TraceID,
+		AgentName:         execution.AgentName,
+		OriginalRequest:   execution.OriginalRequest,
+		Interrupted:       execution.Interrupted,
+		CreatedAt:         execution.CreatedAt,
+		Metadata:          execution.Metadata,
+	}
+	if execution.Result != nil {
+		summary.Success = execution.Result.Success
+		summary.TotalDurationMs = execution.Result.TotalDuration / 1_000_000
+		summary.StepCount = len(execution.Result.Steps)
+		for _, step := range execution.Result.Steps {
+			if !step.Success {
+				summary.FailedSteps++
+			}
+		}
+	}
+	return summary
+}
+
+func viewerConversationIndexKey(conversationID string) string {
+	digest := sha256.Sum256([]byte(conversationID))
+	return fmt.Sprintf("%sconversation:%x", executionKeyPrefix, digest)
+}
+
+func newExecutionReadCache() *executionReadCache {
+	return &executionReadCache{
+		records: make(map[string]*StoredExecution),
+		missing: make(map[string]struct{}),
+	}
+}
+
+func (c *executionReadCache) load(
+	ctx context.Context,
+	client *redis.Client,
+	requestIDs []string,
+) (bool, error) {
+	unknown := make([]string, 0, len(requestIDs))
+	seen := make(map[string]struct{}, len(requestIDs))
+	for _, requestID := range requestIDs {
+		if requestID == "" {
+			continue
+		}
+		if _, duplicate := seen[requestID]; duplicate {
+			continue
+		}
+		seen[requestID] = struct{}{}
+		if _, ok := c.records[requestID]; ok {
+			continue
+		}
+		if _, ok := c.missing[requestID]; ok {
+			continue
+		}
+		unknown = append(unknown, requestID)
+	}
+
+	remaining := viewerExecutionHydrationLimit - c.hydrated
+	truncated := len(unknown) > remaining
+	if remaining <= 0 {
+		return len(unknown) > 0, nil
+	}
+	if len(unknown) > remaining {
+		unknown = unknown[:remaining]
+	}
+	if len(unknown) == 0 {
+		return truncated, nil
+	}
+
+	keys := make([]string, len(unknown))
+	for i, requestID := range unknown {
+		keys[i] = executionKeyPrefix + requestID
+	}
+	values, err := client.MGet(ctx, keys...).Result()
+	if err != nil {
+		return truncated, fmt.Errorf("failed to hydrate executions: %w", err)
+	}
+	c.hydrated += len(unknown)
+	for i, value := range values {
+		requestID := unknown[i]
+		if value == nil {
+			c.missing[requestID] = struct{}{}
+			continue
+		}
+		var data []byte
+		switch typed := value.(type) {
+		case string:
+			data = []byte(typed)
+		case []byte:
+			data = typed
+		default:
+			c.missing[requestID] = struct{}{}
+			continue
+		}
+		execution, decodeErr := deserializeExecution(data)
+		if decodeErr != nil {
+			c.missing[requestID] = struct{}{}
+			continue
+		}
+		c.records[requestID] = execution
+	}
+	return truncated, nil
+}
+
+func handleConversationTimeline(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	values, present := r.URL.Query()["conversation_id"]
+	if !present || len(values) != 1 || values[0] == "" {
+		http.Error(w, "query parameter 'conversation_id' is required", http.StatusBadRequest)
+		return
+	}
+	conversationID := values[0]
+	if reason := core.ValidateConversationID(conversationID); reason != core.ConversationIDValidationNone {
+		http.Error(w, "invalid conversation_id: "+string(reason), http.StatusBadRequest)
+		return
+	}
+
+	if useMock {
+		summaries := make([]ExecutionSummary, 0)
+		for _, summary := range getMockExecutionSummaries() {
+			if summary.ConversationID == conversationID {
+				summaries = append(summaries, summary)
+			}
+		}
+		response := buildConversationTimelineResponse(
+			conversationID,
+			summaries,
+			nil,
+			false,
+			false,
+			false,
+		)
+		_ = json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	response, err := loadConversationTimeline(r.Context(), conversationID)
+	if err != nil {
+		http.Error(w, "conversation timeline unavailable", http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func loadConversationTimeline(
+	parent context.Context,
+	conversationID string,
+) (*ConversationTimelineResponse, error) {
+	client, err := getExecutionDebugClient()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(parent, 10*time.Second)
+	defer cancel()
+
+	conversationKey := viewerConversationIndexKey(conversationID)
+	reverseIDs, err := client.ZRange(
+		ctx,
+		conversationKey,
+		0,
+		viewerConversationMemberReadLimit,
+	).Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read conversation index: %w", err)
+	}
+	reverseMore := len(reverseIDs) > viewerConversationMemberReadLimit
+	if reverseMore {
+		reverseIDs = reverseIDs[:viewerConversationMemberReadLimit]
+	}
+
+	globalRows, err := client.ZRevRangeWithScores(
+		ctx,
+		executionIndexKey,
+		0,
+		viewerGlobalExecutionScanLimit,
+	).Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read global execution index: %w", err)
+	}
+	globalMore := len(globalRows) > viewerGlobalExecutionScanLimit
+	if globalMore {
+		globalRows = globalRows[:viewerGlobalExecutionScanLimit]
+	}
+	globalIDs := make([]string, 0, len(globalRows))
+	for _, row := range globalRows {
+		if requestID, ok := row.Member.(string); ok {
+			globalIDs = append(globalIDs, requestID)
+		}
+	}
+
+	candidates := append(append([]string{}, reverseIDs...), globalIDs...)
+	cache := newExecutionReadCache()
+	hydrationPartial, err := cache.load(ctx, client, candidates)
+	if err != nil {
+		return nil, err
+	}
+
+	reverseSet := make(map[string]struct{}, len(reverseIDs))
+	for _, requestID := range reverseIDs {
+		reverseSet[requestID] = struct{}{}
+	}
+	indexIncomplete := false
+	verified := make(map[string]ExecutionSummary)
+	for _, requestID := range reverseIDs {
+		execution := cache.records[requestID]
+		if execution == nil ||
+			execution.Metadata[orchestration.MetadataConversationID] != conversationID {
+			indexIncomplete = true
+			continue
+		}
+		verified[requestID] = summarizeExecution(execution)
+	}
+	for _, requestID := range globalIDs {
+		execution := cache.records[requestID]
+		if execution == nil ||
+			execution.Metadata[orchestration.MetadataConversationID] != conversationID {
+			continue
+		}
+		verified[requestID] = summarizeExecution(execution)
+	}
+	membershipChecks := make(map[string][]string)
+	for requestID := range verified {
+		if _, inReverse := reverseSet[requestID]; !inReverse {
+			membershipChecks[conversationID] = append(
+				membershipChecks[conversationID],
+				requestID,
+			)
+		}
+	}
+	missingMembers, err := findMissingConversationIndexMembers(
+		ctx,
+		client,
+		membershipChecks,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(missingMembers[conversationID]) > 0 {
+		indexIncomplete = true
+	}
+
+	summaries := make([]ExecutionSummary, 0, len(verified))
+	for _, summary := range verified {
+		summaries = append(summaries, summary)
+	}
+	enrichment, enrichmentErr :=
+		enrichExecutionSummariesFromLLMDebug(ctx, summaries)
+	return buildConversationTimelineResponse(
+		conversationID,
+		summaries,
+		enrichment,
+		reverseMore || globalMore || hydrationPartial,
+		indexIncomplete,
+		enrichmentErr != nil,
+	), nil
+}
+
+func buildConversationTimelineResponse(
+	conversationID string,
+	summaries []ExecutionSummary,
+	enrichment map[string]llmDebugEnrichment,
+	partial bool,
+	indexIncomplete bool,
+	llmEnrichmentIncomplete bool,
+) *ConversationTimelineResponse {
+	sort.SliceStable(summaries, func(i, j int) bool {
+		if summaries[i].CreatedAt.Equal(summaries[j].CreatedAt) {
+			return summaries[i].RequestID < summaries[j].RequestID
+		}
+		return summaries[i].CreatedAt.Before(summaries[j].CreatedAt)
+	})
+
+	topLevel := make(map[string]int)
+	turns := make([]ConversationTimelineTurn, 0)
+	related := make([]ExecutionSummary, 0)
+	for _, summary := range summaries {
+		if isTopLevelExecution(summary) {
+			topLevel[summary.RequestID] = len(turns)
+			item := enrichment[summary.RequestID]
+			turns = append(turns, ConversationTimelineTurn{
+				Execution:         summary,
+				RelatedExecutions: []ExecutionSummary{},
+				LLMCallCount:      item.CallCount,
+				HistoryStatus:     item.HistoryStatus,
+			})
+		} else {
+			related = append(related, summary)
+		}
+	}
+
+	orphans := make([]ExecutionSummary, 0)
+	for _, summary := range related {
+		if turnIndex, ok := topLevel[summary.OriginalRequestID]; ok {
+			turns[turnIndex].RelatedExecutions = append(
+				turns[turnIndex].RelatedExecutions,
+				summary,
+			)
+			continue
+		}
+		orphans = append(orphans, summary)
+	}
+
+	return &ConversationTimelineResponse{
+		ConversationID:          conversationID,
+		Turns:                   nonNilSlice(turns),
+		Orphans:                 nonNilSlice(orphans),
+		TurnCount:               len(turns),
+		ExecutionCount:          len(summaries),
+		IndexIncomplete:         indexIncomplete,
+		LLMEnrichmentIncomplete: llmEnrichmentIncomplete,
+		Partial:                 partial,
+		Timestamp:               time.Now(),
+	}
+}
+
+func handleGroupedExecutionList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	query, err := parseGroupedExecutionQuery(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if useMock {
+		summaries := getMockExecutionSummaries()
+		groups := buildGroupedExecutionUnits(
+			summaries,
+			nil,
+			nil,
+			query,
+		)
+		snapshotScore := "0"
+		snapshotMember := "mock"
+		for _, summary := range summaries {
+			score := float64(summary.CreatedAt.UnixNano())
+			current, _ := strconv.ParseFloat(snapshotScore, 64)
+			if score > current ||
+				(score == current && summary.RequestID > snapshotMember) {
+				snapshotScore = strconv.FormatFloat(score, 'g', -1, 64)
+				snapshotMember = summary.RequestID
+			}
+		}
+		response := paginateGroupedExecutionUnits(
+			groups,
+			query,
+			snapshotScore,
+			snapshotMember,
+			false,
+			false,
+		)
+		_ = json.NewEncoder(w).Encode(response)
+		return
+	}
+
+	response, err := loadGroupedExecutions(r.Context(), query)
+	if err != nil {
+		http.Error(w, "grouped executions unavailable", http.StatusInternalServerError)
+		return
+	}
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func parseGroupedExecutionQuery(r *http.Request) (*groupedExecutionQuery, error) {
+	values := r.URL.Query()
+	query := &groupedExecutionQuery{
+		Search:    strings.ToLower(strings.TrimSpace(values.Get("q"))),
+		Status:    values.Get("status"),
+		Sort:      values.Get("sort"),
+		Direction: values.Get("direction"),
+		Limit:     viewerDefaultGroupPageSize,
+	}
+	if query.Status == "" {
+		query.Status = "all"
+	}
+	switch query.Status {
+	case "all", "success", "failed", "interrupted":
+	default:
+		return nil, fmt.Errorf("unsupported status")
+	}
+	if query.Sort == "" {
+		query.Sort = "created_at"
+	}
+	switch query.Sort {
+	case "original_request", "total_duration_ms", "created_at":
+	default:
+		return nil, fmt.Errorf("unsupported sort")
+	}
+	if query.Direction == "" {
+		if query.Sort == "created_at" {
+			query.Direction = "desc"
+		} else {
+			query.Direction = "asc"
+		}
+	}
+	if query.Direction != "asc" && query.Direction != "desc" {
+		return nil, fmt.Errorf("unsupported direction")
+	}
+	if rawLimit, present := values["limit"]; present {
+		if len(rawLimit) != 1 {
+			return nil, fmt.Errorf("limit must be specified once")
+		}
+		limit, err := strconv.Atoi(rawLimit[0])
+		if err != nil || limit <= 0 {
+			return nil, fmt.Errorf("limit must be a positive integer")
+		}
+		if limit > viewerMaxGroupPageSize {
+			limit = viewerMaxGroupPageSize
+		}
+		query.Limit = limit
+	}
+
+	fingerprintInput := strings.Join([]string{
+		"grouped-executions-v1",
+		query.Search,
+		query.Status,
+		query.Sort,
+		query.Direction,
+	}, "\x00")
+	digest := sha256.Sum256([]byte(fingerprintInput))
+	query.Fingerprint = fmt.Sprintf("%x", digest)
+
+	if rawCursor, present := values["cursor"]; present {
+		if len(rawCursor) != 1 || rawCursor[0] == "" {
+			return nil, fmt.Errorf("cursor must be specified once and non-empty")
+		}
+		if query.Sort == "total_duration_ms" {
+			return nil, fmt.Errorf(
+				"cursor is not supported for total_duration_ms sorting",
+			)
+		}
+		cursor, err := decodeGroupedExecutionCursor(rawCursor[0])
+		if err != nil {
+			return nil, err
+		}
+		if cursor.Fingerprint != query.Fingerprint {
+			return nil, fmt.Errorf("cursor does not match the current query")
+		}
+		expectedSortKind := "number"
+		if query.Sort == "original_request" {
+			expectedSortKind = "string"
+		}
+		if cursor.SortValue.Kind != expectedSortKind {
+			return nil, fmt.Errorf("cursor sort value does not match the current query")
+		}
+		query.Cursor = cursor
+	}
+	return query, nil
+}
+
+func decodeGroupedExecutionCursor(raw string) (*groupedExecutionCursor, error) {
+	if len(raw) > viewerGroupedCursorMaxEncodedLength {
+		return nil, fmt.Errorf("cursor is too large")
+	}
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("malformed cursor")
+	}
+	var cursor groupedExecutionCursor
+	if err := json.Unmarshal(data, &cursor); err != nil {
+		return nil, fmt.Errorf("malformed cursor")
+	}
+	if cursor.Version != groupedCursorSchema ||
+		cursor.Fingerprint == "" ||
+		cursor.SnapshotScore == "" ||
+		cursor.SnapshotMember == "" ||
+		cursor.GroupKey == "" {
+		return nil, fmt.Errorf("unsupported or incomplete cursor")
+	}
+	if cursor.SortValue.Kind != "string" && cursor.SortValue.Kind != "number" {
+		return nil, fmt.Errorf("unsupported cursor sort value")
+	}
+	snapshotScore, err := strconv.ParseFloat(cursor.SnapshotScore, 64)
+	if err != nil || math.IsNaN(snapshotScore) || math.IsInf(snapshotScore, 0) {
+		return nil, fmt.Errorf("malformed cursor snapshot")
+	}
+	return &cursor, nil
+}
+
+func loadGroupedExecutions(
+	parent context.Context,
+	query *groupedExecutionQuery,
+) (*GroupedExecutionListResponse, error) {
+	client, err := getExecutionDebugClient()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(parent, 15*time.Second)
+	defer cancel()
+
+	rows, snapshotScore, snapshotMember, globalPartial, err :=
+		readGroupedGlobalSnapshot(ctx, client, query.Cursor)
+	if err != nil {
+		return nil, err
+	}
+	globalIDs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		globalIDs = append(globalIDs, row.RequestID)
+	}
+
+	cache := newExecutionReadCache()
+	hydrationPartial, err := cache.load(ctx, client, globalIDs)
+	if err != nil {
+		return nil, err
+	}
+	partial := globalPartial || hydrationPartial
+
+	conversationOrder := make([]string, 0)
+	conversationSeen := make(map[string]struct{})
+	for _, row := range rows {
+		execution := cache.records[row.RequestID]
+		if execution == nil {
+			continue
+		}
+		conversationID := execution.Metadata[orchestration.MetadataConversationID]
+		if conversationID == "" {
+			continue
+		}
+		if _, seen := conversationSeen[conversationID]; seen {
+			continue
+		}
+		conversationSeen[conversationID] = struct{}{}
+		if len(conversationOrder) == viewerDistinctConversationLimit {
+			partial = true
+			continue
+		}
+		conversationOrder = append(conversationOrder, conversationID)
+	}
+
+	reverseMembers, reversePartial, err := readConversationMembers(
+		ctx,
+		client,
+		conversationOrder,
+	)
+	if err != nil {
+		return nil, err
+	}
+	partial = partial || reversePartial
+
+	reverseCandidates := make([]string, 0)
+	for _, conversationID := range conversationOrder {
+		reverseCandidates = append(
+			reverseCandidates,
+			reverseMembers[conversationID]...,
+		)
+	}
+	reverseHydrationPartial, err := cache.load(ctx, client, reverseCandidates)
+	if err != nil {
+		return nil, err
+	}
+	partial = partial || reverseHydrationPartial
+
+	snapshotScoreNumber, _ := strconv.ParseFloat(snapshotScore, 64)
+	summariesByID := make(map[string]ExecutionSummary)
+	indexIncomplete := make(map[string]bool)
+	memberSets := make(map[string]map[string]struct{}, len(conversationOrder))
+	for _, row := range rows {
+		execution := cache.records[row.RequestID]
+		if execution == nil {
+			continue
+		}
+		summary := summarizeExecution(execution)
+		summariesByID[summary.RequestID] = summary
+	}
+	for _, conversationID := range conversationOrder {
+		groupKey := groupedConversationKey(conversationID)
+		memberSet := make(map[string]struct{}, len(reverseMembers[conversationID]))
+		memberSets[conversationID] = memberSet
+		for _, requestID := range reverseMembers[conversationID] {
+			memberSet[requestID] = struct{}{}
+			execution := cache.records[requestID]
+			if execution == nil {
+				if _, confirmedMissing := cache.missing[requestID]; confirmedMissing {
+					indexIncomplete[groupKey] = true
+				}
+				continue
+			}
+			if execution.Metadata[orchestration.MetadataConversationID] != conversationID {
+				indexIncomplete[groupKey] = true
+				continue
+			}
+			score := float64(execution.CreatedAt.UnixNano())
+			if executionIsNewerThanSnapshot(
+				score,
+				execution.RequestID,
+				snapshotScoreNumber,
+				snapshotMember,
+			) {
+				continue
+			}
+			summary := summarizeExecution(execution)
+			summariesByID[summary.RequestID] = summary
+		}
+	}
+
+	membershipChecks := make(map[string][]string)
+	for _, row := range rows {
+		execution := cache.records[row.RequestID]
+		if execution == nil {
+			continue
+		}
+		conversationID := execution.Metadata[orchestration.MetadataConversationID]
+		memberSet, expanded := memberSets[conversationID]
+		if conversationID == "" || !expanded {
+			continue
+		}
+		if _, indexed := memberSet[row.RequestID]; !indexed {
+			membershipChecks[conversationID] = append(
+				membershipChecks[conversationID],
+				row.RequestID,
+			)
+		}
+	}
+	missingMembers, err := findMissingConversationIndexMembers(
+		ctx,
+		client,
+		membershipChecks,
+	)
+	if err != nil {
+		return nil, err
+	}
+	for conversationID, requestIDs := range missingMembers {
+		if len(requestIDs) > 0 {
+			indexIncomplete[groupedConversationKey(conversationID)] = true
+		}
+	}
+
+	summaries := make([]ExecutionSummary, 0, len(summariesByID))
+	for _, summary := range summariesByID {
+		summaries = append(summaries, summary)
+	}
+	enrichment, enrichmentErr :=
+		enrichExecutionSummariesFromLLMDebug(ctx, summaries)
+	if enrichmentErr != nil {
+		// DB 7 enrichment is fail-open, but an incomplete enrichment cannot
+		// support an atomic grouped continuation. Mark the response partial so
+		// pagination is suppressed and the UI can fall back to Flat mode.
+		partial = true
+	}
+	groups := buildGroupedExecutionUnits(
+		summaries,
+		enrichment,
+		indexIncomplete,
+		query,
+	)
+	return paginateGroupedExecutionUnits(
+		groups,
+		query,
+		snapshotScore,
+		snapshotMember,
+		partial,
+		enrichmentErr != nil,
+	), nil
+}
+
+func readGroupedGlobalSnapshot(
+	ctx context.Context,
+	client *redis.Client,
+	cursor *groupedExecutionCursor,
+) ([]indexedExecution, string, string, bool, error) {
+	maxScore := "+inf"
+	var snapshotScore float64
+	var snapshotMember string
+	if cursor != nil {
+		maxScore = cursor.SnapshotScore
+		snapshotScore, _ = strconv.ParseFloat(cursor.SnapshotScore, 64)
+		snapshotMember = cursor.SnapshotMember
+	}
+	rows, err := client.ZRevRangeByScoreWithScores(
+		ctx,
+		executionIndexKey,
+		&redis.ZRangeBy{
+			Min:   "-inf",
+			Max:   maxScore,
+			Count: int64(viewerGlobalExecutionScanLimit + 1),
+		},
+	).Result()
+	if err != nil {
+		return nil, "", "", false, fmt.Errorf("failed to read global execution index: %w", err)
+	}
+	if cursor == nil && len(rows) > 0 {
+		snapshotScore = rows[0].Score
+		snapshotMember, _ = rows[0].Member.(string)
+	}
+
+	partial := len(rows) > viewerGlobalExecutionScanLimit
+	if len(rows) > viewerGlobalExecutionScanLimit {
+		rows = rows[:viewerGlobalExecutionScanLimit]
+	}
+	indexed := make([]indexedExecution, 0, len(rows))
+	for _, row := range rows {
+		requestID, ok := row.Member.(string)
+		if !ok {
+			continue
+		}
+		if cursor != nil && executionIsNewerThanSnapshot(
+			row.Score,
+			requestID,
+			snapshotScore,
+			snapshotMember,
+		) {
+			continue
+		}
+		indexed = append(indexed, indexedExecution{
+			RequestID: requestID,
+			Score:     row.Score,
+		})
+	}
+	if snapshotMember == "" {
+		return indexed, "0", "empty", partial, nil
+	}
+	return indexed,
+		strconv.FormatFloat(snapshotScore, 'g', -1, 64),
+		snapshotMember,
+		partial,
+		nil
+}
+
+func executionIsNewerThanSnapshot(
+	score float64,
+	member string,
+	snapshotScore float64,
+	snapshotMember string,
+) bool {
+	if score != snapshotScore {
+		return score > snapshotScore
+	}
+	return member > snapshotMember
+}
+
+func readConversationMembers(
+	ctx context.Context,
+	client *redis.Client,
+	conversationIDs []string,
+) (map[string][]string, bool, error) {
+	result := make(map[string][]string, len(conversationIDs))
+	if len(conversationIDs) == 0 {
+		return result, false, nil
+	}
+	pipe := client.Pipeline()
+	commands := make(map[string]*redis.StringSliceCmd, len(conversationIDs))
+	for _, conversationID := range conversationIDs {
+		commands[conversationID] = pipe.ZRange(
+			ctx,
+			viewerConversationIndexKey(conversationID),
+			0,
+			viewerConversationMemberReadLimit,
+		)
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return nil, false, fmt.Errorf("failed to read conversation indexes: %w", err)
+	}
+	partial := false
+	for _, conversationID := range conversationIDs {
+		members, err := commands[conversationID].Result()
+		if err != nil && err != redis.Nil {
+			return nil, false, fmt.Errorf("failed to read conversation index: %w", err)
+		}
+		if len(members) > viewerConversationMemberReadLimit {
+			members = members[:viewerConversationMemberReadLimit]
+			partial = true
+		}
+		result[conversationID] = members
+	}
+	return result, partial, nil
+}
+
+func findMissingConversationIndexMembers(
+	ctx context.Context,
+	client *redis.Client,
+	checks map[string][]string,
+) (map[string][]string, error) {
+	missing := make(map[string][]string)
+	type membershipCheck struct {
+		conversationID string
+		requestID      string
+		command        *redis.FloatCmd
+	}
+	commands := make([]membershipCheck, 0)
+	pipe := client.Pipeline()
+	for conversationID, requestIDs := range checks {
+		for _, requestID := range requestIDs {
+			commands = append(commands, membershipCheck{
+				conversationID: conversationID,
+				requestID:      requestID,
+				command: pipe.ZScore(
+					ctx,
+					viewerConversationIndexKey(conversationID),
+					requestID,
+				),
+			})
+		}
+	}
+	if len(commands) == 0 {
+		return missing, nil
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return nil, fmt.Errorf("failed to verify conversation index membership: %w", err)
+	}
+	for _, check := range commands {
+		if _, err := check.command.Result(); err == redis.Nil {
+			missing[check.conversationID] = append(
+				missing[check.conversationID],
+				check.requestID,
+			)
+		} else if err != nil {
+			return nil, fmt.Errorf("failed to verify conversation index membership: %w", err)
+		}
+	}
+	return missing, nil
+}
+
+func buildGroupedExecutionUnits(
+	summaries []ExecutionSummary,
+	enrichment map[string]llmDebugEnrichment,
+	indexIncomplete map[string]bool,
+	query *groupedExecutionQuery,
+) []GroupedExecutionGroup {
+	summaryByID := make(map[string]ExecutionSummary, len(summaries))
+	for _, summary := range summaries {
+		summaryByID[summary.RequestID] = summary
+	}
+	groupKeyByID := make(map[string]string, len(summaries))
+	for _, summary := range summaries {
+		switch {
+		case summary.ConversationID != "":
+			groupKeyByID[summary.RequestID] =
+				groupedConversationKey(summary.ConversationID)
+		case !isTopLevelExecution(summary):
+			if owner, ok := summaryByID[summary.OriginalRequestID]; ok {
+				if owner.ConversationID == "" {
+					groupKeyByID[summary.RequestID] =
+						"request:" + owner.RequestID
+				} else {
+					// Conversation membership comes only from this record's
+					// stored conversation_id. Request lineage cannot promote
+					// a stateless related execution into the owner's
+					// conversation.
+					groupKeyByID[summary.RequestID] =
+						"request:" + summary.RequestID
+				}
+			} else {
+				groupKeyByID[summary.RequestID] =
+					"request:" + summary.RequestID
+			}
+		default:
+			groupKeyByID[summary.RequestID] =
+				"request:" + summary.RequestID
+		}
+	}
+
+	membersByGroup := make(map[string][]ExecutionSummary)
+	for _, summary := range summaries {
+		key := groupKeyByID[summary.RequestID]
+		membersByGroup[key] = append(membersByGroup[key], summary)
+	}
+
+	groups := make([]GroupedExecutionGroup, 0, len(membersByGroup))
+	for groupKey, members := range membersByGroup {
+		sort.SliceStable(members, func(i, j int) bool {
+			if members[i].CreatedAt.Equal(members[j].CreatedAt) {
+				return members[i].RequestID < members[j].RequestID
+			}
+			return members[i].CreatedAt.After(members[j].CreatedAt)
+		})
+		conversationID := ""
+		if strings.HasPrefix(groupKey, "conversation:") {
+			for _, member := range members {
+				if member.ConversationID != "" {
+					conversationID = member.ConversationID
+					break
+				}
+			}
+		}
+
+		topLevelByID := make(map[string]ExecutionSummary)
+		related := make([]ExecutionSummary, 0)
+		for _, member := range members {
+			if isTopLevelExecution(member) {
+				topLevelByID[member.RequestID] = member
+			} else {
+				related = append(related, member)
+			}
+		}
+		topLevel := make([]ExecutionSummary, 0, len(topLevelByID))
+		for _, member := range topLevelByID {
+			topLevel = append(topLevel, member)
+		}
+		sort.SliceStable(topLevel, func(i, j int) bool {
+			if topLevel[i].CreatedAt.Equal(topLevel[j].CreatedAt) {
+				return topLevel[i].RequestID < topLevel[j].RequestID
+			}
+			return topLevel[i].CreatedAt.After(topLevel[j].CreatedAt)
+		})
+
+		relatedByOwner := make(map[string][]ExecutionSummary)
+		orphans := make([]ExecutionSummary, 0)
+		for _, member := range related {
+			if _, ok := topLevelByID[member.OriginalRequestID]; ok {
+				relatedByOwner[member.OriginalRequestID] = append(
+					relatedByOwner[member.OriginalRequestID],
+					member,
+				)
+			} else {
+				orphans = append(orphans, member)
+			}
+		}
+		for owner := range relatedByOwner {
+			sort.SliceStable(relatedByOwner[owner], func(i, j int) bool {
+				if relatedByOwner[owner][i].CreatedAt.Equal(
+					relatedByOwner[owner][j].CreatedAt,
+				) {
+					return relatedByOwner[owner][i].RequestID <
+						relatedByOwner[owner][j].RequestID
+				}
+				return relatedByOwner[owner][i].CreatedAt.After(
+					relatedByOwner[owner][j].CreatedAt,
+				)
+			})
+		}
+
+		matching := make([]ExecutionSummary, 0, len(topLevel))
+		for _, member := range topLevel {
+			if executionMatchesGroupedQuery(member, conversationID, query) {
+				matching = append(matching, member)
+			}
+		}
+		if len(matching) == 0 {
+			if len(topLevel) > 0 ||
+				query.Status != "all" ||
+				(query.Search != "" &&
+					!strings.Contains(strings.ToLower(conversationID), query.Search)) {
+				continue
+			}
+			// Preserve a globally-discovered related execution even when its
+			// owning top-level record is outside the bounded snapshot.
+			matching = append(matching, orphans[0])
+		}
+
+		anchor := matching[0]
+		turns := make([]ConversationTimelineTurn, 0, len(matching))
+		if len(topLevel) > 0 {
+			for _, member := range matching {
+				item := enrichment[member.RequestID]
+				turns = append(turns, ConversationTimelineTurn{
+					Execution:         member,
+					RelatedExecutions: nonNilSlice(relatedByOwner[member.RequestID]),
+					LLMCallCount:      item.CallCount,
+					HistoryStatus:     item.HistoryStatus,
+				})
+			}
+		}
+		groups = append(groups, GroupedExecutionGroup{
+			GroupKey:          groupKey,
+			ConversationID:    conversationID,
+			AnchorCreatedAt:   anchor.CreatedAt,
+			MatchingTurnCount: len(turns),
+			TotalTurnCount:    len(topLevel),
+			Turns:             nonNilSlice(turns),
+			Orphans:           nonNilSlice(orphans),
+			IndexIncomplete:   indexIncomplete[groupKey],
+			sortValue:         groupedExecutionSortValue(anchor, query.Sort),
+		})
+	}
+
+	sort.SliceStable(groups, func(i, j int) bool {
+		return compareGroupedExecutionPosition(groups[i], groups[j], query) < 0
+	})
+	return groups
+}
+
+func isTopLevelExecution(summary ExecutionSummary) bool {
+	return summary.OriginalRequestID == "" ||
+		summary.OriginalRequestID == summary.RequestID
+}
+
+func groupedConversationKey(conversationID string) string {
+	digest := sha256.Sum256([]byte(conversationID))
+	return fmt.Sprintf("conversation:%x", digest)
+}
+
+func executionMatchesGroupedQuery(
+	summary ExecutionSummary,
+	conversationID string,
+	query *groupedExecutionQuery,
+) bool {
+	switch query.Status {
+	case "success":
+		if !summary.Success || summary.Interrupted {
+			return false
+		}
+	case "failed":
+		if summary.Success || summary.Interrupted {
+			return false
+		}
+	case "interrupted":
+		if !summary.Interrupted {
+			return false
+		}
+	}
+	if query.Search == "" {
+		return true
+	}
+	return strings.Contains(strings.ToLower(summary.OriginalRequest), query.Search) ||
+		strings.Contains(strings.ToLower(summary.RequestID), query.Search) ||
+		strings.Contains(strings.ToLower(conversationID), query.Search)
+}
+
+func groupedExecutionSortValue(
+	summary ExecutionSummary,
+	field string,
+) groupedSortValue {
+	switch field {
+	case "original_request":
+		return groupedSortValue{
+			Kind:   "string",
+			String: strings.ToLower(summary.OriginalRequest),
+		}
+	case "total_duration_ms":
+		return groupedSortValue{
+			Kind:   "number",
+			Number: summary.TotalDurationMs + summary.LLMTotalDurationMs,
+		}
+	default:
+		return groupedSortValue{
+			Kind:   "number",
+			Number: summary.CreatedAt.UnixNano(),
+		}
+	}
+}
+
+func compareGroupedExecutionPosition(
+	left GroupedExecutionGroup,
+	right GroupedExecutionGroup,
+	query *groupedExecutionQuery,
+) int {
+	primary := compareGroupedSortValue(left.sortValue, right.sortValue)
+	if query.Direction == "desc" {
+		primary = -primary
+	}
+	if primary != 0 {
+		return primary
+	}
+	if !left.AnchorCreatedAt.Equal(right.AnchorCreatedAt) {
+		if left.AnchorCreatedAt.After(right.AnchorCreatedAt) {
+			return -1
+		}
+		return 1
+	}
+	return strings.Compare(left.GroupKey, right.GroupKey)
+}
+
+func compareGroupedSortValue(left, right groupedSortValue) int {
+	if left.Kind == "string" {
+		return strings.Compare(left.String, right.String)
+	}
+	switch {
+	case left.Number < right.Number:
+		return -1
+	case left.Number > right.Number:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func paginateGroupedExecutionUnits(
+	groups []GroupedExecutionGroup,
+	query *groupedExecutionQuery,
+	snapshotScore string,
+	snapshotMember string,
+	partial bool,
+	llmEnrichmentIncomplete bool,
+) *GroupedExecutionListResponse {
+	if query.Cursor != nil {
+		cursorGroup := GroupedExecutionGroup{
+			GroupKey:        query.Cursor.GroupKey,
+			AnchorCreatedAt: time.Unix(0, query.Cursor.AnchorCreatedAt),
+			sortValue:       query.Cursor.SortValue,
+		}
+		filtered := groups[:0]
+		for _, group := range groups {
+			if compareGroupedExecutionPosition(group, cursorGroup, query) > 0 {
+				filtered = append(filtered, group)
+			}
+		}
+		groups = filtered
+	}
+
+	hasMore := len(groups) > query.Limit
+	if hasMore && query.Sort == "total_duration_ms" {
+		// The combined duration includes mutable DB 7 LLM data. It is valid for
+		// a bounded point-in-time sort, but cannot be used as a keyset cursor
+		// across requests without risking skipped or duplicated groups.
+		partial = true
+	}
+	if hasMore {
+		groups = groups[:query.Limit]
+	}
+	response := &GroupedExecutionListResponse{
+		Groups:                  nonNilSlice(groups),
+		QueryFingerprint:        query.Fingerprint,
+		LLMEnrichmentIncomplete: llmEnrichmentIncomplete,
+		Partial:                 partial,
+		Timestamp:               time.Now(),
+	}
+	if hasMore && !partial && len(groups) > 0 {
+		last := groups[len(groups)-1]
+		cursor := groupedExecutionCursor{
+			Version:         groupedCursorSchema,
+			Fingerprint:     query.Fingerprint,
+			SnapshotScore:   snapshotScore,
+			SnapshotMember:  snapshotMember,
+			SortValue:       last.sortValue,
+			AnchorCreatedAt: last.AnchorCreatedAt.UnixNano(),
+			GroupKey:        last.GroupKey,
+		}
+		if encoded, err := encodeGroupedExecutionCursor(cursor); err == nil {
+			response.NextCursor = encoded
+		}
+	}
+	for i := range response.Groups {
+		response.Groups[i].sortValue = groupedSortValue{}
+	}
+	return response
+}
+
+func encodeGroupedExecutionCursor(cursor groupedExecutionCursor) (string, error) {
+	data, err := json.Marshal(cursor)
+	if err != nil {
+		return "", err
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(data)
+	if len(encoded) > viewerGroupedCursorMaxEncodedLength {
+		return "", fmt.Errorf("cursor exceeds encoded limit")
+	}
+	return encoded, nil
+}
+
+func enrichExecutionSummariesFromLLMDebug(
+	ctx context.Context,
+	summaries []ExecutionSummary,
+) (map[string]llmDebugEnrichment, error) {
+	enrichment := make(map[string]llmDebugEnrichment, len(summaries))
+	if len(summaries) == 0 || useMock {
+		return enrichment, nil
+	}
+	client, err := getLLMDebugReadClient()
+	if err != nil {
+		return enrichment, err
+	}
+
+	pipe := client.Pipeline()
+	interactionCommands := make(map[string]*redis.StringSliceCmd, len(summaries))
+	metaCommands := make(map[string]*redis.IntCmd, len(summaries))
+	legacyCommands := make(map[string]*redis.StringCmd, len(summaries))
+	for _, summary := range summaries {
+		requestID := summary.RequestID
+		interactionCommands[requestID] = pipe.LRange(
+			ctx,
+			viewerLLMDebugKeyPrefix+requestID+viewerLLMDebugInterSuffix,
+			0,
+			-1,
+		)
+		metaCommands[requestID] = pipe.Exists(
+			ctx,
+			viewerLLMDebugKeyPrefix+requestID+viewerLLMDebugMetaSuffix,
+		)
+		legacyCommands[requestID] = pipe.Get(
+			ctx,
+			viewerLLMDebugKeyPrefix+requestID,
+		)
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return enrichment, err
+	}
+
+	for i := range summaries {
+		requestID := summaries[i].RequestID
+		var interactions []orchestration.LLMInteraction
+		serialized, listErr := interactionCommands[requestID].Result()
+		if listErr == nil {
+			for _, raw := range serialized {
+				var interaction orchestration.LLMInteraction
+				if json.Unmarshal([]byte(raw), &interaction) == nil {
+					interactions = append(interactions, interaction)
+				}
+			}
+		}
+		if len(interactions) == 0 {
+			if legacy, legacyErr := legacyCommands[requestID].Bytes(); legacyErr == nil {
+				var record orchestration.LLMDebugRecord
+				if decodeViewerStoredJSON(legacy, &record) == nil {
+					interactions = record.Interactions
+				}
+			}
+		}
+		if len(interactions) == 0 {
+			if metaCount, metaErr := metaCommands[requestID].Result(); metaErr == nil &&
+				metaCount > 0 {
+				enrichment[requestID] = llmDebugEnrichment{
+					HistoryStatus: "not_recorded",
+				}
+			}
+			continue
+		}
+
+		deduped := orchestration.DedupeLLMInteractions(interactions)
+		item := llmDebugEnrichment{
+			CallCount:     len(deduped),
+			HistoryStatus: "not_recorded",
+		}
+		for _, interaction := range deduped {
+			item.TotalDurationMs += interaction.DurationMs
+			if strings.Contains(interaction.Type, "conversation_history") {
+				item.HistoryStatus = "recorded"
+			}
+		}
+		enrichment[requestID] = item
+		summaries[i].LLMTotalDurationMs = item.TotalDurationMs
+	}
+	return enrichment, nil
+}
+
+func decodeViewerStoredJSON(data []byte, target interface{}) error {
+	if len(data) == 0 {
+		return fmt.Errorf("empty data")
+	}
+	payload := data
+	switch data[0] {
+	case 0:
+		payload = data[1:]
+	case 1:
+		reader, err := gzip.NewReader(bytes.NewReader(data[1:]))
+		if err != nil {
+			return err
+		}
+		defer func() { _ = reader.Close() }()
+		payload, err = io.ReadAll(reader)
+		if err != nil {
+			return err
+		}
+	}
+	return json.Unmarshal(payload, target)
+}

--- a/examples/registry-viewer-app/main.go
+++ b/examples/registry-viewer-app/main.go
@@ -265,6 +265,9 @@ const (
 	viewerDistinctConversationLimit     = 500
 	viewerExecutionHydrationLimit       = 10000
 	viewerConversationMemberReadLimit   = 1000
+	viewerLLMEnrichmentExecutionLimit   = 200
+	viewerLLMInteractionLimit           = 100
+	viewerLLMInteractionBytesLimit      = 4 * 1024 * 1024
 	viewerGroupedCursorMaxEncodedLength = 2048
 )
 
@@ -2591,7 +2594,7 @@ func getRedisExecutionSummaries(limit int, cursor string) (*executionPage, error
 	// Batch-fetch LLM debug data for all executions to get LLM durations.
 	// This is a separate store (different Redis DB), so a separate read-only
 	// pipeline. Missing DB 7 data is intentionally fail-open.
-	_, _ = enrichExecutionSummariesFromLLMDebug(ctx, summaries)
+	_, _, _ = enrichExecutionSummariesFromLLMDebug(ctx, summaries)
 
 	page := &executionPage{Summaries: summaries, HasMore: hasMore}
 	if hasMore {

--- a/examples/registry-viewer-app/main.go
+++ b/examples/registry-viewer-app/main.go
@@ -135,6 +135,9 @@ type LLMDebugListResponse struct {
 type HITLCheckpoint struct {
 	CheckpointID       string                 `json:"checkpoint_id"`
 	RequestID          string                 `json:"request_id"`
+	OriginalRequestID  string                 `json:"original_request_id,omitempty"`
+	OriginalTraceID    string                 `json:"original_trace_id,omitempty"`
+	OriginalSpanID     string                 `json:"original_span_id,omitempty"`
 	InterruptPoint     string                 `json:"interrupt_point"`
 	Decision           *InterruptDecision     `json:"decision,omitempty"`
 	Plan               *RoutingPlan           `json:"plan,omitempty"`
@@ -255,6 +258,14 @@ const (
 	executionKeyPrefix   = "truvag3:execution:debug:"
 	executionIndexKey    = "truvag3:execution:debug:index"
 	executionTracePrefix = "truvag3:execution:debug:trace:"
+
+	viewerDefaultGroupPageSize          = 50
+	viewerMaxGroupPageSize              = 200
+	viewerGlobalExecutionScanLimit      = 5000
+	viewerDistinctConversationLimit     = 500
+	viewerExecutionHydrationLimit       = 10000
+	viewerConversationMemberReadLimit   = 1000
+	viewerGroupedCursorMaxEncodedLength = 2048
 )
 
 // StoredExecution contains everything needed for DAG visualization
@@ -290,6 +301,7 @@ type ExecutionResult struct {
 type ExecutionSummary struct {
 	RequestID          string            `json:"request_id"`
 	OriginalRequestID  string            `json:"original_request_id,omitempty"`
+	ConversationID     string            `json:"conversation_id,omitempty"`
 	TraceID            string            `json:"trace_id"`
 	AgentName          string            `json:"agent_name,omitempty"`
 	OriginalRequest    string            `json:"original_request"`
@@ -388,6 +400,7 @@ type UnifiedExecutionView struct {
 	// Core execution data
 	RequestID         string           `json:"request_id"`
 	OriginalRequestID string           `json:"original_request_id,omitempty"`
+	ConversationID    string           `json:"conversation_id,omitempty"`
 	TraceID           string           `json:"trace_id,omitempty"`
 	AgentName         string           `json:"agent_name,omitempty"`
 	OriginalRequest   string           `json:"original_request"`
@@ -548,6 +561,7 @@ func main() {
 	mux.HandleFunc("/api/executions", apiMiddleware(handleExecutionList))
 	mux.HandleFunc("/api/executions/search", apiMiddleware(handleExecutionSearch))
 	mux.HandleFunc("/api/executions/", apiMiddleware(handleExecution)) // Handles both /{id} and /{id}/dag
+	mux.HandleFunc("/api/conversations", apiMiddleware(handleConversationTimeline))
 	mux.HandleFunc("/api/analytics/resolution", apiMiddleware(handleResolutionAnalytics))
 
 	// Memory endpoints — all wrapped with apiMiddleware (CORS + gzip + ETag)
@@ -1582,6 +1596,17 @@ func getAgentAddress(agentName string) (string, error) {
 func handleExecutionList(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
+	if values, present := r.URL.Query()["group_conversations"]; present {
+		if len(values) != 1 || (values[0] != "true" && values[0] != "false") {
+			http.Error(w, "group_conversations must be true or false", http.StatusBadRequest)
+			return
+		}
+		if values[0] == "true" {
+			handleGroupedExecutionList(w, r)
+			return
+		}
+	}
+
 	// Parse query parameters
 	limitStr := r.URL.Query().Get("limit")
 	limit := 50
@@ -2321,6 +2346,7 @@ func buildUnifiedView(execution *StoredExecution) *UnifiedExecutionView {
 	unified := &UnifiedExecutionView{
 		RequestID:         execution.RequestID,
 		OriginalRequestID: execution.OriginalRequestID,
+		ConversationID:    execution.Metadata[orchestration.MetadataConversationID],
 		TraceID:           execution.TraceID,
 		AgentName:         execution.AgentName,
 		OriginalRequest:   execution.OriginalRequest,
@@ -2354,6 +2380,14 @@ func buildUnifiedView(execution *StoredExecution) *UnifiedExecutionView {
 			llmRecord, err = store.GetRecord(ctx, execution.RequestID)
 		}
 		if err == nil && llmRecord != nil {
+			if unified.TraceID == "" {
+				unified.TraceID = llmRecord.TraceID
+			}
+			if unified.ConversationID == "" {
+				unified.ConversationID =
+					orchestration.LLMDebugConversationID(llmRecord)
+			}
+
 			// Dedupe agent_llm_call shadows before building the summary so
 			// historical records (written before the framework-side Layer 2
 			// landed) and any still-unmigrated call sites produce correct
@@ -2551,46 +2585,13 @@ func getRedisExecutionSummaries(limit int, cursor string) (*executionPage, error
 			continue
 		}
 
-		summary := ExecutionSummary{
-			RequestID:         execution.RequestID,
-			OriginalRequestID: execution.OriginalRequestID,
-			TraceID:           execution.TraceID,
-			AgentName:         execution.AgentName,
-			OriginalRequest:   execution.OriginalRequest,
-			Interrupted:       execution.Interrupted,
-			CreatedAt:         execution.CreatedAt,
-			Metadata:          execution.Metadata,
-		}
-
-		if execution.Result != nil {
-			summary.Success = execution.Result.Success
-			summary.TotalDurationMs = execution.Result.TotalDuration / 1_000_000 // ns to ms
-			summary.StepCount = len(execution.Result.Steps)
-			for _, step := range execution.Result.Steps {
-				if !step.Success {
-					summary.FailedSteps++
-				}
-			}
-		}
-
-		summaries = append(summaries, summary)
+		summaries = append(summaries, summarizeExecution(execution))
 	}
 
 	// Batch-fetch LLM debug data for all executions to get LLM durations.
-	// This is a separate store (different Redis DB), so a separate pipeline.
-	store, storeErr := getLLMDebugStore()
-	if storeErr == nil && len(summaries) > 0 {
-		for i := range summaries {
-			llmRecord, _ := store.GetRecord(ctx, summaries[i].RequestID)
-			if llmRecord != nil && len(llmRecord.Interactions) > 0 {
-				var llmTotalMs int64
-				for _, interaction := range llmRecord.Interactions {
-					llmTotalMs += interaction.DurationMs
-				}
-				summaries[i].LLMTotalDurationMs = llmTotalMs
-			}
-		}
-	}
+	// This is a separate store (different Redis DB), so a separate read-only
+	// pipeline. Missing DB 7 data is intentionally fail-open.
+	_, _ = enrichExecutionSummariesFromLLMDebug(ctx, summaries)
 
 	page := &executionPage{Summaries: summaries, HasMore: hasMore}
 	if hasMore {

--- a/examples/registry-viewer-app/main.go
+++ b/examples/registry-viewer-app/main.go
@@ -2664,11 +2664,14 @@ func deserializeExecution(data []byte) (*StoredExecution, error) {
 // getMockExecutionSummaries returns mock execution summaries for development
 func getMockExecutionSummaries() []ExecutionSummary {
 	now := time.Now()
+	const mockConversationID = "demo-travel-conversation"
 	return []ExecutionSummary{
 		{
 			RequestID:         "orch-1705312800123456789",
 			OriginalRequestID: "orch-1705312800123456789",
+			ConversationID:    mockConversationID,
 			TraceID:           "abc123def456",
+			AgentName:         "travel-chat-agent",
 			OriginalRequest:   "What's the weather in Tokyo and convert to Celsius?",
 			Success:           true,
 			StepCount:         2,
@@ -2679,7 +2682,9 @@ func getMockExecutionSummaries() []ExecutionSummary {
 		{
 			RequestID:         "orch-1705312700987654321",
 			OriginalRequestID: "orch-1705312700987654321",
+			ConversationID:    mockConversationID,
 			TraceID:           "xyz789abc012",
+			AgentName:         "travel-chat-agent",
 			OriginalRequest:   "Book a flight from NYC to London and check the weather",
 			Success:           false,
 			StepCount:         3,
@@ -2704,6 +2709,7 @@ func getMockExecutionSummaries() []ExecutionSummary {
 // getMockExecution returns a mock execution for development
 func getMockExecution(requestID string) *StoredExecution {
 	now := time.Now()
+	const mockConversationID = "demo-travel-conversation"
 
 	switch requestID {
 	case "orch-1705312800123456789":
@@ -2717,7 +2723,11 @@ func getMockExecution(requestID string) *StoredExecution {
 			RequestID:         requestID,
 			OriginalRequestID: requestID,
 			TraceID:           "abc123def456",
+			AgentName:         "travel-chat-agent",
 			OriginalRequest:   "What's the weather in Tokyo and convert to Celsius?",
+			Metadata: map[string]string{
+				orchestration.MetadataConversationID: mockConversationID,
+			},
 			Plan: &RoutingPlan{
 				PlanID:          requestID,
 				OriginalRequest: "What's the weather in Tokyo and convert to Celsius?",
@@ -2785,7 +2795,11 @@ func getMockExecution(requestID string) *StoredExecution {
 			RequestID:         requestID,
 			OriginalRequestID: requestID,
 			TraceID:           "xyz789abc012",
+			AgentName:         "travel-chat-agent",
 			OriginalRequest:   "Book a flight from NYC to London and check the weather",
+			Metadata: map[string]string{
+				orchestration.MetadataConversationID: mockConversationID,
+			},
 			Plan: &RoutingPlan{
 				PlanID:          requestID,
 				OriginalRequest: "Book a flight from NYC to London and check the weather",

--- a/examples/registry-viewer-app/static/css/components.css
+++ b/examples/registry-viewer-app/static/css/components.css
@@ -487,51 +487,6 @@
     display: flex;
     min-width: 0;
     flex: 1;
-    flex-direction: column;
-    gap: 5px;
-}
-
-.dag-conversation-controls {
-    display: inline-flex;
-    align-self: flex-start;
-    align-items: center;
-    gap: 4px;
-}
-
-.dag-conversation-nav-btn {
-    width: 24px;
-    height: 24px;
-    border: 1px solid rgba(100, 210, 255, 0.28);
-    border-radius: 50%;
-    color: var(--accent-teal);
-    background: rgba(100, 210, 255, 0.06);
-    cursor: pointer;
-}
-
-.dag-conversation-nav-btn:hover:not(:disabled) {
-    color: white;
-    background: rgba(100, 210, 255, 0.16);
-}
-
-.dag-conversation-nav-btn:disabled {
-    cursor: not-allowed;
-    opacity: 0.32;
-}
-
-.dag-conversation-pill {
-    align-self: flex-start;
-    padding: 4px 9px;
-    border: 1px solid rgba(100, 210, 255, 0.35);
-    border-radius: var(--radius-pill);
-    color: var(--accent-teal);
-    background: rgba(100, 210, 255, 0.08);
-    font-size: 10px;
-    cursor: pointer;
-}
-
-.dag-conversation-pill:hover {
-    color: white;
-    background: rgba(100, 210, 255, 0.16);
 }
 
 .dag-conversation-timeline-mode {
@@ -679,12 +634,25 @@
 
 .dag-timeline-card-body {
     position: relative;
+    overflow: hidden;
     margin-bottom: 14px;
-    padding: 14px;
     border: 1px solid var(--glass-border-light);
     border-radius: var(--radius-lg);
     background: rgba(255, 255, 255, 0.035);
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+}
+
+.dag-timeline-card-action {
+    padding: 14px;
+    cursor: pointer;
+    transition:
+        background var(--transition-fast) var(--transition-ease),
+        box-shadow var(--transition-fast) var(--transition-ease);
+}
+
+.dag-timeline-card-action:hover {
+    background: rgba(100, 210, 255, 0.07);
+    box-shadow: inset 3px 0 0 rgba(100, 210, 255, 0.46);
 }
 
 .dag-timeline-card.contains-current .dag-timeline-card-body {
@@ -742,16 +710,36 @@
 
 .dag-timeline-request-id {
     overflow: hidden;
-    margin: 9px 0;
     color: var(--text-muted);
     font-size: 9px;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
+.dag-timeline-card-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 9px;
+}
+
+.dag-timeline-card-footer .dag-timeline-request-id {
+    min-width: 0;
+}
+
+.dag-timeline-related .dag-timeline-request-id {
+    margin-top: 9px;
+}
+
+.dag-timeline-card-footer .dag-view-dag-btn,
+.dag-timeline-related .dag-view-dag-btn {
+    flex: 0 0 auto;
+}
+
 .dag-timeline-related-list {
-    margin-top: 12px;
-    padding-top: 10px;
+    margin: 0 14px 14px;
+    padding-top: 12px;
     border-top: 1px solid var(--border-subtle);
 }
 
@@ -775,6 +763,17 @@
     color: var(--text-secondary);
     background: rgba(0, 0, 0, 0.18);
     font-size: 11px;
+    cursor: pointer;
+    transition:
+        border-color var(--transition-fast) var(--transition-ease),
+        background var(--transition-fast) var(--transition-ease),
+        transform var(--transition-fast) var(--transition-ease);
+}
+
+.dag-timeline-related:hover {
+    border-color: rgba(100, 210, 255, 0.35);
+    background: rgba(100, 210, 255, 0.08);
+    transform: translateY(-1px);
 }
 
 .dag-timeline-related.current {
@@ -815,10 +814,14 @@
 .dag-timeline-nav-btn:focus-visible,
 .dag-copy-id-btn:focus-visible,
 .dag-view-dag-btn:focus-visible,
-.dag-conversation-nav-btn:focus-visible,
-.dag-conversation-pill:focus-visible {
+.dag-timeline-card-action:focus-visible,
+.dag-timeline-related:focus-visible {
     outline: 2px solid var(--accent-teal);
     outline-offset: 2px;
+}
+
+.dag-timeline-card-action:focus-visible {
+    outline-offset: -3px;
 }
 
 @media (max-width: 820px) {
@@ -870,7 +873,13 @@
     .dag-timeline-nav-btn,
     .dag-copy-id-btn,
     .dag-view-dag-btn,
+    .dag-timeline-card-action,
+    .dag-timeline-related,
     .dag-list-diagnostic button {
         transition: none;
+    }
+
+    .dag-timeline-related:hover {
+        transform: none;
     }
 }

--- a/examples/registry-viewer-app/static/css/components.css
+++ b/examples/registry-viewer-app/static/css/components.css
@@ -141,6 +141,719 @@
     to { transform: rotate(360deg); }
 }
 
+/* ── Execution DAG conversation browser ── */
+.dag-panel-mode {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+}
+
+#dagListMode .filters {
+    flex-wrap: wrap;
+}
+
+#dagListMode .search-box {
+    min-width: 210px;
+}
+
+.dag-list-toolbar,
+.dag-list-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-md);
+    padding: 9px 18px;
+    border-bottom: 1px solid var(--border-subtle);
+    background: rgba(0, 0, 0, 0.14);
+}
+
+.dag-list-footer {
+    flex-wrap: wrap;
+    border-top: 1px solid var(--border-subtle);
+    border-bottom: 0;
+}
+
+.dag-list-footer .last-updated {
+    margin-left: auto;
+    padding: 0;
+    border: 0;
+    background: transparent;
+}
+
+.dag-grouping-hint {
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1.35;
+}
+
+.dag-mode-toggle {
+    display: inline-flex;
+    flex: 0 0 auto;
+    padding: 3px;
+    border: 1px solid var(--glass-border-light);
+    border-radius: var(--radius-pill);
+    background: rgba(0, 0, 0, 0.26);
+}
+
+.dag-mode-btn,
+.dag-load-more,
+.dag-open-timeline-btn,
+.dag-back-btn,
+.dag-timeline-nav-btn,
+.dag-copy-id-btn,
+.dag-view-dag-btn,
+.dag-list-diagnostic button {
+    border: 1px solid transparent;
+    color: var(--text-secondary);
+    background: transparent;
+    cursor: pointer;
+    transition:
+        color var(--transition-fast) var(--transition-ease),
+        background var(--transition-fast) var(--transition-ease),
+        border-color var(--transition-fast) var(--transition-ease),
+        transform var(--transition-fast) var(--transition-ease);
+}
+
+.dag-mode-btn {
+    padding: 5px 10px;
+    border-radius: var(--radius-pill);
+    font-size: 11px;
+    font-weight: 650;
+}
+
+.dag-mode-btn:hover,
+.dag-mode-btn.active {
+    color: white;
+    background: rgba(10, 132, 255, 0.72);
+}
+
+.dag-list-diagnostic,
+.dag-timeline-diagnostic {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-md);
+    padding: 10px 18px;
+    border-bottom: 1px solid rgba(255, 179, 64, 0.28);
+    color: var(--accent-orange);
+    background: rgba(255, 179, 64, 0.08);
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.dag-list-diagnostic.error {
+    border-color: rgba(255, 107, 107, 0.28);
+    color: var(--accent-red);
+    background: rgba(255, 107, 107, 0.08);
+}
+
+.dag-list-diagnostic button,
+.dag-load-more {
+    flex: 0 0 auto;
+    padding: 6px 10px;
+    border-color: currentColor;
+    border-radius: var(--radius-md);
+    font-size: 11px;
+}
+
+.dag-list-diagnostic button:hover,
+.dag-load-more:hover,
+.dag-open-timeline-btn:hover,
+.dag-back-btn:hover,
+.dag-copy-id-btn:hover,
+.dag-view-dag-btn:hover {
+    color: white;
+    border-color: rgba(100, 210, 255, 0.48);
+    background: rgba(100, 210, 255, 0.12);
+}
+
+.dag-list-empty {
+    padding: 42px 18px;
+    color: var(--text-muted);
+    text-align: center;
+}
+
+.dag-list-empty .empty-state-icon {
+    margin-bottom: 10px;
+    font-size: 36px;
+}
+
+.dag-conversation-group-row {
+    cursor: default;
+    background:
+        linear-gradient(90deg, rgba(100, 210, 255, 0.08), transparent 58%),
+        rgba(255, 255, 255, 0.025);
+}
+
+.dag-conversation-group-row.expanded {
+    background:
+        linear-gradient(90deg, rgba(100, 210, 255, 0.13), transparent 66%),
+        rgba(255, 255, 255, 0.035);
+}
+
+.dag-conversation-group-row td {
+    border-top: 1px solid rgba(100, 210, 255, 0.22);
+}
+
+.dag-conversation-group-row td:first-child {
+    white-space: nowrap;
+}
+
+.dag-group-expand-btn,
+.dag-group-title-btn {
+    border: 0;
+    color: inherit;
+    background: transparent;
+    cursor: pointer;
+}
+
+.dag-group-expand-btn {
+    width: 26px;
+    height: 26px;
+    margin-right: 5px;
+    border: 1px solid rgba(100, 210, 255, 0.32);
+    border-radius: 50%;
+    color: var(--accent-teal);
+}
+
+.dag-group-expand-btn:hover {
+    color: white;
+    background: rgba(100, 210, 255, 0.15);
+}
+
+.dag-group-title-btn {
+    display: inline-flex;
+    max-width: calc(100% - 98px);
+    padding: 0;
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
+    vertical-align: middle;
+}
+
+.dag-group-kicker,
+.dag-group-id,
+.dag-group-sort-note,
+.dag-relation-label,
+.dag-row-meta {
+    display: block;
+    color: var(--text-muted);
+    font-size: 10px;
+    line-height: 1.4;
+}
+
+.dag-group-kicker {
+    color: var(--accent-teal);
+    font-weight: 700;
+    letter-spacing: 0.35px;
+    text-transform: uppercase;
+}
+
+.dag-group-title {
+    overflow: hidden;
+    max-width: 100%;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dag-group-id,
+.dag-timeline-request-id,
+.dag-mono {
+    font-family: 'SF Mono', 'Monaco', monospace;
+}
+
+.dag-group-id {
+    overflow: hidden;
+    max-width: 100%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dag-open-timeline-btn {
+    margin-left: 8px;
+    padding: 5px 7px;
+    border-color: rgba(100, 210, 255, 0.26);
+    border-radius: var(--radius-md);
+    color: var(--accent-teal);
+    font-size: 10px;
+    vertical-align: middle;
+}
+
+.dag-data-warning {
+    display: inline-block;
+    margin: 5px 0 0 5px;
+    color: var(--accent-orange);
+    font-size: 10px;
+}
+
+.dag-group-count,
+.dag-group-sort-note {
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.dag-group-sort-note {
+    margin-top: 2px;
+}
+
+.dag-execution-title-row {
+    display: flex;
+    align-items: flex-start;
+}
+
+.dag-execution-title {
+    min-width: 0;
+    flex: 1;
+}
+
+.dag-execution-title .service-name {
+    margin-bottom: 4px;
+}
+
+.dag-conversation-turn-row {
+    background: rgba(100, 210, 255, 0.025);
+}
+
+.dag-conversation-turn-row td:nth-child(2),
+.dag-related-execution-row td:nth-child(2) {
+    position: relative;
+}
+
+.dag-conversation-turn-row td:nth-child(2)::before,
+.dag-related-execution-row td:nth-child(2)::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 24px;
+    width: 1px;
+    content: '';
+    background: rgba(100, 210, 255, 0.22);
+}
+
+.dag-turn-dot {
+    position: relative;
+    z-index: 1;
+    width: 8px;
+    height: 8px;
+    margin: 5px 10px 0 2px;
+    flex: 0 0 auto;
+    border: 2px solid var(--accent-teal);
+    border-radius: 50%;
+    background: rgba(10, 10, 15, 0.95);
+    box-shadow: 0 0 8px rgba(100, 210, 255, 0.38);
+}
+
+.dag-related-execution-row td {
+    background: rgba(255, 255, 255, 0.015);
+}
+
+.dag-orphan-execution-row td {
+    background: rgba(255, 179, 64, 0.035);
+}
+
+.dag-relation-label {
+    margin-bottom: 2px;
+    color: var(--accent-purple);
+    font-weight: 650;
+}
+
+.dag-row-meta {
+    display: inline-block;
+    margin: 5px 5px 0 0;
+    padding: 2px 5px;
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.055);
+}
+
+.dag-hitl-resume {
+    color: var(--accent-green) !important;
+    background: rgba(46, 204, 113, 0.15) !important;
+}
+
+.dag-failed-steps,
+.dag-error-text {
+    color: var(--accent-red);
+}
+
+.dag-success-text {
+    color: var(--accent-green);
+}
+
+.dag-detail-heading {
+    display: flex;
+    min-width: 0;
+    flex: 1;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.dag-conversation-controls {
+    display: inline-flex;
+    align-self: flex-start;
+    align-items: center;
+    gap: 4px;
+}
+
+.dag-conversation-nav-btn {
+    width: 24px;
+    height: 24px;
+    border: 1px solid rgba(100, 210, 255, 0.28);
+    border-radius: 50%;
+    color: var(--accent-teal);
+    background: rgba(100, 210, 255, 0.06);
+    cursor: pointer;
+}
+
+.dag-conversation-nav-btn:hover:not(:disabled) {
+    color: white;
+    background: rgba(100, 210, 255, 0.16);
+}
+
+.dag-conversation-nav-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.32;
+}
+
+.dag-conversation-pill {
+    align-self: flex-start;
+    padding: 4px 9px;
+    border: 1px solid rgba(100, 210, 255, 0.35);
+    border-radius: var(--radius-pill);
+    color: var(--accent-teal);
+    background: rgba(100, 210, 255, 0.08);
+    font-size: 10px;
+    cursor: pointer;
+}
+
+.dag-conversation-pill:hover {
+    color: white;
+    background: rgba(100, 210, 255, 0.16);
+}
+
+.dag-conversation-timeline-mode {
+    min-height: 0;
+    background:
+        radial-gradient(circle at top left, rgba(100, 210, 255, 0.08), transparent 44%),
+        rgba(0, 0, 0, 0.08);
+}
+
+.dag-timeline-header {
+    padding: 16px 18px 14px;
+    border-bottom: 1px solid var(--border-subtle);
+    background: rgba(10, 10, 18, 0.82);
+}
+
+.dag-back-btn {
+    margin: -4px 0 10px -6px;
+    padding: 5px 7px;
+    border-radius: var(--radius-md);
+    color: var(--accent-teal);
+    font-size: 12px;
+}
+
+.dag-timeline-heading-row,
+.dag-timeline-id-row,
+.dag-timeline-card-header,
+.dag-timeline-meta,
+.dag-timeline-related {
+    display: flex;
+    align-items: center;
+}
+
+.dag-timeline-heading-row,
+.dag-timeline-card-header {
+    justify-content: space-between;
+    gap: var(--space-md);
+}
+
+.dag-timeline-heading {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 18px;
+    line-height: 1.25;
+}
+
+.dag-timeline-summary {
+    margin-top: 4px;
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.dag-timeline-actions {
+    display: flex;
+    gap: 6px;
+}
+
+.dag-timeline-nav-btn {
+    width: 30px;
+    height: 30px;
+    border-color: var(--glass-border-light);
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.dag-timeline-nav-btn:hover:not(:disabled) {
+    color: white;
+    border-color: rgba(100, 210, 255, 0.42);
+    background: rgba(100, 210, 255, 0.12);
+}
+
+.dag-timeline-nav-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.3;
+}
+
+.dag-timeline-id-row {
+    min-width: 0;
+    margin-top: 12px;
+    gap: 8px;
+}
+
+.dag-timeline-id-row code {
+    overflow: hidden;
+    min-width: 0;
+    padding: 5px 8px;
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    background: rgba(0, 0, 0, 0.28);
+    font-size: 10px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dag-copy-id-btn,
+.dag-view-dag-btn {
+    padding: 5px 8px;
+    border-color: var(--glass-border-light);
+    border-radius: var(--radius-md);
+    font-size: 10px;
+}
+
+.dag-timeline-content {
+    overflow-y: auto;
+    min-height: 0;
+    padding: 18px 16px 32px;
+    flex: 1;
+}
+
+.dag-timeline-card {
+    position: relative;
+    display: grid;
+    grid-template-columns: 34px minmax(0, 1fr);
+}
+
+.dag-timeline-card:not(:last-child) .dag-timeline-rail::after {
+    position: absolute;
+    top: 30px;
+    bottom: -12px;
+    left: 16px;
+    width: 1px;
+    content: '';
+    background: linear-gradient(var(--accent-teal), rgba(100, 210, 255, 0.12));
+}
+
+.dag-timeline-rail {
+    position: relative;
+}
+
+.dag-timeline-rail > span {
+    position: relative;
+    z-index: 1;
+    display: inline-flex;
+    width: 28px;
+    height: 28px;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(100, 210, 255, 0.42);
+    border-radius: 50%;
+    color: var(--accent-teal);
+    background: #0e111a;
+    font-size: 11px;
+    font-weight: 700;
+    box-shadow: 0 0 14px rgba(100, 210, 255, 0.12);
+}
+
+.dag-timeline-card-body {
+    position: relative;
+    margin-bottom: 14px;
+    padding: 14px;
+    border: 1px solid var(--glass-border-light);
+    border-radius: var(--radius-lg);
+    background: rgba(255, 255, 255, 0.035);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+}
+
+.dag-timeline-card.contains-current .dag-timeline-card-body {
+    border-color: rgba(10, 132, 255, 0.55);
+    background: rgba(10, 132, 255, 0.09);
+    box-shadow:
+        0 0 20px rgba(10, 132, 255, 0.1),
+        inset 3px 0 0 var(--accent-blue);
+}
+
+.dag-turn-label {
+    display: block;
+    margin-bottom: 3px;
+    color: var(--accent-teal);
+    font-size: 10px;
+    font-weight: 750;
+    letter-spacing: 0.45px;
+    text-transform: uppercase;
+}
+
+.dag-timeline-card time {
+    color: var(--text-muted);
+    font-size: 10px;
+}
+
+.dag-timeline-request {
+    margin: 12px 0 9px;
+    color: var(--text-primary);
+    font-size: 13px;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+}
+
+.dag-timeline-meta {
+    flex-wrap: wrap;
+    gap: 5px;
+}
+
+.dag-timeline-meta > span {
+    padding: 2px 6px;
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-pill);
+    color: var(--text-muted);
+    background: rgba(0, 0, 0, 0.15);
+    font-size: 9px;
+}
+
+.dag-timeline-meta > .dag-error-text {
+    color: var(--accent-red);
+}
+
+.dag-timeline-meta > .dag-success-text {
+    color: var(--accent-green);
+}
+
+.dag-timeline-request-id {
+    overflow: hidden;
+    margin: 9px 0;
+    color: var(--text-muted);
+    font-size: 9px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dag-timeline-related-list {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid var(--border-subtle);
+}
+
+.dag-related-heading {
+    margin-bottom: 7px;
+    color: var(--text-muted);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+}
+
+.dag-timeline-related {
+    display: grid;
+    grid-template-columns: 16px minmax(0, 1fr) auto;
+    gap: 7px;
+    margin-top: 6px;
+    padding: 9px;
+    border: 1px solid transparent;
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    background: rgba(0, 0, 0, 0.18);
+    font-size: 11px;
+}
+
+.dag-timeline-related.current {
+    border-color: rgba(10, 132, 255, 0.48);
+    background: rgba(10, 132, 255, 0.1);
+}
+
+.dag-related-branch {
+    color: var(--accent-purple);
+}
+
+.dag-timeline-orphans {
+    margin: 12px 0 0 34px;
+    padding: 12px;
+    border: 1px solid rgba(255, 179, 64, 0.24);
+    border-radius: var(--radius-lg);
+    background: rgba(255, 179, 64, 0.045);
+}
+
+.dag-timeline-orphans h3 {
+    margin: 0 0 4px;
+    color: var(--accent-orange);
+    font-size: 12px;
+}
+
+.dag-timeline-orphans p {
+    margin: 0 0 8px;
+    color: var(--text-muted);
+    font-size: 10px;
+    line-height: 1.4;
+}
+
+.dag-mode-btn:focus-visible,
+.dag-group-expand-btn:focus-visible,
+.dag-group-title-btn:focus-visible,
+.dag-open-timeline-btn:focus-visible,
+.dag-back-btn:focus-visible,
+.dag-timeline-nav-btn:focus-visible,
+.dag-copy-id-btn:focus-visible,
+.dag-view-dag-btn:focus-visible,
+.dag-conversation-nav-btn:focus-visible,
+.dag-conversation-pill:focus-visible {
+    outline: 2px solid var(--accent-teal);
+    outline-offset: 2px;
+}
+
+@media (max-width: 820px) {
+    .dag-list-toolbar {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .dag-mode-toggle {
+        align-self: stretch;
+    }
+
+    .dag-mode-btn {
+        flex: 1;
+    }
+
+    .dag-group-title-btn {
+        display: flex;
+        max-width: 100%;
+    }
+
+    .dag-open-timeline-btn {
+        margin: 7px 0 0;
+    }
+
+    .dag-timeline-related {
+        grid-template-columns: 16px minmax(0, 1fr);
+    }
+
+    .dag-timeline-related .dag-view-dag-btn {
+        grid-column: 2;
+        justify-self: start;
+    }
+}
+
 /* ── Reduced motion (§Performance Optimization) ── */
 @media (prefers-reduced-motion: reduce) {
     .glass-card, .glass-container {
@@ -149,5 +862,15 @@
     }
     .glass-card-interactive:hover {
         transform: none;
+    }
+    .dag-mode-btn,
+    .dag-load-more,
+    .dag-open-timeline-btn,
+    .dag-back-btn,
+    .dag-timeline-nav-btn,
+    .dag-copy-id-btn,
+    .dag-view-dag-btn,
+    .dag-list-diagnostic button {
+        transition: none;
     }
 }

--- a/examples/registry-viewer-app/static/index.html
+++ b/examples/registry-viewer-app/static/index.html
@@ -106,12 +106,12 @@
                 <div class="filters">
                     <div class="search-box">
                         <span class="search-icon">⌕</span>
-                        <input type="text" id="llmSearchInput" placeholder="Search by request ID, conversation, source agent, or type...">
+                        <input type="text" id="llmSearchInput" placeholder="Search by request ID, request lineage, source agent, or type...">
                     </div>
                     <button class="filter-btn active" data-filter="all">All</button>
                     <button class="filter-btn" data-filter="success">Success</button>
                     <button class="filter-btn" data-filter="error">Errors</button>
-                    <button class="filter-btn" data-filter="grouped" title="Group related HITL records by conversation">Grouped</button>
+                    <button class="filter-btn" data-filter="grouped" title="Group related HITL records by root request">Grouped</button>
                 </div>
                 <div class="error-banner" id="llmErrorBanner">
                     <strong>Error:</strong> <span id="llmErrorMessage"></span>
@@ -121,7 +121,7 @@
                         <thead>
                             <tr>
                                 <th>Request ID</th>
-                                <th>Conversation</th>
+                                <th>Request lineage</th>
                                 <th>Source</th>
                                 <th>Interactions</th>
                                 <th>Tokens</th>

--- a/examples/registry-viewer-app/static/index.html
+++ b/examples/registry-viewer-app/static/index.html
@@ -299,11 +299,6 @@
                 <div class="detail-header">
                     <div class="dag-detail-heading">
                         <span class="detail-title" id="dagDetailTitle">Select an execution</span>
-                        <div class="dag-conversation-controls hidden" id="dagConversationControls">
-                            <button class="dag-conversation-nav-btn" id="dagConversationPrevious" type="button" data-selected-conversation-nav="previous" aria-label="Previous conversation turn">←</button>
-                            <button class="dag-conversation-pill" id="dagConversationPill" type="button" data-open-selected-conversation></button>
-                            <button class="dag-conversation-nav-btn" id="dagConversationNext" type="button" data-selected-conversation-nav="next" aria-label="Next conversation turn">→</button>
-                        </div>
                     </div>
                     <div class="detail-tabs">
                         <button class="detail-tab active" data-tab="dag-viz">DAG Visualization</button>

--- a/examples/registry-viewer-app/static/index.html
+++ b/examples/registry-viewer-app/static/index.html
@@ -229,36 +229,82 @@
 
             <!-- Execution DAG View -->
             <div class="list-panel hidden" id="dagListPanel">
-                <div class="filters">
-                    <div class="search-box">
-                        <span class="search-icon">⌕</span>
-                        <input type="text" id="dagSearchInput" placeholder="Search by request ID or query...">
+                <div class="dag-panel-mode" id="dagListMode">
+                    <div class="filters">
+                        <div class="search-box">
+                            <span class="search-icon">⌕</span>
+                            <input type="text" id="dagSearchInput" placeholder="Search by request ID, conversation, or query...">
+                        </div>
+                        <button class="filter-btn active" data-filter="all">All</button>
+                        <button class="filter-btn" data-filter="success">Success</button>
+                        <button class="filter-btn" data-filter="failed">Failed</button>
+                        <button class="filter-btn" data-filter="interrupted">Interrupted</button>
                     </div>
-                    <button class="filter-btn active" data-filter="all">All</button>
-                    <button class="filter-btn" data-filter="success">Success</button>
-                    <button class="filter-btn" data-filter="failed">Failed</button>
-                    <button class="filter-btn" data-filter="interrupted">Interrupted</button>
+                    <div class="dag-list-toolbar">
+                        <div class="dag-grouping-hint" id="dagGroupingHint">Conversations stay together · sorted by latest turn</div>
+                        <div class="dag-mode-toggle" role="group" aria-label="Execution list grouping">
+                            <button class="dag-mode-btn active" type="button" data-grouping-mode="grouped" aria-pressed="true">Grouped</button>
+                            <button class="dag-mode-btn" type="button" data-grouping-mode="flat" aria-pressed="false">Flat</button>
+                        </div>
+                    </div>
+                    <div class="dag-list-diagnostic hidden" id="dagListDiagnostic" role="status" aria-live="polite"></div>
+                    <div class="table-container" id="dagTableContainer">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Status</th>
+                                    <th class="sortable" data-sort="original_request">Request</th>
+                                    <th>Steps</th>
+                                    <th class="sortable" data-sort="total_duration_ms">Duration</th>
+                                    <th class="sortable desc" data-sort="created_at">Created</th>
+                                </tr>
+                            </thead>
+                            <tbody id="dagTableBody"></tbody>
+                        </table>
+                    </div>
+                    <div class="dag-list-footer">
+                        <button class="dag-load-more hidden" id="dagLoadMore" type="button" data-load-more-groups>Load more groups</button>
+                        <div class="last-updated" id="dagLastUpdated">Loading...</div>
+                    </div>
                 </div>
-                <div class="table-container">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Status</th>
-                                <th class="sortable" data-sort="original_request">Request</th>
-                                <th>Steps</th>
-                                <th class="sortable" data-sort="total_duration_ms">Duration</th>
-                                <th class="sortable desc" data-sort="created_at">Created</th>
-                            </tr>
-                        </thead>
-                        <tbody id="dagTableBody"></tbody>
-                    </table>
+                <div class="dag-panel-mode dag-conversation-timeline-mode hidden" id="dagConversationMode" aria-live="polite">
+                    <div class="dag-timeline-header">
+                        <button class="dag-back-btn" type="button" data-close-conversation-timeline>← All executions</button>
+                        <div class="dag-timeline-heading-row">
+                            <div>
+                                <h2 class="dag-timeline-heading" id="dagTimelineHeading" tabindex="-1">Conversation timeline</h2>
+                                <div class="dag-timeline-summary" id="dagTimelineSummary">Loading conversation…</div>
+                            </div>
+                            <div class="dag-timeline-actions">
+                                <button class="dag-timeline-nav-btn" id="dagTimelinePrevious" type="button" data-timeline-nav="previous" aria-label="Previous conversation turn">←</button>
+                                <button class="dag-timeline-nav-btn" id="dagTimelineNext" type="button" data-timeline-nav="next" aria-label="Next conversation turn">→</button>
+                            </div>
+                        </div>
+                        <div class="dag-timeline-id-row">
+                            <code id="dagTimelineConversationID"></code>
+                            <button class="dag-copy-id-btn" id="dagCopyConversationID" type="button" data-copy-conversation-id>Copy ID</button>
+                        </div>
+                    </div>
+                    <div class="dag-timeline-diagnostic hidden" id="dagTimelineDiagnostic" role="status"></div>
+                    <div class="dag-timeline-content" id="dagTimelineContent">
+                        <div class="empty-detail">
+                            <div class="empty-detail-icon">💬</div>
+                            <div>Loading conversation timeline…</div>
+                        </div>
+                    </div>
                 </div>
-                <div class="last-updated" id="dagLastUpdated">Loading...</div>
             </div>
             <div class="resize-handle hidden" id="dagResizeHandle"></div>
             <div class="detail-panel hidden" id="dagDetailPanel">
                 <div class="detail-header">
-                    <span class="detail-title" id="dagDetailTitle">Select an execution</span>
+                    <div class="dag-detail-heading">
+                        <span class="detail-title" id="dagDetailTitle">Select an execution</span>
+                        <div class="dag-conversation-controls hidden" id="dagConversationControls">
+                            <button class="dag-conversation-nav-btn" id="dagConversationPrevious" type="button" data-selected-conversation-nav="previous" aria-label="Previous conversation turn">←</button>
+                            <button class="dag-conversation-pill" id="dagConversationPill" type="button" data-open-selected-conversation></button>
+                            <button class="dag-conversation-nav-btn" id="dagConversationNext" type="button" data-selected-conversation-nav="next" aria-label="Next conversation turn">→</button>
+                        </div>
+                    </div>
                     <div class="detail-tabs">
                         <button class="detail-tab active" data-tab="dag-viz">DAG Visualization</button>
                         <button class="detail-tab" data-tab="dag-pre" style="display: none;">Pre-Execution</button>

--- a/examples/registry-viewer-app/static/js/views/dag.js
+++ b/examples/registry-viewer-app/static/js/views/dag.js
@@ -41,9 +41,49 @@ let viewMode = 'full';
 let sortColumn = 'created_at';
 let sortDirection = 'desc';
 
+const DAG_GROUP_PAGE_SIZE = 50;
+const DAG_GROUPING_STORAGE_KEY = 'truvag3.dag.groupingMode';
+
+let groupingMode = readGroupingPreference();
+let groupedExecutionGroups = [];
+let groupedNextCursor = '';
+let groupedQueryFingerprint = '';
+let groupedResponsePartial = false;
+let groupedRequestVersion = 0;
+let groupedLoading = false;
+let expandedGroupKeys = new Set();
+let pendingAutoExpandRequestID = '';
+let conversationCache = new Map();
+let activeConversationID = '';
+let listPanelMode = 'list';
+let timelineReturnFocus = null;
+let dagSearchTimer = null;
+
 // LRU cache for Cytoscape instances — avoids rebuild on tab switch.
 // Key: "requestId:viewMode", Value: { cy, container (child div), requestId }
 const dagCache = new Map();
+
+function readGroupingPreference() {
+    try {
+        return sessionStorage.getItem(DAG_GROUPING_STORAGE_KEY) === 'flat'
+            ? 'flat'
+            : 'grouped';
+    } catch (_) {
+        return 'grouped';
+    }
+}
+
+function storeGroupingPreference(mode) {
+    try {
+        sessionStorage.setItem(DAG_GROUPING_STORAGE_KEY, mode);
+    } catch (_) {
+        // Private browsing and embedded viewers may disable web storage.
+    }
+}
+
+function escapeHtmlAttribute(value) {
+    return escapeHtml(String(value ?? '')).replace(/"/g, '&quot;');
+}
 
 // ---------------------------------------------------------------------------
 // Hook-phase classification
@@ -192,12 +232,17 @@ function unbindAllListeners() {
 }
 
 export function init() {
+    updateGroupingModeControls();
+    showExecutionListMode();
     bindDelegatedEvents();
     fetchExecutions();
 }
 
 export function refresh() {
-    fetchExecutions();
+    fetchExecutions({ preserveExpansion: true });
+    if (listPanelMode === 'timeline' && activeConversationID) {
+        void loadConversationTimeline(activeConversationID, selected?.request_id, { force: true });
+    }
 }
 
 export function destroy() {
@@ -210,6 +255,22 @@ export function destroy() {
     }
     dagCache.clear();
     cyInstance = null;
+    if (dagSearchTimer) {
+        clearTimeout(dagSearchTimer);
+        dagSearchTimer = null;
+    }
+    groupedRequestVersion++;
+    groupedExecutionGroups = [];
+    groupedNextCursor = '';
+    groupedQueryFingerprint = '';
+    groupedResponsePartial = false;
+    groupedLoading = false;
+    expandedGroupKeys.clear();
+    pendingAutoExpandRequestID = '';
+    conversationCache.clear();
+    activeConversationID = '';
+    listPanelMode = 'list';
+    timelineReturnFocus = null;
     // Remove every event listener registered by bindDelegatedEvents() so a
     // subsequent init() (when the user comes back to this view) starts clean.
     unbindAllListeners();
@@ -224,6 +285,7 @@ export function destroy() {
 // removeEventListener. Inline closures cannot be removed and would leak.
 
 function handleDagTableClick(e) {
+    if (e.target.closest('button')) return;
     const row = e.target.closest('tr[data-request-id]');
     if (row) {
         selectExecution(row.dataset.requestId);
@@ -231,9 +293,66 @@ function handleDagTableClick(e) {
 }
 
 function handleDagListPanelClick(e) {
+    const groupingBtn = e.target.closest('[data-grouping-mode]');
+    if (groupingBtn) {
+        setGroupingMode(groupingBtn.dataset.groupingMode);
+        return;
+    }
+    const groupToggle = e.target.closest('[data-toggle-conversation-group]');
+    if (groupToggle) {
+        toggleConversationGroup(
+            groupToggle.dataset.toggleConversationGroup,
+            groupToggle.classList.contains('dag-group-title-btn')
+                ? 'title'
+                : 'expand',
+        );
+        return;
+    }
+    const openTimeline = e.target.closest('[data-open-conversation]');
+    if (openTimeline) {
+        openConversationTimeline(
+            openTimeline.dataset.openConversation,
+            openTimeline,
+        );
+        return;
+    }
+    const closeTimeline = e.target.closest('[data-close-conversation-timeline]');
+    if (closeTimeline) {
+        closeConversationTimeline();
+        return;
+    }
+    const loadMore = e.target.closest('[data-load-more-groups]');
+    if (loadMore) {
+        if (!groupedLoading) void loadExecutionGroups({ reset: false });
+        return;
+    }
+    const timelineExecution = e.target.closest('[data-view-timeline-execution]');
+    if (timelineExecution) {
+        void selectExecution(
+            timelineExecution.dataset.viewTimelineExecution,
+            { restoreTimelineActionFocus: true },
+        );
+        return;
+    }
+    const timelineNav = e.target.closest('[data-timeline-nav]');
+    if (timelineNav) {
+        navigateConversationTurn(timelineNav.dataset.timelineNav);
+        return;
+    }
+    const copyConversation = e.target.closest('[data-copy-conversation-id]');
+    if (copyConversation) {
+        void copyConversationID(copyConversation);
+        return;
+    }
+    const flatFallback = e.target.closest('[data-use-flat-list]');
+    if (flatFallback) {
+        setGroupingMode('flat');
+        return;
+    }
     const filterBtn = e.target.closest('.filter-btn[data-filter]');
     if (filterBtn) {
         setDagFilter(filterBtn.dataset.filter);
+        return;
     }
     const sortTh = e.target.closest('th[data-sort]');
     if (sortTh) {
@@ -242,6 +361,17 @@ function handleDagListPanelClick(e) {
 }
 
 function handleDagDetailPanelClick(e) {
+    const conversationNav = e.target.closest('[data-selected-conversation-nav]');
+    if (conversationNav) {
+        navigateConversationTurn(conversationNav.dataset.selectedConversationNav);
+        return;
+    }
+    const openConversation = e.target.closest('[data-open-selected-conversation]');
+    if (openConversation) {
+        const conversationID = selected?.conversation_id;
+        if (conversationID) openConversationTimeline(conversationID, openConversation);
+        return;
+    }
     const tab = e.target.closest('.detail-tab[data-tab]');
     if (tab) {
         setDagDetailTab(tab.dataset.tab);
@@ -303,7 +433,15 @@ function handleDagDetailContentClick(e) {
 }
 
 function handleDagSearchInput() {
-    renderExecutionList();
+    if (dagSearchTimer) clearTimeout(dagSearchTimer);
+    dagSearchTimer = setTimeout(() => {
+        dagSearchTimer = null;
+        if (groupingMode === 'grouped') {
+            void loadExecutionGroups({ reset: true });
+        } else {
+            renderExecutionList();
+        }
+    }, 250);
 }
 
 function bindDelegatedEvents() {
@@ -318,44 +456,220 @@ function bindDelegatedEvents() {
 // Data fetching
 // ---------------------------------------------------------------------------
 
-async function fetchExecutions() {
+async function fetchExecutions({ preserveExpansion = false } = {}) {
+    if (groupingMode === 'grouped') {
+        await loadExecutionGroups({
+            reset: true,
+            preserveExpansion,
+            withLoadingOverlay: listPanelMode === 'list',
+        });
+        return;
+    }
+    await loadFlatExecutions({ withLoadingOverlay: listPanelMode === 'list' });
+}
+
+async function loadFlatExecutions({ withLoadingOverlay = true } = {}) {
     const listPanel = document.getElementById('dagListPanel');
-    showLoading(listPanel, 'Loading executions...');
+    const requestVersion = ++groupedRequestVersion;
+    if (withLoadingOverlay) showLoading(listPanel, 'Loading executions...');
     try {
         const { data } = await fetchAPI('/api/executions?limit=50');
+        if (requestVersion !== groupedRequestVersion || groupingMode !== 'flat') return;
         executions = data.executions || [];
+        setDagListDiagnostic('');
         renderExecutionList();
         updateDagStats();
+        updateDagLastUpdated(data.timestamp);
     } catch (error) {
+        if (requestVersion !== groupedRequestVersion) return;
         console.error('Failed to fetch executions:', error);
+        setDagListDiagnostic(
+            'The execution list could not be loaded. Refresh to try again.',
+            'error',
+        );
     } finally {
-        hideLoading(listPanel);
+        if (requestVersion === groupedRequestVersion && withLoadingOverlay) {
+            hideLoading(listPanel);
+        }
     }
 }
 
-function updateDagStats() {
-    const total = executions.length;
-    const successful = executions.filter(e => e.success).length;
+async function loadExecutionGroups({
+    reset,
+    withLoadingOverlay = true,
+    preserveExpansion = false,
+}) {
+    const listPanel = document.getElementById('dagListPanel');
+    const requestVersion = ++groupedRequestVersion;
+    if (reset && !preserveExpansion) {
+        requestSelectedGroupAutoExpansion();
+    }
+    groupedLoading = true;
+    updateGroupedLoadMoreControl();
+    if (withLoadingOverlay && reset) showLoading(listPanel, 'Loading conversation groups...');
+
+    const query = new URLSearchParams({
+        group_conversations: 'true',
+        q: document.getElementById('dagSearchInput')?.value.trim() || '',
+        status: filter,
+        sort: sortColumn,
+        direction: sortDirection,
+        limit: String(DAG_GROUP_PAGE_SIZE),
+    });
+    if (!reset && groupedNextCursor) query.set('cursor', groupedNextCursor);
+
+    try {
+        const { data } = await fetchAPI(`/api/executions?${query.toString()}`);
+        if (requestVersion !== groupedRequestVersion || groupingMode !== 'grouped') return;
+
+        if (!Array.isArray(data.groups)) {
+            setDagListDiagnostic(
+                'This Registry Viewer server does not support conversation grouping, so the flat list is shown.',
+                'warning',
+                false,
+            );
+            groupedExecutionGroups = [];
+            groupedNextCursor = '';
+            pendingAutoExpandRequestID = '';
+            groupingMode = 'flat';
+            updateGroupingModeControls();
+            executions = Array.isArray(data.executions) ? data.executions : [];
+            renderExecutionList();
+            updateDagStats(executions);
+            updateDagLastUpdated(data.timestamp);
+            return;
+        }
+
+        if (reset) {
+            groupedExecutionGroups = data.groups;
+            if (!preserveExpansion) {
+                expandedGroupKeys.clear();
+            }
+        } else if (
+            !groupedQueryFingerprint ||
+            groupedQueryFingerprint === data.query_fingerprint
+        ) {
+            groupedExecutionGroups = groupedExecutionGroups.concat(data.groups);
+        } else {
+            throw new Error('grouped response fingerprint changed during pagination');
+        }
+
+        groupedQueryFingerprint = data.query_fingerprint || '';
+        groupedNextCursor = data.next_cursor || '';
+        groupedResponsePartial = Boolean(data.partial);
+        applyPendingSelectedGroupAutoExpansion();
+        renderExecutionList();
+
+        const materialized = flattenGroupedExecutions(groupedExecutionGroups);
+        executions = materialized;
+        updateDagStats(materialized);
+        updateDagLastUpdated(data.timestamp);
+        updateGroupedDiagnostics(data);
+    } catch (error) {
+        if (requestVersion !== groupedRequestVersion) return;
+        console.error('Failed to fetch conversation groups:', error);
+        if (reset && !preserveExpansion) {
+            groupedExecutionGroups = [];
+            groupedNextCursor = '';
+            renderServerExecutionGroups([]);
+        }
+        setDagListDiagnostic(
+            'Conversation grouping is temporarily unavailable. The flat execution list remains available.',
+            'error',
+            true,
+        );
+    } finally {
+        if (requestVersion === groupedRequestVersion) {
+            groupedLoading = false;
+            updateGroupedLoadMoreControl();
+            if (withLoadingOverlay && reset) hideLoading(listPanel);
+        }
+    }
+}
+
+function updateGroupedLoadMoreControl() {
+    const loadMore = document.getElementById('dagLoadMore');
+    if (!loadMore) return;
+    loadMore.disabled =
+        groupedLoading ||
+        !groupedNextCursor ||
+        groupedResponsePartial;
+    loadMore.textContent = groupedLoading ? 'Loading…' : 'Load more groups';
+}
+
+function updateDagStats(sourceExecutions = executions) {
+    const unique = new Map();
+    sourceExecutions.forEach(execution => {
+        if (execution?.request_id) unique.set(execution.request_id, execution);
+    });
+    const values = Array.from(unique.values());
+    const total = values.length;
+    const successful = values.filter(e => e.success).length;
     const rate = total > 0 ? Math.round((successful / total) * 100) : 0;
 
     document.getElementById('executionCount').textContent = total;
     document.getElementById('successRate').textContent = `${rate}%`;
 }
 
+function flattenGroupedExecutions(groups) {
+    const result = [];
+    (groups || []).forEach(group => {
+        (group.turns || []).forEach(turn => {
+            if (turn.execution) result.push(turn.execution);
+            result.push(...(turn.related_executions || []));
+        });
+        result.push(...(group.orphans || []));
+    });
+    return result;
+}
+
+function updateDagLastUpdated(timestamp) {
+    const value = timestamp ? new Date(timestamp) : new Date();
+    const label = Number.isNaN(value.getTime()) ? new Date() : value;
+    const target = document.getElementById('dagLastUpdated');
+    if (target) target.textContent = `Last updated: ${label.toLocaleTimeString()}`;
+}
+
+function updateGroupedDiagnostics(data) {
+    const messages = [];
+    if (data.llm_enrichment_incomplete) {
+        messages.push('LLM duration and call counts are incomplete because DB 7 could not be fully read.');
+    }
+    if (data.partial) {
+        messages.push('This grouped result reached a safety bound; some groups may not be shown.');
+    }
+    if (messages.length > 0) {
+        setDagListDiagnostic(messages.join(' '), 'warning', true);
+    } else {
+        setDagListDiagnostic('');
+    }
+}
+
+function setDagListDiagnostic(message, tone = 'warning', offerFlat = false) {
+    const target = document.getElementById('dagListDiagnostic');
+    if (!target) return;
+    target.classList.toggle('hidden', !message);
+    target.classList.toggle('error', tone === 'error');
+    target.classList.toggle('warning', tone === 'warning');
+    target.innerHTML = message
+        ? `<span>${escapeHtml(message)}</span>${offerFlat ? '<button type="button" data-use-flat-list>Use flat list</button>' : ''}`
+        : '';
+}
+
 // ---------------------------------------------------------------------------
 // Filters and sorting
 // ---------------------------------------------------------------------------
-
-function filterExecutions() {
-    renderExecutionList();
-}
 
 function setDagFilter(f) {
     filter = f;
     document.querySelectorAll('#dagListPanel .filter-btn').forEach(btn => {
         btn.classList.toggle('active', btn.dataset.filter === f);
     });
-    renderExecutionList();
+    if (groupingMode === 'grouped') {
+        void loadExecutionGroups({ reset: true });
+    } else {
+        renderExecutionList();
+    }
 }
 
 function sortDagTable(column) {
@@ -374,7 +688,11 @@ function sortDagTable(column) {
     const th = document.querySelector(`#dagListPanel th[data-sort="${column}"]`);
     if (th) th.classList.add(sortDirection);
 
-    renderExecutionList();
+    if (groupingMode === 'grouped') {
+        void loadExecutionGroups({ reset: true });
+    } else {
+        renderExecutionList();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -382,6 +700,299 @@ function sortDagTable(column) {
 // ---------------------------------------------------------------------------
 
 function renderExecutionList() {
+    if (groupingMode === 'grouped') {
+        renderServerExecutionGroups(groupedExecutionGroups);
+        return;
+    }
+    renderLegacyExecutionList();
+}
+
+function setGroupingMode(mode) {
+    if (mode !== 'grouped' && mode !== 'flat') return;
+    if (groupingMode === mode) return;
+
+    groupingMode = mode;
+    storeGroupingPreference(mode);
+    groupedRequestVersion++;
+    groupedLoading = false;
+    groupedExecutionGroups = [];
+    groupedNextCursor = '';
+    groupedQueryFingerprint = '';
+    groupedResponsePartial = false;
+    expandedGroupKeys.clear();
+    pendingAutoExpandRequestID = mode === 'grouped'
+        ? (selected?.request_id || '')
+        : '';
+    setDagListDiagnostic('');
+    updateGroupingModeControls();
+    showExecutionListMode();
+    void fetchExecutions();
+}
+
+function updateGroupingModeControls() {
+    document.querySelectorAll('[data-grouping-mode]').forEach(button => {
+        const active = button.dataset.groupingMode === groupingMode;
+        button.classList.toggle('active', active);
+        button.setAttribute('aria-pressed', String(active));
+    });
+    const hint = document.getElementById('dagGroupingHint');
+    if (hint) {
+        hint.textContent = groupingMode === 'grouped'
+            ? 'Conversations stay together · sorted by latest matching turn'
+            : 'One row per execution · legacy list behavior';
+    }
+    const loadMore = document.getElementById('dagLoadMore');
+    if (loadMore && groupingMode === 'flat') loadMore.classList.add('hidden');
+}
+
+function showExecutionListMode() {
+    listPanelMode = 'list';
+    document.getElementById('dagListMode')?.classList.remove('hidden');
+    document.getElementById('dagConversationMode')?.classList.add('hidden');
+}
+
+function toggleConversationGroup(groupKey, triggerKind = 'expand') {
+    if (!groupKey) return;
+    if (expandedGroupKeys.has(groupKey)) {
+        expandedGroupKeys.delete(groupKey);
+    } else {
+        expandedGroupKeys.add(groupKey);
+    }
+    renderServerExecutionGroups(groupedExecutionGroups);
+    requestAnimationFrame(() => {
+        const trigger = Array.from(document.querySelectorAll(
+            '[data-toggle-conversation-group]',
+        )).find(button =>
+            button.dataset.toggleConversationGroup === groupKey &&
+            (triggerKind === 'title'
+                ? button.classList.contains('dag-group-title-btn')
+                : button.classList.contains('dag-group-expand-btn'))
+        );
+        trigger?.focus({ preventScroll: true });
+    });
+}
+
+function groupContainsRequest(group, requestID) {
+    if (!requestID) return false;
+    return (group.turns || []).some(turn =>
+        turn.execution?.request_id === requestID ||
+        (turn.related_executions || []).some(item => item.request_id === requestID)
+    ) || (group.orphans || []).some(item => item.request_id === requestID);
+}
+
+function requestSelectedGroupAutoExpansion() {
+    pendingAutoExpandRequestID = selected?.request_id || '';
+}
+
+function applyPendingSelectedGroupAutoExpansion() {
+    if (!pendingAutoExpandRequestID) return;
+    const group = groupedExecutionGroups.find(candidate =>
+        groupContainsRequest(candidate, pendingAutoExpandRequestID)
+    );
+    if (!group) return;
+
+    // The selected record is now represented by the current server page, so
+    // this one-shot request has been consumed. Standalone units have nothing
+    // to expand; conversation units open once and can then be collapsed by
+    // the user without a later render overriding that choice.
+    pendingAutoExpandRequestID = '';
+    if (group.conversation_id) {
+        expandedGroupKeys.add(group.group_key);
+    }
+}
+
+function renderServerExecutionGroups(groups) {
+    const container = document.getElementById('dagTableBody');
+    if (!container) return;
+
+    if (groups.length === 0) {
+        container.innerHTML = `
+            <tr>
+                <td colspan="5" class="dag-list-empty">
+                    <div class="empty-state-icon">💬</div>
+                    <div>No matching conversation groups found</div>
+                </td>
+            </tr>`;
+    } else {
+        const rows = [];
+        groups.forEach(group => {
+            if (!group.conversation_id) {
+                (group.turns || []).forEach(turn => {
+                    rows.push(renderGroupedExecutionRow(turn.execution, {
+                        llmCallCount: turn.llm_call_count,
+                        historyStatus: turn.history_status,
+                    }));
+                    (turn.related_executions || []).forEach(related => {
+                        rows.push(renderGroupedExecutionRow(related, {
+                            related: true,
+                            relationLabel: 'Related',
+                        }));
+                    });
+                });
+                (group.orphans || []).forEach(orphan => {
+                    rows.push(renderGroupedExecutionRow(orphan, {
+                        related: true,
+                        relationLabel: 'Related record',
+                    }));
+                });
+                return;
+            }
+
+            const expanded = expandedGroupKeys.has(group.group_key);
+            rows.push(renderConversationGroupHeader(group, expanded));
+            if (!expanded) return;
+
+            (group.turns || []).forEach(turn => {
+                rows.push(renderGroupedExecutionRow(turn.execution, {
+                    conversationTurn: true,
+                    llmCallCount: turn.llm_call_count,
+                    historyStatus: turn.history_status,
+                }));
+                (turn.related_executions || []).forEach(related => {
+                    rows.push(renderGroupedExecutionRow(related, {
+                        related: true,
+                        relationLabel: 'Related execution',
+                    }));
+                });
+            });
+            (group.orphans || []).forEach(orphan => {
+                rows.push(renderGroupedExecutionRow(orphan, {
+                    related: true,
+                    relationLabel: 'Unattached related record',
+                    orphan: true,
+                }));
+            });
+        });
+        container.innerHTML = rows.join('');
+    }
+
+    const loadMore = document.getElementById('dagLoadMore');
+    if (loadMore) {
+        loadMore.classList.toggle(
+            'hidden',
+            !groupedNextCursor || groupedResponsePartial,
+        );
+        updateGroupedLoadMoreControl();
+    }
+}
+
+function renderConversationGroupHeader(group, expanded) {
+    const turns = group.turns || [];
+    const anchor = turns[0]?.execution || group.orphans?.[0] || {};
+    const executionCount = turns.reduce(
+        (count, turn) => count + 1 + (turn.related_executions || []).length,
+        (group.orphans || []).length,
+    );
+    const visibleExecutions = flattenGroupedExecutions([group]);
+    const totalDuration =
+        (anchor.total_duration_ms || 0) +
+        (anchor.llm_total_duration_ms || 0);
+    const successful = visibleExecutions.every(item => item.success);
+    const interrupted = visibleExecutions.some(item => item.interrupted);
+    const statusClass = interrupted ? 'interrupted' : (successful ? 'success' : 'error');
+    const statusLabel = interrupted ? '⏸ Interrupted' : (successful ? '✓ Success' : '⚠ Mixed');
+    const shortConversationID = truncateText(group.conversation_id, 28);
+    const matchingTurnCount = group.matching_turn_count ?? turns.length;
+    const totalTurnCount = group.total_turn_count || turns.length;
+    const turnCountLabel = matchingTurnCount === totalTurnCount
+        ? `${totalTurnCount} turn${totalTurnCount === 1 ? '' : 's'}`
+        : `${matchingTurnCount} matching · ${totalTurnCount} total`;
+
+    return `
+        <tr class="dag-conversation-group-row ${expanded ? 'expanded' : ''}">
+            <td>
+                <button
+                    class="dag-group-expand-btn"
+                    type="button"
+                    data-toggle-conversation-group="${escapeHtmlAttribute(group.group_key)}"
+                    aria-expanded="${expanded}"
+                    aria-label="${expanded ? 'Collapse' : 'Expand'} conversation ${escapeHtmlAttribute(shortConversationID)}"
+                >${expanded ? '▾' : '▸'}</button>
+                <span class="status-badge ${statusClass}">${statusLabel}</span>
+            </td>
+            <td>
+                <button
+                    class="dag-group-title-btn"
+                    type="button"
+                    data-toggle-conversation-group="${escapeHtmlAttribute(group.group_key)}"
+                    aria-expanded="${expanded}"
+                >
+                    <span class="dag-group-kicker">Conversation · ${turnCountLabel}</span>
+                    <span class="dag-group-title">${escapeHtml(truncateText(anchor.original_request || 'Untitled conversation', 62))}</span>
+                    <span class="dag-group-id">${escapeHtml(shortConversationID)}</span>
+                </button>
+                <button
+                    class="dag-open-timeline-btn"
+                    type="button"
+                    data-open-conversation="${escapeHtmlAttribute(group.conversation_id)}"
+                >View timeline</button>
+                ${group.index_incomplete ? '<span class="dag-data-warning">Index incomplete</span>' : ''}
+            </td>
+            <td><span class="dag-group-count">${executionCount} execution${executionCount === 1 ? '' : 's'}</span></td>
+            <td><span class="dag-mono">${formatDuration(totalDuration)}</span></td>
+            <td>
+                <span class="time-ago">${formatTimeAgo(group.anchor_created_at || anchor.created_at)}</span>
+                <span class="dag-group-sort-note">latest match</span>
+            </td>
+        </tr>`;
+}
+
+function renderGroupedExecutionRow(exec, options = {}) {
+    if (!exec) return '';
+    const {
+        conversationTurn = false,
+        related = false,
+        relationLabel = '',
+        orphan = false,
+        llmCallCount = 0,
+        historyStatus = '',
+    } = options;
+    const isSelected = selected?.request_id === exec.request_id;
+    const rowClasses = [
+        isSelected ? 'selected' : '',
+        conversationTurn ? 'dag-conversation-turn-row' : '',
+        related ? 'child-row dag-related-execution-row' : '',
+        orphan ? 'dag-orphan-execution-row' : '',
+    ].filter(Boolean).join(' ');
+    const requestID = exec.request_id || '';
+    const originalRequestID = exec.original_request_id || requestID;
+    const statusClass = exec.interrupted ? 'interrupted' : (exec.success ? 'success' : 'error');
+    const statusLabel = exec.interrupted ? '⏸ Interrupted' : (exec.success ? '✓ Success' : '✗ Failed');
+    const duration = (exec.total_duration_ms || 0) + (exec.llm_total_duration_ms || 0);
+
+    return `
+        <tr class="${rowClasses}"
+            data-request-id="${escapeHtmlAttribute(requestID)}"
+            data-original-request-id="${escapeHtmlAttribute(originalRequestID)}">
+            <td>
+                <span class="status-badge ${statusClass}">${statusLabel}</span>
+            </td>
+            <td>
+                <div class="dag-execution-title-row">
+                    ${related ? '<span class="child-indicator">↳</span>' : (conversationTurn ? '<span class="dag-turn-dot" aria-hidden="true"></span>' : '')}
+                    <div class="dag-execution-title">
+                        ${relationLabel ? `<span class="dag-relation-label">${escapeHtml(relationLabel)}</span>` : ''}
+                        <div class="service-name">${escapeHtml(truncateText(exec.original_request || 'Unknown request', related ? 48 : 58))}</div>
+                        <span class="request-id">${escapeHtml(requestID)}</span>
+                        ${exec.interrupted ? '<span class="hitl-resume-badge">HITL Interrupted</span>' : ''}
+                        ${exec.metadata?.resume_checkpoint_id ? '<span class="hitl-resume-badge dag-hitl-resume">HITL Resume</span>' : ''}
+                        ${llmCallCount ? `<span class="dag-row-meta">${llmCallCount} LLM call${llmCallCount === 1 ? '' : 's'}</span>` : ''}
+                        ${historyStatus ? `<span class="dag-row-meta">${escapeHtml(historyStatus)}</span>` : ''}
+                    </div>
+                </div>
+            </td>
+            <td>
+                <div class="step-progress">
+                    <span>${exec.step_count || 0} steps</span>
+                    ${exec.failed_steps > 0 ? `<span class="dag-failed-steps">(${exec.failed_steps} failed)</span>` : ''}
+                </div>
+            </td>
+            <td><span class="dag-mono">${formatDuration(duration)}</span></td>
+            <td><span class="time-ago">${formatTimeAgo(exec.created_at)}</span></td>
+        </tr>`;
+}
+
+function renderLegacyExecutionList() {
     const container = document.getElementById('dagTableBody');
     const searchInput = document.getElementById('dagSearchInput');
     const searchTerm = searchInput ? searchInput.value.toLowerCase() : '';
@@ -587,16 +1198,369 @@ function renderExecutionList() {
 }
 
 // ---------------------------------------------------------------------------
+// Conversation timeline
+// ---------------------------------------------------------------------------
+
+function openConversationTimeline(conversationID, trigger) {
+    if (!conversationID) return;
+    if (listPanelMode !== 'timeline') {
+        timelineReturnFocus = trigger || document.activeElement;
+    }
+    activeConversationID = conversationID;
+    listPanelMode = 'timeline';
+    document.getElementById('dagListMode')?.classList.add('hidden');
+    document.getElementById('dagConversationMode')?.classList.remove('hidden');
+    renderConversationTimelineState(conversationID);
+    document.getElementById('dagTimelineHeading')?.focus({ preventScroll: true });
+    void loadConversationTimeline(conversationID, selected?.request_id);
+}
+
+function closeConversationTimeline() {
+    showExecutionListMode();
+    const refreshedGroupTrigger = Array.from(document.querySelectorAll(
+        '[data-open-conversation]',
+    )).find(button => button.dataset.openConversation === activeConversationID);
+    const conversationControls = document.getElementById('dagConversationControls');
+    const selectedConversationPill = conversationControls?.classList.contains('hidden')
+        ? null
+        : document.getElementById('dagConversationPill');
+    const focusTarget = timelineReturnFocus?.isConnected
+        ? timelineReturnFocus
+        : (refreshedGroupTrigger ||
+            selectedConversationPill ||
+            document.getElementById('dagSearchInput'));
+    timelineReturnFocus = null;
+    focusTarget?.focus({ preventScroll: true });
+}
+
+function renderConversationTimelineState(conversationID) {
+    const cached = conversationCache.get(conversationID);
+    if (cached?.data) {
+        renderConversationTimeline(cached.data);
+        return;
+    }
+    const idTarget = document.getElementById('dagTimelineConversationID');
+    if (idTarget) idTarget.textContent = conversationID;
+    const summary = document.getElementById('dagTimelineSummary');
+    if (summary) summary.textContent = 'Loading conversation…';
+    setTimelineDiagnostic('');
+    const content = document.getElementById('dagTimelineContent');
+    if (content) {
+        content.innerHTML = `
+            <div class="empty-detail">
+                <div class="empty-detail-icon">💬</div>
+                <div>Loading conversation timeline…</div>
+            </div>`;
+    }
+}
+
+async function loadConversationTimeline(
+    conversationID,
+    selectedRequestID,
+    { force = false } = {},
+) {
+    if (!conversationID) return null;
+    const cached = conversationCache.get(conversationID);
+    if (!force && cached?.data) {
+        updateConversationAffordance(selected, cached.data);
+        if (activeConversationID === conversationID && listPanelMode === 'timeline') {
+            renderConversationTimeline(cached.data, selectedRequestID);
+        }
+        return cached.data;
+    }
+    if (!force && cached?.promise) return cached.promise;
+
+    updateConversationAffordance(selected, null, true);
+    const endpoint = `/api/conversations?${new URLSearchParams({
+        conversation_id: conversationID,
+    }).toString()}`;
+    const promise = fetchAPI(endpoint)
+        .then(({ data }) => {
+            conversationCache.set(conversationID, { data });
+            if (selected?.conversation_id === conversationID) {
+                updateConversationAffordance(selected, data);
+            }
+            if (activeConversationID === conversationID && listPanelMode === 'timeline') {
+                renderConversationTimeline(
+                    data,
+                    selected?.request_id || selectedRequestID,
+                );
+            }
+            return data;
+        })
+        .catch(error => {
+            console.error('Failed to fetch conversation timeline:', error);
+            if (cached?.data) {
+                conversationCache.set(conversationID, { data: cached.data });
+                if (selected?.conversation_id === conversationID) {
+                    updateConversationAffordance(selected, cached.data);
+                }
+                if (activeConversationID === conversationID && listPanelMode === 'timeline') {
+                    renderConversationTimeline(cached.data, selected?.request_id);
+                    appendTimelineDiagnostic('The latest refresh failed; showing the cached timeline.');
+                }
+                return cached.data;
+            }
+            conversationCache.set(conversationID, { error });
+            if (selected?.conversation_id === conversationID) {
+                updateConversationAffordance(selected);
+            }
+            if (activeConversationID === conversationID && listPanelMode === 'timeline') {
+                renderTimelineError();
+            }
+            return null;
+        });
+    conversationCache.set(conversationID, { promise });
+    return promise;
+}
+
+function updateConversationAffordance(execution, timeline = null, loading = false) {
+    const controls = document.getElementById('dagConversationControls');
+    const pill = document.getElementById('dagConversationPill');
+    if (!controls || !pill) return;
+    const conversationID = execution?.conversation_id;
+    controls.classList.toggle('hidden', !conversationID);
+    if (!conversationID) {
+        pill.textContent = '';
+        pill.removeAttribute('title');
+        return;
+    }
+
+    const cachedTimeline = timeline || conversationCache.get(conversationID)?.data;
+    const turnIndex = cachedTimeline
+        ? findConversationTurnIndex(cachedTimeline, execution.request_id)
+        : -1;
+    if (turnIndex >= 0) {
+        const count = cachedTimeline.turn_count || cachedTimeline.turns?.length || 0;
+        pill.textContent = `💬 Turn ${turnIndex + 1} of ${count} · Timeline`;
+    } else if (loading) {
+        pill.textContent = '💬 Conversation · Loading turns…';
+    } else {
+        pill.textContent = '💬 View conversation';
+    }
+    pill.title = `Open conversation ${conversationID}`;
+
+    const previous = document.getElementById('dagConversationPrevious');
+    const next = document.getElementById('dagConversationNext');
+    if (previous) {
+        previous.disabled = loading || turnIndex <= 0;
+        previous.title = 'Previous conversation turn';
+    }
+    if (next) {
+        const turnCount = cachedTimeline?.turns?.length || 0;
+        next.disabled = loading || turnIndex < 0 || turnIndex >= turnCount - 1;
+        next.title = 'Next conversation turn';
+    }
+}
+
+function renderConversationTimeline(timeline, selectedRequestID = selected?.request_id) {
+    if (!timeline || activeConversationID !== timeline.conversation_id) return;
+    const turns = timeline.turns || [];
+    const turnCount = timeline.turn_count || turns.length;
+    const executionCount = timeline.execution_count || 0;
+    const idTarget = document.getElementById('dagTimelineConversationID');
+    if (idTarget) idTarget.textContent = timeline.conversation_id;
+    const summary = document.getElementById('dagTimelineSummary');
+    if (summary) {
+        summary.textContent = `${turnCount} turn${turnCount === 1 ? '' : 's'} · ${executionCount} execution${executionCount === 1 ? '' : 's'} · chronological`;
+    }
+
+    const diagnosticMessages = [];
+    if (timeline.index_incomplete) {
+        diagnosticMessages.push('The reverse index is incomplete; verified DB 8 records are still shown.');
+    }
+    if (timeline.llm_enrichment_incomplete) {
+        diagnosticMessages.push('LLM call counts and history status are incomplete.');
+    }
+    if (timeline.partial) {
+        diagnosticMessages.push('The timeline reached a safety bound and may omit records.');
+    }
+    setTimelineDiagnostic(diagnosticMessages.join(' '));
+
+    const currentTurnIndex = findConversationTurnIndex(timeline, selectedRequestID);
+    const previous = document.getElementById('dagTimelinePrevious');
+    const next = document.getElementById('dagTimelineNext');
+    if (previous) previous.disabled = currentTurnIndex <= 0;
+    if (next) next.disabled = currentTurnIndex < 0 || currentTurnIndex >= turns.length - 1;
+
+    const content = document.getElementById('dagTimelineContent');
+    if (!content) return;
+    if (turns.length === 0 && (timeline.orphans || []).length === 0) {
+        content.innerHTML = `
+            <div class="empty-detail">
+                <div class="empty-detail-icon">💬</div>
+                <div>No verified executions are available for this conversation.</div>
+            </div>`;
+        return;
+    }
+
+    const cards = turns.map((turn, index) =>
+        renderTimelineTurn(turn, index, turns.length, selectedRequestID)
+    );
+    if ((timeline.orphans || []).length > 0) {
+        cards.push(`
+            <section class="dag-timeline-orphans">
+                <h3>Unattached related records</h3>
+                <p>These executions carry the conversation ID, but their top-level owner was not available.</p>
+                ${(timeline.orphans || []).map(orphan =>
+                    renderTimelineRelatedExecution(orphan, selectedRequestID, true)
+                ).join('')}
+            </section>`);
+    }
+    content.innerHTML = cards.join('');
+    content.querySelector('.dag-timeline-card.current, .dag-timeline-related.current')
+        ?.scrollIntoView({ block: 'nearest' });
+}
+
+function renderTimelineTurn(turn, index, totalTurns, selectedRequestID) {
+    const execution = turn.execution || {};
+    const related = turn.related_executions || [];
+    const containsSelected = execution.request_id === selectedRequestID ||
+        related.some(item => item.request_id === selectedRequestID);
+    const statusClass = execution.interrupted
+        ? 'interrupted'
+        : (execution.success ? 'success' : 'error');
+    const statusLabel = execution.interrupted
+        ? '⏸ Interrupted'
+        : (execution.success ? '✓ Success' : '✗ Failed');
+    const duration = (execution.total_duration_ms || 0) +
+        (execution.llm_total_duration_ms || 0);
+
+    return `
+        <article class="dag-timeline-card ${containsSelected ? 'contains-current' : ''} ${execution.request_id === selectedRequestID ? 'current' : ''}" ${containsSelected ? 'aria-current="true"' : ''}>
+            <div class="dag-timeline-rail" aria-hidden="true">
+                <span>${index + 1}</span>
+            </div>
+            <div class="dag-timeline-card-body">
+                <div class="dag-timeline-card-header">
+                    <div>
+                        <span class="dag-turn-label">Turn ${index + 1} of ${totalTurns}</span>
+                        <time datetime="${escapeHtmlAttribute(execution.created_at || '')}">${formatDateTime(execution.created_at)}</time>
+                    </div>
+                    <span class="status-badge ${statusClass}">${statusLabel}</span>
+                </div>
+                <div class="dag-timeline-request">${escapeHtml(execution.original_request || 'Unknown request')}</div>
+                <div class="dag-timeline-meta">
+                    ${execution.agent_name ? `<span>${escapeHtml(execution.agent_name)}</span>` : ''}
+                    <span>${execution.step_count || 0} steps</span>
+                    ${execution.failed_steps ? `<span class="dag-error-text">${execution.failed_steps} failed</span>` : ''}
+                    <span>${formatDuration(duration)}</span>
+                    ${turn.llm_call_count ? `<span>${turn.llm_call_count} LLM call${turn.llm_call_count === 1 ? '' : 's'}</span>` : ''}
+                    ${turn.history_status ? `<span>${escapeHtml(turn.history_status)}</span>` : ''}
+                </div>
+                <div class="dag-timeline-request-id">${escapeHtml(execution.request_id || '')}</div>
+                <button class="dag-view-dag-btn" type="button" data-view-timeline-execution="${escapeHtmlAttribute(execution.request_id || '')}" ${execution.request_id === selectedRequestID ? 'aria-current="true"' : ''}>
+                    ${execution.request_id === selectedRequestID ? 'Viewing DAG' : 'View DAG'}
+                </button>
+                ${related.length > 0 ? `
+                    <div class="dag-timeline-related-list">
+                        <div class="dag-related-heading">${related.length} related execution${related.length === 1 ? '' : 's'}</div>
+                        ${related.map(item =>
+                            renderTimelineRelatedExecution(item, selectedRequestID)
+                        ).join('')}
+                    </div>` : ''}
+            </div>
+        </article>`;
+}
+
+function renderTimelineRelatedExecution(execution, selectedRequestID, orphan = false) {
+    const current = execution.request_id === selectedRequestID;
+    const duration = (execution.total_duration_ms || 0) +
+        (execution.llm_total_duration_ms || 0);
+    const relation = orphan
+        ? 'Unattached'
+        : (execution.metadata?.resume_checkpoint_id ? 'HITL resume' : 'Delegated / related');
+    return `
+        <div class="dag-timeline-related ${current ? 'current' : ''}" ${current ? 'aria-current="true"' : ''}>
+            <span class="dag-related-branch" aria-hidden="true">↳</span>
+            <div>
+                <span class="dag-relation-label">${relation}</span>
+                <div>${escapeHtml(truncateText(execution.original_request || 'Unknown request', 72))}</div>
+                <div class="dag-timeline-meta">
+                    ${execution.agent_name ? `<span>${escapeHtml(execution.agent_name)}</span>` : ''}
+                    <span>${formatDateTime(execution.created_at)}</span>
+                    <span>${execution.step_count || 0} steps</span>
+                    <span>${formatDuration(duration)}</span>
+                    <span class="${execution.success ? 'dag-success-text' : 'dag-error-text'}">${execution.interrupted ? 'Interrupted' : (execution.success ? 'Success' : 'Failed')}</span>
+                </div>
+                <div class="dag-timeline-request-id">${escapeHtml(execution.request_id || '')}</div>
+            </div>
+            <button class="dag-view-dag-btn" type="button" data-view-timeline-execution="${escapeHtmlAttribute(execution.request_id || '')}" ${current ? 'aria-current="true"' : ''}>
+                ${current ? 'Viewing DAG' : 'View DAG'}
+            </button>
+        </div>`;
+}
+
+function findConversationTurnIndex(timeline, requestID) {
+    if (!timeline || !requestID) return -1;
+    return (timeline.turns || []).findIndex(turn =>
+        turn.execution?.request_id === requestID ||
+        (turn.related_executions || []).some(item => item.request_id === requestID)
+    );
+}
+
+function navigateConversationTurn(direction) {
+    const conversationID = listPanelMode === 'timeline'
+        ? activeConversationID
+        : selected?.conversation_id;
+    const timeline = conversationCache.get(conversationID)?.data;
+    if (!timeline) return;
+    const currentIndex = findConversationTurnIndex(timeline, selected?.request_id);
+    const targetIndex = direction === 'previous' ? currentIndex - 1 : currentIndex + 1;
+    const target = timeline.turns?.[targetIndex]?.execution?.request_id;
+    if (target) void selectExecution(target);
+}
+
+function copyConversationID(button) {
+    if (activeConversationID) copyToClipboard(activeConversationID, button);
+}
+
+function setTimelineDiagnostic(message) {
+    const target = document.getElementById('dagTimelineDiagnostic');
+    if (!target) return;
+    target.classList.toggle('hidden', !message);
+    target.textContent = message || '';
+}
+
+function appendTimelineDiagnostic(message) {
+    const target = document.getElementById('dagTimelineDiagnostic');
+    if (!target || !message) return;
+    const combined = [target.textContent.trim(), message]
+        .filter(Boolean)
+        .join(' ');
+    target.classList.remove('hidden');
+    target.textContent = combined;
+}
+
+function renderTimelineError() {
+    const summary = document.getElementById('dagTimelineSummary');
+    if (summary) summary.textContent = 'Conversation unavailable';
+    setTimelineDiagnostic('The conversation timeline could not be loaded. Refresh to try again.');
+    const content = document.getElementById('dagTimelineContent');
+    if (content) {
+        content.innerHTML = `
+            <div class="empty-detail">
+                <div class="empty-detail-icon">⚠</div>
+                <div>The selected execution remains available in the DAG panel.</div>
+            </div>`;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Execution selection & detail
 // ---------------------------------------------------------------------------
 
-async function selectExecution(requestId) {
+async function selectExecution(
+    requestId,
+    { restoreTimelineActionFocus = false } = {},
+) {
     document.querySelectorAll('.node-popup').forEach(p => p.remove());
     const detailPanel = document.getElementById('dagDetailPanel');
     showLoading(detailPanel, 'Loading execution...');
     try {
         // Use unified endpoint to get execution, LLM debug, and HITL data in one call
         const { data } = await fetchAPI(`/api/executions/${requestId}/unified`);
+        const selectionChanged = selected?.request_id !== data.request_id;
         selected = data;
         // Multi-phase support: merge all phase plan steps into plan.steps
         // so existing rendering code works unchanged
@@ -611,9 +1575,36 @@ async function selectExecution(requestId) {
         // matching suffixes on iterative call types (tiered_selection,
         // etc.) where the base label collides across iterations.
         annotateCallLabels(selected.llm_interactions);
+        if (selectionChanged) {
+            requestSelectedGroupAutoExpansion();
+        }
+        applyPendingSelectedGroupAutoExpansion();
         renderExecutionList();
+        updateConversationAffordance(
+            selected,
+            null,
+            Boolean(selected.conversation_id),
+        );
+        if (selected.conversation_id) {
+            void loadConversationTimeline(
+                selected.conversation_id,
+                selected.request_id,
+            );
+        }
+        const activeTimeline = conversationCache.get(activeConversationID)?.data;
+        if (activeTimeline && listPanelMode === 'timeline') {
+            renderConversationTimeline(activeTimeline, selected.request_id);
+        }
         updateDetailTabs(); // Update tab visibility based on available data
         renderExecutionDetail();
+        if (restoreTimelineActionFocus && listPanelMode === 'timeline') {
+            requestAnimationFrame(() => {
+                const action = Array.from(document.querySelectorAll(
+                    '[data-view-timeline-execution]',
+                )).find(button => button.dataset.viewTimelineExecution === requestId);
+                action?.focus({ preventScroll: true });
+            });
+        }
     } catch (error) {
         console.error('Failed to fetch execution:', error);
     } finally {

--- a/examples/registry-viewer-app/static/js/views/dag.js
+++ b/examples/registry-viewer-app/static/js/views/dag.js
@@ -360,18 +360,20 @@ function handleDagListPanelClick(e) {
     }
 }
 
+function handleDagListPanelKeydown(e) {
+    if (e.repeat || (e.key !== 'Enter' && e.key !== ' ')) return;
+    const timelineExecution = e.target.closest(
+        '[data-view-timeline-execution][role="button"]',
+    );
+    if (!timelineExecution) return;
+    e.preventDefault();
+    void selectExecution(
+        timelineExecution.dataset.viewTimelineExecution,
+        { restoreTimelineActionFocus: true },
+    );
+}
+
 function handleDagDetailPanelClick(e) {
-    const conversationNav = e.target.closest('[data-selected-conversation-nav]');
-    if (conversationNav) {
-        navigateConversationTurn(conversationNav.dataset.selectedConversationNav);
-        return;
-    }
-    const openConversation = e.target.closest('[data-open-selected-conversation]');
-    if (openConversation) {
-        const conversationID = selected?.conversation_id;
-        if (conversationID) openConversationTimeline(conversationID, openConversation);
-        return;
-    }
     const tab = e.target.closest('.detail-tab[data-tab]');
     if (tab) {
         setDagDetailTab(tab.dataset.tab);
@@ -447,6 +449,7 @@ function handleDagSearchInput() {
 function bindDelegatedEvents() {
     addTrackedListener(document.getElementById('dagTableBody'), 'click', handleDagTableClick);
     addTrackedListener(document.getElementById('dagListPanel'), 'click', handleDagListPanelClick);
+    addTrackedListener(document.getElementById('dagListPanel'), 'keydown', handleDagListPanelKeydown);
     addTrackedListener(document.getElementById('dagDetailPanel'), 'click', handleDagDetailPanelClick);
     addTrackedListener(document.getElementById('dagDetailContent'), 'click', handleDagDetailContentClick);
     addTrackedListener(document.getElementById('dagSearchInput'), 'input', handleDagSearchInput);
@@ -1220,14 +1223,9 @@ function closeConversationTimeline() {
     const refreshedGroupTrigger = Array.from(document.querySelectorAll(
         '[data-open-conversation]',
     )).find(button => button.dataset.openConversation === activeConversationID);
-    const conversationControls = document.getElementById('dagConversationControls');
-    const selectedConversationPill = conversationControls?.classList.contains('hidden')
-        ? null
-        : document.getElementById('dagConversationPill');
     const focusTarget = timelineReturnFocus?.isConnected
         ? timelineReturnFocus
         : (refreshedGroupTrigger ||
-            selectedConversationPill ||
             document.getElementById('dagSearchInput'));
     timelineReturnFocus = null;
     focusTarget?.focus({ preventScroll: true });
@@ -1262,7 +1260,6 @@ async function loadConversationTimeline(
     if (!conversationID) return null;
     const cached = conversationCache.get(conversationID);
     if (!force && cached?.data) {
-        updateConversationAffordance(selected, cached.data);
         if (activeConversationID === conversationID && listPanelMode === 'timeline') {
             renderConversationTimeline(cached.data, selectedRequestID);
         }
@@ -1270,16 +1267,12 @@ async function loadConversationTimeline(
     }
     if (!force && cached?.promise) return cached.promise;
 
-    updateConversationAffordance(selected, null, true);
     const endpoint = `/api/conversations?${new URLSearchParams({
         conversation_id: conversationID,
     }).toString()}`;
     const promise = fetchAPI(endpoint)
         .then(({ data }) => {
             conversationCache.set(conversationID, { data });
-            if (selected?.conversation_id === conversationID) {
-                updateConversationAffordance(selected, data);
-            }
             if (activeConversationID === conversationID && listPanelMode === 'timeline') {
                 renderConversationTimeline(
                     data,
@@ -1292,9 +1285,6 @@ async function loadConversationTimeline(
             console.error('Failed to fetch conversation timeline:', error);
             if (cached?.data) {
                 conversationCache.set(conversationID, { data: cached.data });
-                if (selected?.conversation_id === conversationID) {
-                    updateConversationAffordance(selected, cached.data);
-                }
                 if (activeConversationID === conversationID && listPanelMode === 'timeline') {
                     renderConversationTimeline(cached.data, selected?.request_id);
                     appendTimelineDiagnostic('The latest refresh failed; showing the cached timeline.');
@@ -1302,9 +1292,6 @@ async function loadConversationTimeline(
                 return cached.data;
             }
             conversationCache.set(conversationID, { error });
-            if (selected?.conversation_id === conversationID) {
-                updateConversationAffordance(selected);
-            }
             if (activeConversationID === conversationID && listPanelMode === 'timeline') {
                 renderTimelineError();
             }
@@ -1312,45 +1299,6 @@ async function loadConversationTimeline(
         });
     conversationCache.set(conversationID, { promise });
     return promise;
-}
-
-function updateConversationAffordance(execution, timeline = null, loading = false) {
-    const controls = document.getElementById('dagConversationControls');
-    const pill = document.getElementById('dagConversationPill');
-    if (!controls || !pill) return;
-    const conversationID = execution?.conversation_id;
-    controls.classList.toggle('hidden', !conversationID);
-    if (!conversationID) {
-        pill.textContent = '';
-        pill.removeAttribute('title');
-        return;
-    }
-
-    const cachedTimeline = timeline || conversationCache.get(conversationID)?.data;
-    const turnIndex = cachedTimeline
-        ? findConversationTurnIndex(cachedTimeline, execution.request_id)
-        : -1;
-    if (turnIndex >= 0) {
-        const count = cachedTimeline.turn_count || cachedTimeline.turns?.length || 0;
-        pill.textContent = `💬 Turn ${turnIndex + 1} of ${count} · Timeline`;
-    } else if (loading) {
-        pill.textContent = '💬 Conversation · Loading turns…';
-    } else {
-        pill.textContent = '💬 View conversation';
-    }
-    pill.title = `Open conversation ${conversationID}`;
-
-    const previous = document.getElementById('dagConversationPrevious');
-    const next = document.getElementById('dagConversationNext');
-    if (previous) {
-        previous.disabled = loading || turnIndex <= 0;
-        previous.title = 'Previous conversation turn';
-    }
-    if (next) {
-        const turnCount = cachedTimeline?.turns?.length || 0;
-        next.disabled = loading || turnIndex < 0 || turnIndex >= turnCount - 1;
-        next.title = 'Next conversation turn';
-    }
 }
 
 function renderConversationTimeline(timeline, selectedRequestID = selected?.request_id) {
@@ -1432,26 +1380,37 @@ function renderTimelineTurn(turn, index, totalTurns, selectedRequestID) {
                 <span>${index + 1}</span>
             </div>
             <div class="dag-timeline-card-body">
-                <div class="dag-timeline-card-header">
-                    <div>
-                        <span class="dag-turn-label">Turn ${index + 1} of ${totalTurns}</span>
-                        <time datetime="${escapeHtmlAttribute(execution.created_at || '')}">${formatDateTime(execution.created_at)}</time>
+                <div
+                    class="dag-timeline-card-action"
+                    role="button"
+                    tabindex="0"
+                    data-view-timeline-execution="${escapeHtmlAttribute(execution.request_id || '')}"
+                    aria-label="View DAG for turn ${index + 1}: ${escapeHtmlAttribute(truncateText(execution.original_request || 'Unknown request', 90))}"
+                    ${execution.request_id === selectedRequestID ? 'aria-current="true"' : ''}
+                >
+                    <div class="dag-timeline-card-header">
+                        <div>
+                            <span class="dag-turn-label">Turn ${index + 1} of ${totalTurns}</span>
+                            <time datetime="${escapeHtmlAttribute(execution.created_at || '')}">${formatDateTime(execution.created_at)}</time>
+                        </div>
+                        <span class="status-badge ${statusClass}">${statusLabel}</span>
                     </div>
-                    <span class="status-badge ${statusClass}">${statusLabel}</span>
+                    <div class="dag-timeline-request">${escapeHtml(execution.original_request || 'Unknown request')}</div>
+                    <div class="dag-timeline-meta">
+                        ${execution.agent_name ? `<span>${escapeHtml(execution.agent_name)}</span>` : ''}
+                        <span>${execution.step_count || 0} steps</span>
+                        ${execution.failed_steps ? `<span class="dag-error-text">${execution.failed_steps} failed</span>` : ''}
+                        <span>${formatDuration(duration)}</span>
+                        ${turn.llm_call_count ? `<span>${turn.llm_call_count} LLM call${turn.llm_call_count === 1 ? '' : 's'}</span>` : ''}
+                        ${turn.history_status ? `<span>${escapeHtml(turn.history_status)}</span>` : ''}
+                    </div>
+                    <div class="dag-timeline-card-footer">
+                        <span class="dag-timeline-request-id">${escapeHtml(execution.request_id || '')}</span>
+                        <span class="dag-view-dag-btn" aria-hidden="true">
+                            ${execution.request_id === selectedRequestID ? 'Viewing DAG' : 'View DAG'}
+                        </span>
+                    </div>
                 </div>
-                <div class="dag-timeline-request">${escapeHtml(execution.original_request || 'Unknown request')}</div>
-                <div class="dag-timeline-meta">
-                    ${execution.agent_name ? `<span>${escapeHtml(execution.agent_name)}</span>` : ''}
-                    <span>${execution.step_count || 0} steps</span>
-                    ${execution.failed_steps ? `<span class="dag-error-text">${execution.failed_steps} failed</span>` : ''}
-                    <span>${formatDuration(duration)}</span>
-                    ${turn.llm_call_count ? `<span>${turn.llm_call_count} LLM call${turn.llm_call_count === 1 ? '' : 's'}</span>` : ''}
-                    ${turn.history_status ? `<span>${escapeHtml(turn.history_status)}</span>` : ''}
-                </div>
-                <div class="dag-timeline-request-id">${escapeHtml(execution.request_id || '')}</div>
-                <button class="dag-view-dag-btn" type="button" data-view-timeline-execution="${escapeHtmlAttribute(execution.request_id || '')}" ${execution.request_id === selectedRequestID ? 'aria-current="true"' : ''}>
-                    ${execution.request_id === selectedRequestID ? 'Viewing DAG' : 'View DAG'}
-                </button>
                 ${related.length > 0 ? `
                     <div class="dag-timeline-related-list">
                         <div class="dag-related-heading">${related.length} related execution${related.length === 1 ? '' : 's'}</div>
@@ -1471,7 +1430,14 @@ function renderTimelineRelatedExecution(execution, selectedRequestID, orphan = f
         ? 'Unattached'
         : (execution.metadata?.resume_checkpoint_id ? 'HITL resume' : 'Delegated / related');
     return `
-        <div class="dag-timeline-related ${current ? 'current' : ''}" ${current ? 'aria-current="true"' : ''}>
+        <div
+            class="dag-timeline-related ${current ? 'current' : ''}"
+            role="button"
+            tabindex="0"
+            data-view-timeline-execution="${escapeHtmlAttribute(execution.request_id || '')}"
+            aria-label="View DAG for ${escapeHtmlAttribute(relation.toLowerCase())} execution: ${escapeHtmlAttribute(truncateText(execution.original_request || 'Unknown request', 90))}"
+            ${current ? 'aria-current="true"' : ''}
+        >
             <span class="dag-related-branch" aria-hidden="true">↳</span>
             <div>
                 <span class="dag-relation-label">${relation}</span>
@@ -1485,9 +1451,9 @@ function renderTimelineRelatedExecution(execution, selectedRequestID, orphan = f
                 </div>
                 <div class="dag-timeline-request-id">${escapeHtml(execution.request_id || '')}</div>
             </div>
-            <button class="dag-view-dag-btn" type="button" data-view-timeline-execution="${escapeHtmlAttribute(execution.request_id || '')}" ${current ? 'aria-current="true"' : ''}>
+            <span class="dag-view-dag-btn" aria-hidden="true">
                 ${current ? 'Viewing DAG' : 'View DAG'}
-            </button>
+            </span>
         </div>`;
 }
 
@@ -1580,17 +1546,6 @@ async function selectExecution(
         }
         applyPendingSelectedGroupAutoExpansion();
         renderExecutionList();
-        updateConversationAffordance(
-            selected,
-            null,
-            Boolean(selected.conversation_id),
-        );
-        if (selected.conversation_id) {
-            void loadConversationTimeline(
-                selected.conversation_id,
-                selected.request_id,
-            );
-        }
         const activeTimeline = conversationCache.get(activeConversationID)?.data;
         if (activeTimeline && listPanelMode === 'timeline') {
             renderConversationTimeline(activeTimeline, selected.request_id);
@@ -2265,7 +2220,10 @@ function initCytoscape() {
                     const resInfoFull = getResolutionInfo(result);
                     const baseLabelFull = step.agent_name || stepCapability;
                     const trimMetaFull = result?.metadata?.result_trim;
-                    const wasTrimmedFull = isLossyTrim(trimMetaFull);
+                    // A step can be compacted without deterministic source loss
+                    // (for example, a distiller that analyzed the full source).
+                    // Keep compaction visibility separate from the loss warning.
+                    const wasTrimmedFull = hasTrimDisplay(trimMetaFull);
                     const trimLabelFull = wasTrimmedFull ? trimNodeLabel(trimMetaFull) : '';
                     nodes.push({
                         data: {
@@ -2393,7 +2351,9 @@ function initCytoscape() {
                 const resInfoFull = getResolutionInfo(result);
                 const baseLabelFull = step.agent_name || stepCapability;
                 const trimMetaFull = result?.metadata?.result_trim;
-                const wasTrimmedFull = isLossyTrim(trimMetaFull);
+                // Mirror the multi-phase path: show every recorded compaction,
+                // while isLossyTrim remains the authoritative loss check.
+                const wasTrimmedFull = hasTrimDisplay(trimMetaFull);
                 const trimLabelFull = wasTrimmedFull ? trimNodeLabel(trimMetaFull) : '';
                 nodes.push({
                     data: {
@@ -4255,8 +4215,9 @@ function hasTrimDisplay(trim) {
     return !!(trim && trim.original_bytes > 0 && (isLossyTrim(trim) || trim.original_bytes !== trim.trimmed_bytes));
 }
 
-// trimNodeLabel renders the node's scissors marker for a lossy trim; ' lossy' disambiguates
-// when the byte pair alone would read as a no-op or growth.
+// trimNodeLabel renders the node's scissors marker whenever compaction changed the result.
+// 'lossy' disambiguates the unusual case where known content loss still produced an
+// equal-sized or larger output because disclosure annotations added bytes.
 function trimNodeLabel(trim) {
     const marker = trim.content_lost === true && trim.trimmed_bytes >= trim.original_bytes ? ' lossy' : '';
     return `\n✂ ${formatBytes(trim.original_bytes)}→${formatBytes(trim.trimmed_bytes)}${marker}`;

--- a/examples/registry-viewer-app/static/js/views/llm-debug.js
+++ b/examples/registry-viewer-app/static/js/views/llm-debug.js
@@ -2,7 +2,7 @@
  * LLM Debug View.
  *
  * Displays LLM interaction records with filtering, detail views,
- * and conversation grouping. Falls back to mock data when the API
+ * and request-lineage grouping. Falls back to mock data when the API
  * is unavailable (e.g., local development without a running backend).
  */
 
@@ -36,7 +36,7 @@ let selected = null;
 let activeTab = 'interactions';
 let typeFilter = 'all';
 let expandedInteractions = new Set();
-let conversationFilter = null;
+let lineageFilter = null;
 
 // ---------------------------------------------------------------------------
 // Lifecycle
@@ -56,7 +56,7 @@ let boundListeners = [];
 
 export function destroy() {
     expandedInteractions = new Set();
-    conversationFilter = null;
+    lineageFilter = null;
     // Remove all event listeners added by setupEventDelegation
     boundListeners.forEach(({ el, type, fn }) => el.removeEventListener(type, fn));
     boundListeners = [];
@@ -80,11 +80,11 @@ function setupEventDelegation() {
     const tbody = document.getElementById('llmTableBody');
     if (tbody) {
         addTrackedListener(tbody, 'click', (e) => {
-            // Check for conversation filter click first
-            const convEl = e.target.closest('[data-conversation-id]');
-            if (convEl) {
+            // Check for request-lineage filter click first
+            const lineageEl = e.target.closest('[data-lineage-request-id]');
+            if (lineageEl) {
                 e.stopPropagation();
-                filterByConversation(convEl.dataset.conversationId);
+                filterByRequestLineage(lineageEl.dataset.lineageRequestId);
                 return;
             }
             const row = e.target.closest('tr[data-request-id]');
@@ -161,10 +161,10 @@ function setupEventDelegation() {
                 return;
             }
 
-            // Conversation filter link in detail view
-            const convLink = e.target.closest('[data-conversation-id]');
-            if (convLink) {
-                filterByConversation(convLink.dataset.conversationId);
+            // Request-lineage filter link in detail view
+            const lineageLink = e.target.closest('[data-lineage-request-id]');
+            if (lineageLink) {
+                filterByRequestLineage(lineageLink.dataset.lineageRequestId);
             }
         });
     }
@@ -197,8 +197,8 @@ function filterLLMRecords() {
             (record.interactions ? record.interactions.some(i => !i.success) : false);
         const origReqId = record.original_request_id || record.request_id;
 
-        // Check conversation filter first
-        if (conversationFilter && origReqId !== conversationFilter) {
+        // Check request-lineage filter first
+        if (lineageFilter && origReqId !== lineageFilter) {
             return false;
         }
 
@@ -228,29 +228,29 @@ function filterLLMRecords() {
     renderLLMTable(filtered);
 }
 
-function countLinkedRecords(conversationId) {
+function countLineageRecords(originalRequestId) {
     return records.filter(r => {
         const origReqId = r.original_request_id || r.request_id;
-        return origReqId === conversationId;
+        return origReqId === originalRequestId;
     }).length;
 }
 
-function filterByConversation(conversationId) {
-    // Don't allow filtering if there's only one record with this conversation ID
-    const linkedCount = countLinkedRecords(conversationId);
-    if (linkedCount <= 1 && conversationFilter !== conversationId) {
+function filterByRequestLineage(originalRequestId) {
+    // Don't allow filtering if this root request has only one record.
+    const linkedCount = countLineageRecords(originalRequestId);
+    if (linkedCount <= 1 && lineageFilter !== originalRequestId) {
         return;
     }
 
-    if (conversationFilter === conversationId) {
+    if (lineageFilter === originalRequestId) {
         // Toggle off - clear the filter
-        conversationFilter = null;
+        lineageFilter = null;
         const input = document.getElementById('llmSearchInput');
-        if (input) input.placeholder = 'Search by request ID, conversation, source agent, or type...';
+        if (input) input.placeholder = 'Search by request ID, request lineage, source agent, or type...';
     } else {
-        conversationFilter = conversationId;
+        lineageFilter = originalRequestId;
         const input = document.getElementById('llmSearchInput');
-        if (input) input.placeholder = `Filtering by conversation: ${truncateText(conversationId, 16)} (click again to clear)`;
+        if (input) input.placeholder = `Filtering by root request: ${truncateText(originalRequestId, 16)} (click again to clear)`;
     }
     filterLLMRecords();
 }
@@ -298,13 +298,13 @@ function renderLLMTable(list) {
         // Original request ID links related HITL records
         const origReqId = record.original_request_id || record.request_id;
         const isResumed = origReqId !== record.request_id;
-        // Check if this conversation has linked records (makes it clickable)
-        const hasLinkedRecords = countLinkedRecords(origReqId) > 1;
+        // Check whether this request lineage has linked records.
+        const hasLinkedRecords = countLineageRecords(origReqId) > 1;
         return `
         <tr data-request-id="${record.request_id}" class="${selected?.request_id === record.request_id ? 'selected' : ''}">
             <td><span class="request-id" title="${record.request_id}">${record.request_id}</span></td>
             <td>
-                <span class="request-id" title="${origReqId}${hasLinkedRecords ? ' (click to filter linked records)' : ''}" style="${hasLinkedRecords ? 'cursor: pointer; text-decoration: underline; text-decoration-style: dotted;' : ''}" ${hasLinkedRecords ? `data-conversation-id="${origReqId}"` : ''}>
+                <span class="request-id" title="${origReqId}${hasLinkedRecords ? ' (click to filter linked records)' : ''}" style="${hasLinkedRecords ? 'cursor: pointer; text-decoration: underline; text-decoration-style: dotted;' : ''}" ${hasLinkedRecords ? `data-lineage-request-id="${origReqId}"` : ''}>
                     ${isResumed ? '🔗 ' : ''}${origReqId}
                 </span>
             </td>
@@ -448,15 +448,15 @@ function renderLLMInteractionsView(record) {
     // Determine if this is a resumed request
     const origReqId = record.original_request_id || record.request_id;
     const isResumed = origReqId !== record.request_id;
-    // Check if this conversation has linked records
-    const hasLinkedRecords = countLinkedRecords(origReqId) > 1;
+    // Check whether this root request has linked records.
+    const hasLinkedRecords = countLineageRecords(origReqId) > 1;
 
     // Record Info
     html += `<div class="info-section"><div class="info-section-title"><span class="section-icon">📊</span> Record Info</div><div class="info-grid">
         <div class="info-label">Request ID</div><div class="info-value mono">${record.request_id}</div>
-        <div class="info-label">Conversation ID</div><div class="info-value mono" style="display: flex; align-items: center; gap: 8px;">
+        <div class="info-label">Root request ID</div><div class="info-value mono" style="display: flex; align-items: center; gap: 8px;">
             ${isResumed ? '<span title="This is a resumed HITL request">🔗</span>' : ''}
-            <span style="${hasLinkedRecords ? 'cursor: pointer; text-decoration: underline; text-decoration-style: dotted;' : ''}" ${hasLinkedRecords ? `data-conversation-id="${origReqId}" title="Click to filter linked records (${countLinkedRecords(origReqId)} total)"` : ''}>${origReqId}</span>
+            <span style="${hasLinkedRecords ? 'cursor: pointer; text-decoration: underline; text-decoration-style: dotted;' : ''}" ${hasLinkedRecords ? `data-lineage-request-id="${origReqId}" title="Click to filter linked records (${countLineageRecords(origReqId)} total)"` : ''}>${origReqId}</span>
             ${isResumed ? '<span style="font-size: 11px; color: var(--text-muted);">(HITL resume)</span>' : ''}
         </div>
         ${record.trace_id ? `<div class="info-label">Trace ID</div><div class="info-value mono">${record.trace_id}</div>` : ''}

--- a/examples/travel-chat-agent/chat_agent.go
+++ b/examples/travel-chat-agent/chat_agent.go
@@ -327,11 +327,17 @@ func travelConversationTurnsFromMessages(history []Message) []core.ConversationT
 }
 
 func (t *TravelChatAgent) addConversationHistoryMetadata(metadata map[string]interface{}, sessionID string, history []Message) {
-	if sessionID == "" || len(history) == 0 {
+	if sessionID == "" {
+		return
+	}
+
+	// This example maps one chat session to exactly one conversation.
+	metadata[orchestration.MetadataConversationID] = sessionID
+
+	if len(history) == 0 {
 		return
 	}
 	metadata[orchestration.MetadataConversationTurns] = travelConversationTurnsFromMessages(history)
-	metadata[orchestration.MetadataConversationSessionKey] = sessionID
 	if formattedHistory := t.formatConversationHistory(history); formattedHistory != "" {
 		metadata[core.EnrichmentConversationHistory] = formattedHistory
 	}

--- a/orchestration/ARCHITECTURE.md
+++ b/orchestration/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # TruvaG3 Orchestration Module Architecture
 
-**Version**: 1.0
+**Version**: 1.1
 **Purpose**: Comprehensive architectural documentation for the orchestration module
 **Audience**: Core contributors, module developers, system architects, LLM-based coding agents
 
@@ -23,6 +23,8 @@
 12. [Common Patterns & Examples](#common-patterns--examples)
 13. [Troubleshooting Guide](#troubleshooting-guide)
 14. [Future Considerations](#future-considerations)
+15. [Summary](#summary)
+16. [Version History](#version-history)
 
 ---
 
@@ -464,6 +466,37 @@ When a step reaches a HITL checkpoint, parameters are presented to a human for a
 ---
 
 ## Execution Models
+
+### Conversation correlation ingress
+
+`resolveConversationContext` is the single orchestration-ingress authority for
+canonical multi-turn correlation. It applies this presence-aware precedence:
+
+1. `metadata[MetadataConversationID]`
+2. the effective core candidate (`X-TruvaG3-Conversation-ID` before
+   programmatic `core.WithConversationID`)
+3. W3C baggage member `conversation_id`
+
+The resolver first clones metadata and removes inherited conversation identity
+from core context and baggage. A present higher-precedence candidate therefore
+blocks all lower-precedence candidates even when it is invalid. Valid identity
+is promoted atomically to sanitized request metadata, core context, and exact
+W3C baggage. The baggage member is marked metric-ineligible. Rejection is
+fail-open for business execution: it records only a bounded diagnostic reason,
+does not mark a span failed, does not expose the raw value, and leaves no
+conversation identity in the resulting request context.
+
+`MetadataConversationID` is canonical correlation metadata and is independent
+of `MetadataConversationTurns`. Producers must set it whenever an application
+has a conversation identity, including the first turn and delegation paths
+with no stored history. `session_id` remains application metadata; an example
+may map a session UUID to the canonical conversation ID, but the framework
+does not assign session semantics.
+
+Both structured-turn and formatted-history compaction caches use the resolved
+conversation ID. Changing that identifier during an in-flight conversation
+causes a cache miss and re-compaction; it never joins content from two
+conversations.
 
 ### 1. AI-Driven Orchestration
 
@@ -1590,6 +1623,46 @@ The orchestration module includes a debug store that captures complete LLM reque
 
 The store name is historical: it now carries both true LLM calls and selected non-LLM hook interactions when they materially improve production debugging. Examples include `conversation_history_prepare` (`Category: "logic"`), `user_memory_similarity_search` (`Category: "vector_db"`), and persistence-policy decisions (`Category: "logic"`). The registry viewer uses `HookPhase` plus `Category` to route these uniformly into LLM Debug, Pre-Execution, and Post-Execution views.
 
+#### Conversation-aware execution storage
+
+Conversation identity is stored in the existing `StoredExecution.Metadata` and
+`ExecutionSummary.Metadata` maps. `ExecutionConversationID` and
+`ExecutionSummaryConversationID` are the canonical accessors; the exported
+record field sets remain unchanged.
+
+`ExecutionStore` keeps its minimal required method set.
+`ConversationExecutionLister` is a separate optional capability discovered by
+type assertion. `NoOpExecutionStore` intentionally does not advertise it.
+Similarly, `StorageProvider` remains backend-neutral and unchanged;
+`IndexTTLManager` is an optional capability for providers that can extend a
+sorted index TTL without shortening it. A provider without that capability
+remains supported and relies on bounded lazy stale-member cleanup.
+
+Both the provider-backed store and direct Redis store:
+
+- validate `conversation_id` before any conversation-index command;
+- store records even when optional index or index-TTL maintenance fails;
+- use canonical single-colon keys and a SHA-256 digest rather than exposing the
+  raw ID in the key;
+- treat record metadata as authoritative and the index as an accelerator;
+- verify loaded record membership and prune stale or mismatched index members
+  without deleting live execution records;
+- return conversation results chronologically.
+
+`ExecutionStoreConfig.ConversationQueryLimit` defaults to 1000 and bounds
+returned records. `ConversationIndexScanLimit` defaults to 5000 and bounds
+work when stale entries are encountered. Explicit positive config values win;
+otherwise environment values are normalized by the factory and invalid or
+non-positive values fall back to defaults.
+
+HITL checkpoints use a framework-owned shallow clone of top-level application
+metadata. Framework additions, including `conversation_id` and
+`original_trace_id`, are read from `checkpoint.UserContext`; the caller's
+original top-level map is not mutated. Nested application values retain normal
+Go reference semantics. Resume context restores the validated canonical
+conversation ID before the `hitl.resume` linked span starts. Missing or invalid
+identity is scrubbed rather than inherited.
+
 **Configuration:**
 ```bash
 # Enable debug capture (default: false)
@@ -2223,3 +2296,12 @@ The orchestration module is the brain of the TruvaG3 framework, coordinating too
 The module follows the framework's design principles religiously, ensuring that it remains modular, testable, and maintainable while providing powerful orchestration capabilities.
 
 Remember: **The orchestrator never imports other modules directly** - it only depends on core interfaces. This is not a limitation but a strength that enables true modularity and flexibility.
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.1 | 2026-07-27 | Established the pre-release conversation-resolution, checkpoint, and optional execution-store capability contracts |
+| 1.0 | 2025-09-28 | Initial architecture documentation |

--- a/orchestration/README.md
+++ b/orchestration/README.md
@@ -1241,6 +1241,8 @@ if metrics.ComponentCallsFailed > 10 {
 | `TRUVAG3_LLM_DEBUG_TTL` | `24h` | TTL for successful debug records |
 | `TRUVAG3_LLM_DEBUG_ERROR_TTL` | `168h` | TTL for error debug records (7 days) |
 | `TRUVAG3_LLM_DEBUG_REDIS_DB` | `7` | Redis database index for debug storage |
+| `TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT` | `1000` | Maximum records returned by `ListByConversationID` |
+| `TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT` | `5000` | Maximum conversation-index members inspected by one lookup, including stale entries |
 | `TRUVAG3_ITERATIVE_PLANNING_ENABLED` | `true` | Enable multi-phase iterative planning. When enabled, the LLM planner can generate partial plans that execute in phases. Uses a tiered approach: Phase 1 discovers, Phase 2+ acts on results with context-aware tool re-selection. |
 | `TRUVAG3_ITERATIVE_MAX_PHASES` | `5` | Maximum planning phases per request. Most queries need at most 2. |
 | `TRUVAG3_ITERATIVE_MAX_TOTAL_STEPS` | `200` | Maximum total steps across all phases. Prevents runaway plan generation. |
@@ -1738,6 +1740,10 @@ These features are not yet implemented but could be added:
 - `LLMInteraction` - Single LLM call record with `SourceComponent` and `CallDescription` attribution
 - `LLMDebugRecordSummary` - Lightweight summary with `SourceComponents` for agent name listing
 - `LLMCallRecorderAdapter` - Bridges `LLMDebugStore` to `telemetry.LLMCallRecorder`
+- `ExecutionStore` - Required request-oriented execution persistence contract
+- `ConversationExecutionLister` - Optional capability for bounded chronological conversation lookup
+- `IndexTTLManager` - Optional `StorageProvider` capability for extending conversation-index TTL
+- `ExecutionStoreConfig` - Includes conversation query and stale-index scan limits
 
 ### Key Functions
 - `CreateOrchestrator(config, deps)` - Create orchestrator with dependencies
@@ -1753,6 +1759,35 @@ These features are not yet implemented but could be added:
 - `ExecuteWorkflow(ctx, workflow, inputs)` - Execute defined workflow
 - `ParseWorkflowYAML(data)` - Parse workflow from YAML
 - `NewLLMCallRecorderAdapter(store)` - Bridge `LLMDebugStore` to `telemetry.LLMCallRecorder`
+- `ExecutionConversationID(execution)` - Read canonical conversation metadata
+- `ExecutionSummaryConversationID(summary)` - Read canonical conversation metadata from a summary
+
+### Conversation-aware execution stores
+
+Conversation identity is canonical metadata, not a new field on
+`StoredExecution`:
+
+```go
+if lister, ok := store.(orchestration.ConversationExecutionLister); ok {
+    turns, err := lister.ListByConversationID(ctx, conversationID, 50)
+    // turns are chronological and bounded by ExecutionStoreConfig
+}
+```
+
+Do capability discovery with a type assertion. `ExecutionStore` and
+`StorageProvider` deliberately keep their existing required method sets, and
+the NoOp store does not claim conversation lookup support.
+
+Provider-backed stores may additionally implement `IndexTTLManager`. If they
+do not, writes and queries still work; bounded lazy cleanup removes stale
+membership as records expire. Execution record metadata is the source of truth
+and the hashed conversation index is only an accelerator. Optional
+conversation-index or TTL failures never fail the orchestration request.
+
+`MetadataConversationID` should be supplied whenever a conversation exists,
+including the first turn when `MetadataConversationTurns` is empty. It is
+separate from application `session_id`; an application may intentionally map
+the same opaque UUID to both concepts.
 
 ### Configuration Options
 - `WithCapabilityProvider(type, url)` - Configure capability provider type and URL

--- a/orchestration/conversation_compactor.go
+++ b/orchestration/conversation_compactor.go
@@ -126,13 +126,7 @@ func (c *LLMConversationCompactor) recordDebugInteraction(
 
 	recordCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if bag := telemetry.GetBaggage(ctx); bag != nil {
-		pairs := make([]string, 0, len(bag)*2)
-		for k, v := range bag {
-			pairs = append(pairs, k, v)
-		}
-		recordCtx = telemetry.WithBaggage(recordCtx, pairs...)
-	}
+	recordCtx = telemetry.CopyBaggage(recordCtx, ctx)
 
 	interaction := LLMInteraction{
 		Type:            "conversation_history_compaction",

--- a/orchestration/conversation_compactor_test.go
+++ b/orchestration/conversation_compactor_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/truvaagents/truva-g3/core"
 	"github.com/truvaagents/truva-g3/telemetry"
+	"go.opentelemetry.io/otel/baggage"
 )
 
 type conversationCompactorTestAIClient struct {
@@ -65,6 +66,51 @@ func TestLLMConversationCompactor_RecordsDebugInteractionOnSuccess(t *testing.T)
 	}
 	if interaction.Response != "short summary" {
 		t.Fatalf("expected debug interaction response to be recorded, got %q", interaction.Response)
+	}
+}
+
+func TestLLMConversationCompactor_PreservesBaggageMemberPropertiesForDebugStore(t *testing.T) {
+	client := &conversationCompactorTestAIClient{
+		response: &core.AIResponse{Content: "short summary"},
+	}
+	compactor, err := NewLLMConversationCompactor(client, nil)
+	if err != nil {
+		t.Fatalf("NewLLMConversationCompactor() error = %v", err)
+	}
+	debugStore := &mockLLMDebugStore{}
+	compactor.SetLLMDebugStore(debugStore)
+
+	ctx, err := telemetry.WithBaggageExact(
+		context.Background(),
+		MetadataConversationID,
+		"conversation-debug",
+		telemetry.WithMetricLabelEligibility(false),
+	)
+	if err != nil {
+		t.Fatalf("WithBaggageExact() error = %v", err)
+	}
+	ctx = telemetry.WithBaggage(ctx, "request_id", "request-debug")
+
+	if _, err := compactor.Compact(ctx, "", []core.ConversationTurn{
+		{Role: "user", Content: "new turn"},
+	}); err != nil {
+		t.Fatalf("Compact() error = %v", err)
+	}
+
+	debugStore.mu.Lock()
+	if len(debugStore.contexts) != 1 {
+		debugStore.mu.Unlock()
+		t.Fatalf("captured context count = %d, want 1", len(debugStore.contexts))
+	}
+	recordCtx := debugStore.contexts[0]
+	debugStore.mu.Unlock()
+
+	member := baggage.FromContext(recordCtx).Member(MetadataConversationID)
+	if member.Value() != "conversation-debug" {
+		t.Fatalf("copied conversation ID = %q", member.Value())
+	}
+	if !hasMetricExclusionProperty(member) {
+		t.Fatalf("copied baggage properties = %v, want metric exclusion", member.Properties())
 	}
 }
 

--- a/orchestration/conversation_context.go
+++ b/orchestration/conversation_context.go
@@ -1,0 +1,186 @@
+package orchestration
+
+import (
+	"context"
+
+	"github.com/truvaagents/truva-g3/core"
+	"github.com/truvaagents/truva-g3/telemetry"
+)
+
+const (
+	conversationIDSourceMetadata     = "metadata"
+	conversationIDSourceBaggage      = "baggage"
+	conversationIDSourceBaggageExact = "baggage_exact"
+
+	conversationIDRejectionMetric = "orchestration.conversation_id.rejected.total"
+)
+
+type ingressConversationCandidate struct {
+	present bool
+	value   string
+	source  string
+	reason  core.ConversationIDValidationReason
+}
+
+// resolveConversationContext is the single orchestration-ingress authority for
+// selecting, validating, and promoting a conversation ID. Correlation failure
+// is fail-open: business execution continues with the identity fully scrubbed.
+func (o *AIOrchestrator) resolveConversationContext(
+	ctx context.Context,
+	metadata map[string]interface{},
+) (context.Context, string, map[string]interface{}) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	metadataCandidate := conversationIDCandidateFromMetadata(metadata)
+	coreCandidate := core.GetConversationIDCandidate(ctx)
+	baggageValues := telemetry.GetBaggage(ctx)
+	baggageValue, baggagePresent := baggageValues[MetadataConversationID]
+
+	requestMetadata := cloneMetadata(metadata)
+	delete(requestMetadata, MetadataConversationID)
+
+	ctx = core.WithoutConversationID(ctx)
+	ctx = telemetry.WithoutBaggageMember(ctx, MetadataConversationID)
+
+	selected := ingressConversationCandidate{}
+	switch {
+	case metadataCandidate.Present:
+		selected = ingressConversationCandidate{
+			present: true,
+			value:   metadataCandidate.Value,
+			source:  conversationIDSourceMetadata,
+			reason:  metadataCandidate.Reason,
+		}
+	case coreCandidate.Present:
+		selected = ingressConversationCandidate{
+			present: true,
+			value:   coreCandidate.Value,
+			source:  boundedCoreConversationSource(coreCandidate.Source),
+			reason:  coreCandidate.RejectionReason,
+		}
+	case baggagePresent:
+		selected = ingressConversationCandidate{
+			present: true,
+			value:   baggageValue,
+			source:  conversationIDSourceBaggage,
+		}
+	}
+
+	if !selected.present {
+		return ctx, "", requestMetadata
+	}
+	if selected.reason != core.ConversationIDValidationNone {
+		o.emitConversationIDRejection(selected.source, string(selected.reason))
+		return ctx, "", requestMetadata
+	}
+	if reason := core.ValidateConversationID(selected.value); reason != core.ConversationIDValidationNone {
+		o.emitConversationIDRejection(selected.source, string(reason))
+		return ctx, "", requestMetadata
+	}
+
+	baggageCtx, err := telemetry.WithBaggageExact(
+		ctx,
+		MetadataConversationID,
+		selected.value,
+		telemetry.WithMetricLabelEligibility(false),
+	)
+	if err != nil {
+		o.emitConversationIDRejection(
+			conversationIDSourceBaggageExact,
+			conversationIDBaggageRejectionReason(err),
+		)
+		return ctx, "", requestMetadata
+	}
+
+	if requestMetadata == nil {
+		requestMetadata = make(map[string]interface{})
+	}
+	requestMetadata[MetadataConversationID] = selected.value
+	return core.WithConversationID(baggageCtx, selected.value), selected.value, requestMetadata
+}
+
+func boundedCoreConversationSource(source core.ConversationIDCandidateSource) string {
+	if source == core.ConversationIDSourceCoreHeader {
+		return string(core.ConversationIDSourceCoreHeader)
+	}
+	return string(core.ConversationIDSourceCoreContext)
+}
+
+func (o *AIOrchestrator) emitConversationIDRejection(source, reason string) {
+	if o == nil || o.telemetry == nil {
+		return
+	}
+	o.telemetry.RecordMetric(conversationIDRejectionMetric, 1, map[string]string{
+		"source": source,
+		"reason": reason,
+		"module": telemetry.ModuleOrchestration,
+	})
+}
+
+func conversationIDBaggageRejectionReason(err error) string {
+	reason, ok := telemetry.BaggageExactErrorReasonOf(err)
+	if !ok {
+		return "invalid_baggage_key"
+	}
+	switch reason {
+	case telemetry.BaggageExactInvalidUTF8:
+		return string(core.ConversationIDValidationInvalidUTF8)
+	case telemetry.BaggageExactKeyTooLong, telemetry.BaggageExactValueTooLong:
+		return string(core.ConversationIDValidationTooLong)
+	case telemetry.BaggageExactItemLimit:
+		return "item_limit"
+	case telemetry.BaggageExactTotalSize:
+		return "total_size"
+	default:
+		return "invalid_baggage_key"
+	}
+}
+
+func cloneMetadata(metadata map[string]interface{}) map[string]interface{} {
+	if metadata == nil {
+		return nil
+	}
+	cloned := make(map[string]interface{}, len(metadata))
+	for key, value := range metadata {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func mergeMetadata(
+	base map[string]interface{},
+	overlay map[string]interface{},
+) map[string]interface{} {
+	if len(overlay) == 0 {
+		return base
+	}
+	if base == nil {
+		base = make(map[string]interface{}, len(overlay))
+	}
+	for key, value := range overlay {
+		base[key] = value
+	}
+	return base
+}
+
+func withCheckpointMetadata(
+	ctx context.Context,
+	requestMetadata map[string]interface{},
+	conversationID string,
+) context.Context {
+	checkpointMetadata := cloneMetadata(GetMetadata(ctx))
+	checkpointMetadata = mergeMetadata(checkpointMetadata, requestMetadata)
+	delete(checkpointMetadata, MetadataConversationID)
+	if conversationID != "" {
+		if checkpointMetadata == nil {
+			checkpointMetadata = make(map[string]interface{})
+		}
+		checkpointMetadata[MetadataConversationID] = conversationID
+	}
+	if len(checkpointMetadata) == 0 {
+		return ctx
+	}
+	return WithMetadata(ctx, checkpointMetadata)
+}

--- a/orchestration/conversation_context_test.go
+++ b/orchestration/conversation_context_test.go
@@ -1,0 +1,960 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/truvaagents/truva-g3/core"
+	"github.com/truvaagents/truva-g3/telemetry"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type conversationMetricRecord struct {
+	name   string
+	value  float64
+	labels map[string]string
+}
+
+type conversationCaptureTelemetry struct {
+	records []conversationMetricRecord
+	spans   []*mockSpan
+}
+
+func (c *conversationCaptureTelemetry) StartSpan(
+	ctx context.Context,
+	name string,
+) (context.Context, core.Span) {
+	span := &mockSpan{name: name}
+	c.spans = append(c.spans, span)
+	return ctx, span
+}
+
+func (c *conversationCaptureTelemetry) RecordMetric(
+	name string,
+	value float64,
+	labels map[string]string,
+) {
+	labelsCopy := make(map[string]string, len(labels))
+	for key, labelValue := range labels {
+		labelsCopy[key] = labelValue
+	}
+	c.records = append(c.records, conversationMetricRecord{
+		name:   name,
+		value:  value,
+		labels: labelsCopy,
+	})
+}
+
+type conversationShortCircuitHook struct {
+	contextMetadata map[string]interface{}
+	coreID          string
+	baggageID       string
+}
+
+func (h *conversationShortCircuitHook) Name() string {
+	return "conversation-ingress-capture"
+}
+
+func (h *conversationShortCircuitHook) BeforePlanning(
+	ctx context.Context,
+	_ *core.PipelineContext,
+) (*core.PipelineShortCircuit, error) {
+	h.contextMetadata = cloneMetadata(GetMetadata(ctx))
+	h.coreID = core.GetConversationID(ctx)
+	h.baggageID = telemetry.GetBaggage(ctx)[MetadataConversationID]
+	return &core.PipelineShortCircuit{
+		Response: "short-circuit response",
+		Source:   "unit-test",
+	}, nil
+}
+
+func TestProcessRequestEntryPoints_PromoteConversationID(t *testing.T) {
+	const conversationID = "conversation-entry-point"
+
+	tests := []struct {
+		name        string
+		streaming   bool
+		requestSpan string
+	}{
+		{
+			name:        "non-streaming",
+			requestSpan: "orchestrator.process_request",
+		},
+		{
+			name:        "streaming",
+			streaming:   true,
+			requestSpan: "orchestrator.process_request_streaming",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var aiClient core.AIClient = NewMockAIClient()
+			if test.streaming {
+				aiClient = NewStreamingMockAIClient()
+			}
+
+			orchestrator := NewAIOrchestrator(
+				DefaultConfig(),
+				NewMockDiscovery(),
+				aiClient,
+			)
+			capture := &conversationCaptureTelemetry{}
+			orchestrator.SetTelemetry(capture)
+			hook := &conversationShortCircuitHook{}
+			orchestrator.pipelineHooks = []core.PipelineHook{hook}
+
+			recorder := tracetest.NewSpanRecorder()
+			provider := sdktrace.NewTracerProvider(
+				sdktrace.WithSpanProcessor(recorder),
+			)
+			t.Cleanup(func() {
+				_ = provider.Shutdown(context.Background())
+			})
+			ctx, parentSpan := provider.Tracer("conversation-entry-test").Start(
+				context.Background(),
+				"parent-request",
+			)
+
+			var (
+				responseMetadata map[string]interface{}
+				err              error
+			)
+			if test.streaming {
+				var response *StreamingOrchestratorResponse
+				response, err = orchestrator.ProcessRequestStreaming(
+					ctx,
+					"request",
+					map[string]interface{}{
+						MetadataConversationID: conversationID,
+					},
+					func(core.StreamChunk) error { return nil },
+				)
+				if response != nil {
+					responseMetadata = response.Metadata
+				}
+			} else {
+				var response *OrchestratorResponse
+				response, err = orchestrator.ProcessRequest(
+					ctx,
+					"request",
+					map[string]interface{}{
+						MetadataConversationID: conversationID,
+					},
+				)
+				if response != nil {
+					responseMetadata = response.Metadata
+				}
+			}
+			parentSpan.End()
+
+			if err != nil {
+				t.Fatalf("request entry point error = %v", err)
+			}
+			if responseMetadata[MetadataConversationID] != conversationID {
+				t.Fatalf("response metadata = %v", responseMetadata)
+			}
+			if hook.coreID != conversationID ||
+				hook.baggageID != conversationID ||
+				hook.contextMetadata[MetadataConversationID] != conversationID {
+				t.Fatalf(
+					"hook correlation: core=%q baggage=%q metadata=%v",
+					hook.coreID,
+					hook.baggageID,
+					hook.contextMetadata,
+				)
+			}
+
+			requestSpan := findConversationMockSpan(capture.spans, test.requestSpan)
+			if requestSpan == nil {
+				t.Fatalf("missing request span %q", test.requestSpan)
+			}
+			if got := requestSpan.attributes[MetadataConversationID]; got != conversationID {
+				t.Fatalf("request span conversation ID = %v", got)
+			}
+
+			ended := recorder.Ended()
+			if len(ended) != 1 {
+				t.Fatalf("ended OTel spans = %d, want 1", len(ended))
+			}
+			if got, ok := readOnlySpanStringAttribute(
+				ended[0],
+				MetadataConversationID,
+			); !ok || got != conversationID {
+				t.Fatalf("parent span conversation ID = %q, %v", got, ok)
+			}
+		})
+	}
+}
+
+func TestResolveConversationContext_PrecedenceAndPromotion(t *testing.T) {
+	ctx := telemetry.WithBaggage(context.Background(), MetadataConversationID, "from-baggage")
+	ctx = core.WithConversationID(ctx, "from-core")
+	input := map[string]interface{}{
+		MetadataConversationID: "from-metadata",
+		"application_key":      "preserved",
+	}
+	tel := &conversationCaptureTelemetry{}
+	orchestrator := &AIOrchestrator{telemetry: tel}
+
+	gotCtx, gotID, gotMetadata := orchestrator.resolveConversationContext(ctx, input)
+
+	if gotID != "from-metadata" {
+		t.Fatalf("conversation ID = %q, want from-metadata", gotID)
+	}
+	if got := core.GetConversationID(gotCtx); got != gotID {
+		t.Fatalf("core conversation ID = %q, want %q", got, gotID)
+	}
+	if got := telemetry.GetBaggage(gotCtx)[MetadataConversationID]; got != gotID {
+		t.Fatalf("baggage conversation ID = %q, want %q", got, gotID)
+	}
+	if got := gotMetadata[MetadataConversationID]; got != gotID {
+		t.Fatalf("metadata conversation ID = %v, want %q", got, gotID)
+	}
+	if gotMetadata["application_key"] != "preserved" {
+		t.Fatalf("unrelated metadata was not preserved: %v", gotMetadata)
+	}
+	if len(tel.records) != 0 {
+		t.Fatalf("valid resolution emitted rejection metrics: %+v", tel.records)
+	}
+	gotMetadata["application_key"] = "working-copy-only"
+	if input["application_key"] != "preserved" {
+		t.Fatal("valid resolution mutated caller-owned metadata")
+	}
+
+	member := baggage.FromContext(gotCtx).Member(MetadataConversationID)
+	if member.Value() != gotID {
+		t.Fatalf("promoted baggage member = %q, want %q", member.Value(), gotID)
+	}
+	if !hasMetricExclusionProperty(member) {
+		t.Fatalf("promoted baggage properties = %v, want metric exclusion", member.Properties())
+	}
+}
+
+func TestResolveConversationContext_ValidCoreAndBaggageSources(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  context.Context
+		want string
+	}{
+		{
+			name: "programmatic core",
+			ctx:  core.WithConversationID(context.Background(), "from-core"),
+			want: "from-core",
+		},
+		{
+			name: "incoming baggage",
+			ctx: telemetry.WithBaggage(
+				context.Background(),
+				MetadataConversationID,
+				"from-baggage",
+			),
+			want: "from-baggage",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tel := &conversationCaptureTelemetry{}
+			orchestrator := &AIOrchestrator{telemetry: tel}
+
+			gotCtx, gotID, gotMetadata := orchestrator.resolveConversationContext(test.ctx, nil)
+
+			if gotID != test.want ||
+				core.GetConversationID(gotCtx) != test.want ||
+				telemetry.GetBaggage(gotCtx)[MetadataConversationID] != test.want ||
+				gotMetadata[MetadataConversationID] != test.want {
+				t.Fatalf(
+					"promotion mismatch: id=%q core=%q baggage=%q metadata=%v",
+					gotID,
+					core.GetConversationID(gotCtx),
+					telemetry.GetBaggage(gotCtx)[MetadataConversationID],
+					gotMetadata,
+				)
+			}
+			if len(tel.records) != 0 {
+				t.Fatalf("valid source emitted rejection: %+v", tel.records)
+			}
+			if !hasMetricExclusionProperty(
+				baggage.FromContext(gotCtx).Member(MetadataConversationID),
+			) {
+				t.Fatal("source was not re-promoted with metric exclusion")
+			}
+		})
+	}
+}
+
+func TestResolveConversationContext_NoConversationPreservesUnrelatedContext(t *testing.T) {
+	ctx := telemetry.WithBaggage(context.Background(), "tenant", "tenant-1")
+	metadata := map[string]interface{}{"application_key": "preserved"}
+	tel := &conversationCaptureTelemetry{}
+	orchestrator := &AIOrchestrator{telemetry: tel}
+
+	gotCtx, gotID, gotMetadata := orchestrator.resolveConversationContext(ctx, metadata)
+
+	if gotID != "" || core.GetConversationID(gotCtx) != "" {
+		t.Fatalf("unexpected conversation ID = %q", gotID)
+	}
+	if telemetry.GetBaggage(gotCtx)["tenant"] != "tenant-1" {
+		t.Fatalf("unrelated baggage was lost: %v", telemetry.GetBaggage(gotCtx))
+	}
+	if gotMetadata["application_key"] != "preserved" {
+		t.Fatalf("unrelated metadata was lost: %v", gotMetadata)
+	}
+	if len(tel.records) != 0 {
+		t.Fatalf("absent conversation emitted rejection: %+v", tel.records)
+	}
+}
+
+func TestResolveConversationContext_InvalidMetadataBlocksAndScrubsFallback(t *testing.T) {
+	rawInvalid := "invalid conversation"
+	ctx := telemetry.WithBaggage(context.Background(), MetadataConversationID, "from-baggage")
+	ctx = core.WithConversationID(ctx, "from-core")
+	input := map[string]interface{}{
+		MetadataConversationID: rawInvalid,
+		"application_key":      "preserved",
+	}
+	tel := &conversationCaptureTelemetry{}
+	orchestrator := &AIOrchestrator{telemetry: tel}
+
+	gotCtx, gotID, gotMetadata := orchestrator.resolveConversationContext(ctx, input)
+
+	if gotID != "" || core.GetConversationID(gotCtx) != "" {
+		t.Fatalf("rejected conversation leaked into core context: %q, %q", gotID, core.GetConversationID(gotCtx))
+	}
+	if _, present := telemetry.GetBaggage(gotCtx)[MetadataConversationID]; present {
+		t.Fatal("lower-precedence baggage survived invalid metadata")
+	}
+	if _, present := gotMetadata[MetadataConversationID]; present {
+		t.Fatal("rejected reserved metadata survived sanitization")
+	}
+	if gotMetadata["application_key"] != "preserved" {
+		t.Fatalf("unrelated metadata was not preserved: %v", gotMetadata)
+	}
+	if input[MetadataConversationID] != rawInvalid {
+		t.Fatal("caller-owned metadata was mutated")
+	}
+	assertConversationRejection(
+		t,
+		tel.records,
+		conversationIDSourceMetadata,
+		string(core.ConversationIDValidationInvalidCharacter),
+		rawInvalid,
+	)
+}
+
+func TestResolveConversationContext_InvalidIncomingBaggageIsRejected(t *testing.T) {
+	carrier := propagation.MapCarrier{
+		"baggage": MetadataConversationID + "=invalid%20conversation",
+	}
+	ctx := propagation.Baggage{}.Extract(context.Background(), carrier)
+	if got := telemetry.GetBaggage(ctx)[MetadataConversationID]; got != "invalid conversation" {
+		t.Fatalf("decoded test baggage = %q", got)
+	}
+	tel := &conversationCaptureTelemetry{}
+	orchestrator := &AIOrchestrator{telemetry: tel}
+
+	gotCtx, gotID, gotMetadata := orchestrator.resolveConversationContext(ctx, nil)
+
+	if gotID != "" || core.GetConversationID(gotCtx) != "" {
+		t.Fatalf("invalid baggage leaked conversation identity: %q", gotID)
+	}
+	if _, present := telemetry.GetBaggage(gotCtx)[MetadataConversationID]; present {
+		t.Fatal("invalid incoming baggage survived sanitization")
+	}
+	if _, present := gotMetadata[MetadataConversationID]; present {
+		t.Fatal("invalid incoming baggage appeared in metadata")
+	}
+	assertConversationRejection(
+		t,
+		tel.records,
+		conversationIDSourceBaggage,
+		string(core.ConversationIDValidationInvalidCharacter),
+		"invalid conversation",
+	)
+}
+
+func TestResolveConversationContext_RejectionDoesNotMarkSpanError(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+	})
+
+	ctx, span := provider.Tracer("conversation-context-test").Start(
+		context.Background(),
+		"request",
+	)
+	tel := &conversationCaptureTelemetry{}
+	orchestrator := &AIOrchestrator{telemetry: tel}
+
+	gotCtx, gotID, gotMetadata := orchestrator.resolveConversationContext(
+		ctx,
+		map[string]interface{}{
+			MetadataConversationID: "invalid conversation",
+			"application_key":      "preserved",
+		},
+	)
+	span.End()
+
+	if gotID != "" || core.GetConversationID(gotCtx) != "" {
+		t.Fatalf("rejected conversation leaked into context: %q", gotID)
+	}
+	if _, present := gotMetadata[MetadataConversationID]; present {
+		t.Fatal("rejected reserved metadata survived sanitization")
+	}
+	if gotMetadata["application_key"] != "preserved" {
+		t.Fatalf("unrelated metadata was not preserved: %v", gotMetadata)
+	}
+	assertConversationRejection(
+		t,
+		tel.records,
+		conversationIDSourceMetadata,
+		string(core.ConversationIDValidationInvalidCharacter),
+		"invalid conversation",
+	)
+
+	ended := recorder.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(ended))
+	}
+	if status := ended[0].Status(); status.Code != codes.Unset {
+		t.Fatalf("span status = %v (%q), want unset", status.Code, status.Description)
+	}
+	for _, event := range ended[0].Events() {
+		if event.Name == "exception" {
+			t.Fatalf("conversation rejection recorded an exception event: %+v", event)
+		}
+	}
+}
+
+func TestResolveConversationContext_InvalidTypeBlocksFallback(t *testing.T) {
+	ctx := core.WithConversationID(context.Background(), "from-core")
+	tel := &conversationCaptureTelemetry{}
+	orchestrator := &AIOrchestrator{telemetry: tel}
+
+	gotCtx, gotID, gotMetadata := orchestrator.resolveConversationContext(
+		ctx,
+		map[string]interface{}{MetadataConversationID: 42},
+	)
+
+	if gotID != "" || core.GetConversationID(gotCtx) != "" {
+		t.Fatalf("invalid type leaked conversation identity: %q", gotID)
+	}
+	if _, present := gotMetadata[MetadataConversationID]; present {
+		t.Fatal("invalid typed reserved metadata survived sanitization")
+	}
+	assertConversationRejection(
+		t,
+		tel.records,
+		conversationIDSourceMetadata,
+		string(core.ConversationIDValidationInvalidType),
+		"42",
+	)
+}
+
+func TestResolveConversationContext_InvalidCoreBlocksBaggageFallback(t *testing.T) {
+	ctx := telemetry.WithBaggage(context.Background(), MetadataConversationID, "from-baggage")
+	ctx = core.WithConversationID(ctx, "invalid conversation")
+	tel := &conversationCaptureTelemetry{}
+	orchestrator := &AIOrchestrator{telemetry: tel}
+
+	gotCtx, gotID, _ := orchestrator.resolveConversationContext(ctx, nil)
+
+	if gotID != "" || core.GetConversationID(gotCtx) != "" {
+		t.Fatalf("invalid core candidate leaked conversation identity: %q", gotID)
+	}
+	if _, present := telemetry.GetBaggage(gotCtx)[MetadataConversationID]; present {
+		t.Fatal("baggage fallback survived invalid core candidate")
+	}
+	assertConversationRejection(
+		t,
+		tel.records,
+		string(core.ConversationIDSourceCoreContext),
+		string(core.ConversationIDValidationInvalidCharacter),
+		"invalid conversation",
+	)
+}
+
+func TestResolveConversationContext_BaggageCapacityFailureIsFailOpenAndScrubbed(t *testing.T) {
+	ctx := context.Background()
+	for i := 0; i < telemetry.MaxBaggageItems; i++ {
+		var err error
+		ctx, err = telemetry.WithBaggageExact(ctx, fmt.Sprintf("key%d", i), "value")
+		if err != nil {
+			t.Fatalf("fill baggage member %d: %v", i, err)
+		}
+	}
+	ctx = core.WithConversationID(ctx, "conversation-capacity")
+	tel := &conversationCaptureTelemetry{}
+	orchestrator := &AIOrchestrator{telemetry: tel}
+
+	gotCtx, gotID, gotMetadata := orchestrator.resolveConversationContext(ctx, nil)
+
+	if gotID != "" || core.GetConversationID(gotCtx) != "" {
+		t.Fatalf("capacity-rejected conversation leaked: %q", gotID)
+	}
+	if _, present := telemetry.GetBaggage(gotCtx)[MetadataConversationID]; present {
+		t.Fatal("capacity-rejected conversation appeared in baggage")
+	}
+	if _, present := gotMetadata[MetadataConversationID]; present {
+		t.Fatal("capacity-rejected conversation appeared in metadata")
+	}
+	assertConversationRejection(
+		t,
+		tel.records,
+		conversationIDSourceBaggageExact,
+		"item_limit",
+		"conversation-capacity",
+	)
+}
+
+func TestResolveConversationContext_ReusedContextReplacesOldIdentity(t *testing.T) {
+	orchestrator := &AIOrchestrator{telemetry: &conversationCaptureTelemetry{}}
+	firstCtx, firstID, _ := orchestrator.resolveConversationContext(
+		context.Background(),
+		map[string]interface{}{MetadataConversationID: "conversation-one"},
+	)
+	if firstID != "conversation-one" {
+		t.Fatalf("first ID = %q", firstID)
+	}
+
+	secondCtx, secondID, secondMetadata := orchestrator.resolveConversationContext(
+		firstCtx,
+		map[string]interface{}{MetadataConversationID: "conversation-two"},
+	)
+
+	if secondID != "conversation-two" {
+		t.Fatalf("second ID = %q", secondID)
+	}
+	if got := core.GetConversationID(secondCtx); got != secondID {
+		t.Fatalf("core ID = %q, want %q", got, secondID)
+	}
+	if got := telemetry.GetBaggage(secondCtx)[MetadataConversationID]; got != secondID {
+		t.Fatalf("baggage ID = %q, want %q", got, secondID)
+	}
+	if got := secondMetadata[MetadataConversationID]; got != secondID {
+		t.Fatalf("metadata ID = %v, want %q", got, secondID)
+	}
+}
+
+func TestCheckpointMetadataMergeClonesTopLevelMaps(t *testing.T) {
+	nested := map[string]string{"shared": "shallow"}
+	existing := map[string]interface{}{
+		"resume_key":           "resume",
+		MetadataConversationID: "stale",
+	}
+	request := map[string]interface{}{
+		"request_key": "request",
+		"nested":      nested,
+	}
+	ctx := WithMetadata(context.Background(), existing)
+
+	gotCtx := withCheckpointMetadata(ctx, request, "conversation-current")
+	got := GetMetadata(gotCtx)
+
+	if got["resume_key"] != "resume" || got["request_key"] != "request" {
+		t.Fatalf("metadata merge lost values: %v", got)
+	}
+	if got[MetadataConversationID] != "conversation-current" {
+		t.Fatalf("canonical conversation ID = %v", got[MetadataConversationID])
+	}
+
+	got["framework_added"] = "checkpoint-only"
+	request["request_key"] = "caller-mutated"
+	existing["resume_key"] = "caller-mutated"
+	if _, present := request["framework_added"]; present {
+		t.Fatal("checkpoint mutation appeared in request map")
+	}
+	if _, present := existing["framework_added"]; present {
+		t.Fatal("checkpoint mutation appeared in existing context map")
+	}
+	if got["request_key"] != "request" || got["resume_key"] != "resume" {
+		t.Fatalf("caller mutation changed checkpoint metadata: %v", got)
+	}
+	gotNested, ok := got["nested"].(map[string]string)
+	if !ok {
+		t.Fatalf("nested metadata type = %T", got["nested"])
+	}
+	gotNested["shared"] = "mutated-through-clone"
+	if nested["shared"] != "mutated-through-clone" {
+		t.Fatal("metadata clone unexpectedly deep-copied nested application data")
+	}
+}
+
+func TestCheckpointMetadataMergePreservesExistingOnNilRequest(t *testing.T) {
+	existing := map[string]interface{}{"session_id": "session-1"}
+	ctx := WithMetadata(context.Background(), existing)
+
+	got := GetMetadata(withCheckpointMetadata(ctx, nil, ""))
+
+	if got["session_id"] != "session-1" {
+		t.Fatalf("existing resume metadata was lost: %v", got)
+	}
+	got["checkpoint_only"] = true
+	if _, present := existing["checkpoint_only"]; present {
+		t.Fatal("existing caller-owned metadata map was not cloned")
+	}
+}
+
+func TestCreateCheckpoint_DoesNotMutateCallerMetadataMap(t *testing.T) {
+	callerMetadata := map[string]interface{}{"session_id": "session-1"}
+	ctx := withCheckpointMetadata(
+		context.Background(),
+		callerMetadata,
+		"conversation-checkpoint",
+	)
+	traceID, err := trace.TraceIDFromHex("11111111111111111111111111111111")
+	if err != nil {
+		t.Fatalf("TraceIDFromHex() error = %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("2222222222222222")
+	if err != nil {
+		t.Fatalf("SpanIDFromHex() error = %v", err)
+	}
+	ctx = trace.ContextWithSpanContext(ctx, trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID,
+		SpanID:  spanID,
+	}))
+	ctx = WithRequestMode(ctx, RequestModeNonStreaming)
+
+	controller := &DefaultInterruptController{logger: &core.NoOpLogger{}}
+	checkpoint := controller.createCheckpoint(
+		ctx,
+		&RoutingPlan{OriginalRequest: "request"},
+		nil,
+		nil,
+		&InterruptDecision{},
+		InterruptPointPlanGenerated,
+	)
+
+	if checkpoint.UserContext[MetadataConversationID] != "conversation-checkpoint" {
+		t.Fatalf("checkpoint conversation ID = %v", checkpoint.UserContext[MetadataConversationID])
+	}
+	if checkpoint.UserContext["original_trace_id"] != traceID.String() {
+		t.Fatalf("checkpoint trace metadata = %v", checkpoint.UserContext)
+	}
+	if _, present := callerMetadata[MetadataConversationID]; present {
+		t.Fatal("framework conversation ID appeared in caller-owned metadata")
+	}
+	if _, present := callerMetadata["original_trace_id"]; present {
+		t.Fatal("framework trace ID appeared in caller-owned metadata")
+	}
+
+	checkpoint.UserContext["checkpoint_only"] = true
+	callerMetadata["caller_only"] = true
+	if _, present := callerMetadata["checkpoint_only"]; present {
+		t.Fatal("checkpoint mutation appeared in caller-owned metadata")
+	}
+	if _, present := checkpoint.UserContext["caller_only"]; present {
+		t.Fatal("caller mutation appeared in checkpoint metadata")
+	}
+}
+
+func TestStoreExecutionAsync_CapturesTraceAndConversationFromCanonicalContexts(t *testing.T) {
+	orchestrator, store := storeExecutionAsyncFixture(t)
+	traceID, err := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("TraceIDFromHex() error = %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("0123456789abcdef")
+	if err != nil {
+		t.Fatalf("SpanIDFromHex() error = %v", err)
+	}
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(
+		trace.SpanContextConfig{TraceID: traceID, SpanID: spanID, Remote: true},
+	))
+	ctx = telemetry.WithBaggage(ctx,
+		"trace_id", "baggage-trace-must-not-win",
+		"original_request_id", "original-request",
+	)
+	ctx = core.WithConversationID(ctx, "conversation-store")
+
+	orchestrator.storeExecutionAsync(ctx, "request", "request-current", nil, nil, nil)
+	orchestrator.executionWg.Wait()
+
+	stored := lastStored(store)
+	if stored == nil {
+		t.Fatal("execution was not stored")
+	}
+	if stored.TraceID != traceID.String() {
+		t.Fatalf("stored trace ID = %q, want span-context trace %q", stored.TraceID, traceID)
+	}
+	if stored.OriginalRequestID != "original-request" {
+		t.Fatalf("original request ID = %q", stored.OriginalRequestID)
+	}
+	if got := ExecutionConversationID(stored); got != "conversation-store" {
+		t.Fatalf("stored conversation ID = %q", got)
+	}
+}
+
+type failingConversationExecutionStore struct {
+	err error
+}
+
+func (s *failingConversationExecutionStore) Store(context.Context, *StoredExecution) error {
+	return s.err
+}
+func (s *failingConversationExecutionStore) Get(context.Context, string) (*StoredExecution, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *failingConversationExecutionStore) GetByTraceID(context.Context, string) (*StoredExecution, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *failingConversationExecutionStore) SetMetadata(context.Context, string, string, string) error {
+	return errors.New("not implemented")
+}
+func (s *failingConversationExecutionStore) ExtendTTL(context.Context, string, time.Duration) error {
+	return errors.New("not implemented")
+}
+func (s *failingConversationExecutionStore) ListRecent(context.Context, int) ([]ExecutionSummary, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestStoreExecutionAsync_FailureLogIsSanitizedAndCorrelated(t *testing.T) {
+	const sensitiveError = "redis://user:secret@redis.internal:6379/8?conversation_id=raw-secret"
+	traceID, err := trace.TraceIDFromHex("abcdef0123456789abcdef0123456789")
+	if err != nil {
+		t.Fatalf("TraceIDFromHex() error = %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("abcdef0123456789")
+	if err != nil {
+		t.Fatalf("SpanIDFromHex() error = %v", err)
+	}
+	var warningFields map[string]interface{}
+	logger := &mockLogger{
+		warnFunc: func(_ string, fields map[string]interface{}) {
+			warningFields = fields
+		},
+	}
+	orchestrator := &AIOrchestrator{
+		config: DefaultConfig(),
+		executionStore: &failingConversationExecutionStore{
+			err: errors.New(sensitiveError),
+		},
+		logger: logger,
+	}
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(
+		trace.SpanContextConfig{TraceID: traceID, SpanID: spanID},
+	))
+	ctx = core.WithConversationID(ctx, "conversation-log")
+
+	orchestrator.storeExecutionAsync(ctx, "request", "request-log", nil, nil, nil)
+	orchestrator.executionWg.Wait()
+
+	if warningFields == nil {
+		t.Fatal("expected execution-store warning")
+	}
+	if warningFields["operation"] != "execution_store" ||
+		warningFields["request_id"] != "request-log" ||
+		warningFields["error_type"] != "store_write" ||
+		warningFields["trace_id"] != traceID.String() ||
+		warningFields[MetadataConversationID] != "conversation-log" {
+		t.Fatalf("warning fields = %v", warningFields)
+	}
+	safeMessage, _ := warningFields["error"].(string)
+	if safeMessage == "" || strings.Contains(safeMessage, "redis://") ||
+		strings.Contains(safeMessage, "secret") ||
+		strings.Contains(safeMessage, "raw-secret") {
+		t.Fatalf("unsafe execution-store error = %q", safeMessage)
+	}
+}
+
+func findConversationMockSpan(spans []*mockSpan, name string) *mockSpan {
+	for _, span := range spans {
+		if span.name == name {
+			return span
+		}
+	}
+	return nil
+}
+
+func readOnlySpanStringAttribute(
+	span sdktrace.ReadOnlySpan,
+	key string,
+) (string, bool) {
+	for _, attr := range span.Attributes() {
+		if string(attr.Key) == key {
+			return attr.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func TestExecutionConversationAccessors(t *testing.T) {
+	if got := ExecutionConversationID(nil); got != "" {
+		t.Fatalf("nil execution conversation ID = %q", got)
+	}
+	execution := &StoredExecution{
+		Metadata: map[string]string{MetadataConversationID: "conversation-record"},
+	}
+	if got := ExecutionConversationID(execution); got != "conversation-record" {
+		t.Fatalf("execution accessor = %q", got)
+	}
+	summary := ExecutionSummary{
+		Metadata: map[string]string{MetadataConversationID: "conversation-summary"},
+	}
+	if got := ExecutionSummaryConversationID(summary); got != "conversation-summary" {
+		t.Fatalf("summary accessor = %q", got)
+	}
+}
+
+func TestConversationIDBaggageRejectionReasonIsBounded(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "invalid UTF-8",
+			err:  &telemetry.BaggageExactError{Reason: telemetry.BaggageExactInvalidUTF8},
+			want: string(core.ConversationIDValidationInvalidUTF8),
+		},
+		{
+			name: "key too long",
+			err:  &telemetry.BaggageExactError{Reason: telemetry.BaggageExactKeyTooLong},
+			want: string(core.ConversationIDValidationTooLong),
+		},
+		{
+			name: "value too long",
+			err:  &telemetry.BaggageExactError{Reason: telemetry.BaggageExactValueTooLong},
+			want: string(core.ConversationIDValidationTooLong),
+		},
+		{
+			name: "item limit",
+			err:  &telemetry.BaggageExactError{Reason: telemetry.BaggageExactItemLimit},
+			want: "item_limit",
+		},
+		{
+			name: "total size",
+			err:  &telemetry.BaggageExactError{Reason: telemetry.BaggageExactTotalSize},
+			want: "total_size",
+		},
+		{
+			name: "invalid key",
+			err:  &telemetry.BaggageExactError{Reason: telemetry.BaggageExactInvalidKey},
+			want: "invalid_baggage_key",
+		},
+		{
+			name: "unknown error",
+			err:  errors.New("raw backend details"),
+			want: "invalid_baggage_key",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := conversationIDBaggageRejectionReason(test.err); got != test.want {
+				t.Fatalf("reason = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestConversationIDDiagnosticHelpersAreNilSafeAndBounded(t *testing.T) {
+	if got := boundedCoreConversationSource(core.ConversationIDSourceCoreHeader); got != "core_header" {
+		t.Fatalf("header source = %q", got)
+	}
+	if got := boundedCoreConversationSource("unexpected"); got != "core_context" {
+		t.Fatalf("unexpected source = %q", got)
+	}
+	var orchestrator *AIOrchestrator
+	orchestrator.emitConversationIDRejection("metadata", "empty")
+	(&AIOrchestrator{}).emitConversationIDRejection("metadata", "empty")
+}
+
+func TestSafeExecutionStoreError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", err: nil, want: ""},
+		{
+			name: "deadline",
+			err:  fmt.Errorf("wrapped: %w", context.DeadlineExceeded),
+			want: "execution store write timed out",
+		},
+		{
+			name: "canceled",
+			err:  fmt.Errorf("wrapped: %w", context.Canceled),
+			want: "execution store write canceled",
+		},
+		{
+			name: "backend",
+			err:  errors.New("redis://user:secret@host/8?raw=value"),
+			want: "execution store backend write failed",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := safeExecutionStoreError(test.err); got != test.want {
+				t.Fatalf("safe error = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRedisExecutionStore_SetMetadataRejectsReservedConversationIDBeforeIO(t *testing.T) {
+	store := &RedisExecutionDebugStore{}
+	err := store.SetMetadata(
+		context.Background(),
+		"request-1",
+		MetadataConversationID,
+		"conversation-replacement",
+	)
+	if err == nil {
+		t.Fatal("expected reserved metadata validation error")
+	}
+}
+
+func hasMetricExclusionProperty(member baggage.Member) bool {
+	for _, property := range member.Properties() {
+		value, ok := property.Value()
+		if property.Key() == "truvag3_metric_label" && ok && value == "false" {
+			return true
+		}
+	}
+	return false
+}
+
+func assertConversationRejection(
+	t *testing.T,
+	records []conversationMetricRecord,
+	source string,
+	reason string,
+	rejectedValue string,
+) {
+	t.Helper()
+	if len(records) != 1 {
+		t.Fatalf("rejection records = %+v, want exactly one", records)
+	}
+	record := records[0]
+	if record.name != conversationIDRejectionMetric || record.value != 1 {
+		t.Fatalf("rejection metric = %+v", record)
+	}
+	wantLabels := map[string]string{
+		"source": source,
+		"reason": reason,
+		"module": telemetry.ModuleOrchestration,
+	}
+	if len(record.labels) != len(wantLabels) {
+		t.Fatalf("rejection labels = %v, want %v", record.labels, wantLabels)
+	}
+	for key, want := range wantLabels {
+		if got := record.labels[key]; got != want {
+			t.Fatalf("rejection label %s = %q, want %q", key, got, want)
+		}
+	}
+	if strings.Contains(fmt.Sprint(record), rejectedValue) {
+		t.Fatalf("rejection metric exposed raw value %q: %+v", rejectedValue, record)
+	}
+}

--- a/orchestration/conversation_debug_persistence_test.go
+++ b/orchestration/conversation_debug_persistence_test.go
@@ -1,0 +1,368 @@
+package orchestration
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/truvaagents/truva-g3/core"
+	"github.com/truvaagents/truva-g3/telemetry"
+)
+
+func TestLLMDebugConversationID(t *testing.T) {
+	if got := LLMDebugConversationID(nil); got != "" {
+		t.Fatalf("nil record conversation ID = %q", got)
+	}
+
+	var historical LLMDebugRecord
+	if err := json.Unmarshal([]byte(`{"request_id":"historical"}`), &historical); err != nil {
+		t.Fatalf("historical record unmarshal: %v", err)
+	}
+	if got := LLMDebugConversationID(&historical); got != "" {
+		t.Fatalf("historical record conversation ID = %q", got)
+	}
+
+	current := &LLMDebugRecord{Metadata: map[string]string{
+		MetadataConversationID: "conversation-current",
+	}}
+	if got := LLMDebugConversationID(current); got != "conversation-current" {
+		t.Fatalf("current record conversation ID = %q", got)
+	}
+}
+
+func TestRedisLLMDebugStoreOldStringConversationCompatibility(t *testing.T) {
+	_, store := setupRedisLLMDebugTestStore(t)
+	record := &LLMDebugRecord{
+		RequestID: "request-old-string",
+		Metadata: map[string]string{
+			MetadataConversationID: "conversation-old-string",
+		},
+	}
+	serialized, err := store.serialize(record)
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	if err := store.client.Set(
+		context.Background(),
+		llmDebugKeyPrefix+record.RequestID,
+		serialized,
+		defaultDebugTTL,
+	).Err(); err != nil {
+		t.Fatalf("seed old record: %v", err)
+	}
+
+	got, err := store.GetRecord(context.Background(), record.RequestID)
+	if err != nil {
+		t.Fatalf("GetRecord: %v", err)
+	}
+	if conversationID := LLMDebugConversationID(got); conversationID != "conversation-old-string" {
+		t.Fatalf("old-string conversation ID = %q", conversationID)
+	}
+}
+
+func TestLLMDebugStoresConversationFirstValidWriterWins(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(t *testing.T) LLMDebugStore
+	}{
+		{
+			name: "memory",
+			store: func(*testing.T) LLMDebugStore {
+				return NewMemoryLLMDebugStore()
+			},
+		},
+		{
+			name: "redis",
+			store: func(t *testing.T) LLMDebugStore {
+				_, store := setupRedisLLMDebugTestStore(t)
+				return store
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := test.store(t)
+			requestID := "request-first-valid"
+			interaction := LLMInteraction{Type: "plan_generation", Success: true}
+
+			if err := store.RecordInteraction(context.Background(), requestID, interaction); err != nil {
+				t.Fatalf("empty first write: %v", err)
+			}
+
+			baggageCtx := telemetry.WithBaggage(
+				context.Background(),
+				MetadataConversationID,
+				"conversation-first",
+			)
+			if err := store.RecordInteraction(baggageCtx, requestID, interaction); err != nil {
+				t.Fatalf("valid backfill: %v", err)
+			}
+
+			differentCtx := core.WithConversationID(
+				context.Background(),
+				"conversation-different",
+			)
+			if err := store.RecordInteraction(differentCtx, requestID, interaction); err != nil {
+				t.Fatalf("later different write: %v", err)
+			}
+
+			invalidCoreCtx := telemetry.WithBaggage(
+				context.Background(),
+				MetadataConversationID,
+				"conversation-fallback-must-not-win",
+			)
+			invalidCoreCtx = core.WithConversationID(invalidCoreCtx, "invalid conversation")
+			if err := store.RecordInteraction(invalidCoreCtx, requestID, interaction); err != nil {
+				t.Fatalf("later invalid write: %v", err)
+			}
+
+			record, err := store.GetRecord(context.Background(), requestID)
+			if err != nil {
+				t.Fatalf("GetRecord: %v", err)
+			}
+			if got := LLMDebugConversationID(record); got != "conversation-first" {
+				t.Fatalf("conversation ID = %q, want first valid writer", got)
+			}
+		})
+	}
+}
+
+func TestLLMDebugStoresCoreConversationWinsOverBaggage(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(t *testing.T) LLMDebugStore
+	}{
+		{
+			name: "memory",
+			store: func(*testing.T) LLMDebugStore {
+				return NewMemoryLLMDebugStore()
+			},
+		},
+		{
+			name: "redis",
+			store: func(t *testing.T) LLMDebugStore {
+				_, store := setupRedisLLMDebugTestStore(t)
+				return store
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := test.store(t)
+			ctx := telemetry.WithBaggage(
+				context.Background(),
+				MetadataConversationID,
+				"conversation-baggage",
+			)
+			ctx = core.WithConversationID(ctx, "conversation-core")
+			if err := store.RecordInteraction(
+				ctx,
+				"request-precedence",
+				LLMInteraction{Type: "plan_generation", Success: true},
+			); err != nil {
+				t.Fatalf("RecordInteraction: %v", err)
+			}
+			record, err := store.GetRecord(context.Background(), "request-precedence")
+			if err != nil {
+				t.Fatalf("GetRecord: %v", err)
+			}
+			if got := LLMDebugConversationID(record); got != "conversation-core" {
+				t.Fatalf("conversation ID = %q, want core candidate", got)
+			}
+		})
+	}
+}
+
+func TestLLMDebugStoresInvalidCoreBlocksBaggageFallback(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(t *testing.T) LLMDebugStore
+	}{
+		{
+			name: "memory",
+			store: func(*testing.T) LLMDebugStore {
+				return NewMemoryLLMDebugStore()
+			},
+		},
+		{
+			name: "redis",
+			store: func(t *testing.T) LLMDebugStore {
+				_, store := setupRedisLLMDebugTestStore(t)
+				return store
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := test.store(t)
+			ctx := telemetry.WithBaggage(
+				context.Background(),
+				MetadataConversationID,
+				"conversation-baggage",
+			)
+			ctx = core.WithConversationID(ctx, "invalid conversation")
+			if err := store.RecordInteraction(
+				ctx,
+				"request-invalid-precedence",
+				LLMInteraction{Type: "plan_generation", Success: true},
+			); err != nil {
+				t.Fatalf("RecordInteraction: %v", err)
+			}
+			record, err := store.GetRecord(
+				context.Background(),
+				"request-invalid-precedence",
+			)
+			if err != nil {
+				t.Fatalf("GetRecord: %v", err)
+			}
+			if got := LLMDebugConversationID(record); got != "" {
+				t.Fatalf("invalid core candidate fell through to baggage: %q", got)
+			}
+		})
+	}
+}
+
+func TestLLMDebugStoresRejectReservedConversationMetadata(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(t *testing.T) LLMDebugStore
+	}{
+		{
+			name: "memory",
+			store: func(*testing.T) LLMDebugStore {
+				return NewMemoryLLMDebugStore()
+			},
+		},
+		{
+			name: "redis",
+			store: func(t *testing.T) LLMDebugStore {
+				_, store := setupRedisLLMDebugTestStore(t)
+				return store
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := test.store(t)
+			ctx := core.WithConversationID(context.Background(), "conversation-original")
+			if err := store.RecordInteraction(
+				ctx,
+				"request-metadata",
+				LLMInteraction{Type: "plan_generation", Success: true},
+			); err != nil {
+				t.Fatalf("RecordInteraction: %v", err)
+			}
+			if err := store.SetMetadata(
+				context.Background(),
+				"request-metadata",
+				MetadataConversationID,
+				"conversation-replacement",
+			); err == nil {
+				t.Fatal("expected reserved metadata error")
+			}
+			if err := store.SetMetadata(
+				context.Background(),
+				"request-metadata",
+				"investigation",
+				"keep",
+			); err != nil {
+				t.Fatalf("unrelated SetMetadata: %v", err)
+			}
+			record, err := store.GetRecord(context.Background(), "request-metadata")
+			if err != nil {
+				t.Fatalf("GetRecord: %v", err)
+			}
+			if got := LLMDebugConversationID(record); got != "conversation-original" {
+				t.Fatalf("conversation ID = %q", got)
+			}
+			if record.Metadata["investigation"] != "keep" {
+				t.Fatalf("investigation metadata = %v", record.Metadata)
+			}
+		})
+	}
+}
+
+func TestLLMDebugRedisWritersUseCompatibleConversationField(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run: %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	orchestrationStore := &RedisLLMDebugStore{
+		client:   redis.NewClient(&redis.Options{Addr: mr.Addr()}),
+		logger:   &core.NoOpLogger{},
+		ttl:      defaultDebugTTL,
+		errorTTL: errorDebugTTL,
+	}
+	recorder, err := telemetry.NewRedisLLMCallRecorder(
+		telemetry.WithRecorderRedisURL("redis://"+mr.Addr()),
+		telemetry.WithRecorderRedisDB(0),
+	)
+	if err != nil {
+		t.Fatalf("NewRedisLLMCallRecorder: %v", err)
+	}
+	t.Cleanup(func() { _ = recorder.Close() })
+
+	ctx := core.WithConversationID(context.Background(), "conversation-format")
+	if err := orchestrationStore.RecordInteraction(
+		ctx,
+		"request-orchestration-writer",
+		LLMInteraction{Type: "plan_generation", Success: true},
+	); err != nil {
+		t.Fatalf("orchestration writer: %v", err)
+	}
+	if err := recorder.RecordLLMCall(
+		ctx,
+		"request-telemetry-writer",
+		telemetry.LLMCallRecord{CallType: "agent_llm_call", Success: true},
+	); err != nil {
+		t.Fatalf("telemetry writer: %v", err)
+	}
+
+	for _, requestID := range []string{
+		"request-orchestration-writer",
+		"request-telemetry-writer",
+	} {
+		metaKey := llmDebugKeyPrefix + requestID + llmDebugMetaSuffix
+		if got := mr.HGet(metaKey, "meta:"+MetadataConversationID); got != "conversation-format" {
+			t.Fatalf("%s conversation field = %q", requestID, got)
+		}
+		record, getErr := orchestrationStore.GetRecord(context.Background(), requestID)
+		if getErr != nil {
+			t.Fatalf("GetRecord(%s): %v", requestID, getErr)
+		}
+		if got := LLMDebugConversationID(record); got != "conversation-format" {
+			t.Fatalf("%s typed conversation ID = %q", requestID, got)
+		}
+	}
+}
+
+func TestNoOpLLMDebugConversationDefaultsRemainSafe(t *testing.T) {
+	store := NewNoOpLLMDebugStore()
+	if err := store.RecordInteraction(
+		context.Background(),
+		"request-noop",
+		LLMInteraction{},
+	); err != nil {
+		t.Fatalf("RecordInteraction: %v", err)
+	}
+	if err := store.SetMetadata(
+		context.Background(),
+		"request-noop",
+		MetadataConversationID,
+		"conversation-noop",
+	); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	record, err := store.GetRecord(context.Background(), "request-noop")
+	if err == nil || LLMDebugConversationID(record) != "" {
+		t.Fatalf("NoOp GetRecord = (%v, %v)", record, err)
+	}
+}

--- a/orchestration/conversation_history_additional_test.go
+++ b/orchestration/conversation_history_additional_test.go
@@ -487,7 +487,7 @@ func TestPrepareKnownEnrichments_UsesPreparedLegacyTextAndIgnoresInvalidTurnPayl
 	enrichments := map[string]interface{}{}
 	metadata := map[string]interface{}{
 		MetadataConversationTurns:          []interface{}{"bad"},
-		MetadataConversationSessionKey:     "session-1",
+		MetadataConversationID:             "conversation-1",
 		core.EnrichmentConversationHistory: "legacy history",
 	}
 

--- a/orchestration/execution_conversation_store_test.go
+++ b/orchestration/execution_conversation_store_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func newRedisExecutionConversationTestStore(
-	t *testing.T,
+	t testing.TB,
 	config ExecutionStoreConfig,
 ) (*miniredis.Miniredis, *RedisExecutionDebugStore) {
 	t.Helper()
@@ -37,6 +38,8 @@ func newRedisExecutionConversationTestStore(
 		indexScanLimit: config.ConversationIndexScanLimit,
 	}
 }
+
+var benchmarkConversationSummariesSink []ExecutionSummary
 
 func executionWithConversation(
 	requestID string,
@@ -1174,6 +1177,262 @@ func TestDirectConversationIndexFailureIsNonFatalNilSafeAndSanitized(t *testing.
 	if err := store.Store(context.Background(), execution); err != nil {
 		t.Fatalf("nil logger made optional index failure fatal: %v", err)
 	}
+}
+
+type benchmarkCountingStorageProvider struct {
+	*mockStorageProvider
+	commandCount  uint64
+	preserveStale bool
+}
+
+func (p *benchmarkCountingStorageProvider) Get(
+	ctx context.Context,
+	key string,
+) (string, error) {
+	p.commandCount++
+	return p.mockStorageProvider.Get(ctx, key)
+}
+
+func (p *benchmarkCountingStorageProvider) ListByScoreDesc(
+	ctx context.Context,
+	key string,
+	min string,
+	max string,
+	offset int64,
+	count int64,
+) ([]string, error) {
+	p.commandCount++
+	return p.mockStorageProvider.ListByScoreDesc(
+		ctx,
+		key,
+		min,
+		max,
+		offset,
+		count,
+	)
+}
+
+func (p *benchmarkCountingStorageProvider) RemoveFromIndex(
+	ctx context.Context,
+	key string,
+	members ...string,
+) error {
+	p.commandCount++
+	if p.preserveStale {
+		return nil
+	}
+	return p.mockStorageProvider.RemoveFromIndex(ctx, key, members...)
+}
+
+type benchmarkRedisCommandHook struct {
+	commandCount  atomic.Uint64
+	preserveStale bool
+}
+
+func (h *benchmarkRedisCommandHook) BeforeProcess(
+	ctx context.Context,
+	cmd redis.Cmder,
+) (context.Context, error) {
+	h.commandCount.Add(1)
+	h.redirectStaleCleanup(cmd)
+	return ctx, nil
+}
+
+func (*benchmarkRedisCommandHook) AfterProcess(context.Context, redis.Cmder) error {
+	return nil
+}
+
+func (h *benchmarkRedisCommandHook) BeforeProcessPipeline(
+	ctx context.Context,
+	cmds []redis.Cmder,
+) (context.Context, error) {
+	h.commandCount.Add(uint64(len(cmds)))
+	for _, cmd := range cmds {
+		h.redirectStaleCleanup(cmd)
+	}
+	return ctx, nil
+}
+
+func (*benchmarkRedisCommandHook) AfterProcessPipeline(
+	context.Context,
+	[]redis.Cmder,
+) error {
+	return nil
+}
+
+func (h *benchmarkRedisCommandHook) redirectStaleCleanup(cmd redis.Cmder) {
+	if !h.preserveStale || cmd.Name() != "zrem" {
+		return
+	}
+	args := cmd.Args()
+	if len(args) > 1 {
+		args[1] = fmt.Sprint(args[1]) + ":benchmark-noop"
+	}
+}
+
+func BenchmarkConversationExecutionLookup(b *testing.B) {
+	b.Run("provider/query_limit", benchmarkProviderConversationQueryLimit)
+	b.Run("provider/stale_scan_ceiling", benchmarkProviderConversationStaleScanCeiling)
+	b.Run("direct_redis/query_limit", benchmarkDirectConversationQueryLimit)
+	b.Run("direct_redis/stale_scan_ceiling", benchmarkDirectConversationStaleScanCeiling)
+}
+
+func benchmarkProviderConversationQueryLimit(b *testing.B) {
+	config := DefaultExecutionStoreConfig()
+	provider := &benchmarkCountingStorageProvider{
+		mockStorageProvider: newMockStorageProvider(),
+	}
+	store := NewExecutionStoreWithProvider(provider, config, nil)
+	lister := store.(ConversationExecutionLister)
+	conversationID := "conversation-provider-query-benchmark"
+	base := time.Unix(1_700_000_000, 0)
+	for i := 0; i < config.ConversationQueryLimit; i++ {
+		if err := store.Store(
+			context.Background(),
+			executionWithConversation(
+				fmt.Sprintf("provider-live-%04d", i),
+				conversationID,
+				base.Add(time.Duration(i)*time.Second),
+			),
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
+	provider.commandCount = 0
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(config.ConversationQueryLimit), "records/op")
+	b.ResetTimer()
+	var got []ExecutionSummary
+	for i := 0; i < b.N; i++ {
+		var err error
+		got, err = lister.ListByConversationID(
+			context.Background(),
+			conversationID,
+			config.ConversationQueryLimit,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	benchmarkConversationSummariesSink = got
+	b.ReportMetric(float64(provider.commandCount)/float64(b.N), "provider_cmds/op")
+}
+
+func benchmarkProviderConversationStaleScanCeiling(b *testing.B) {
+	config := DefaultExecutionStoreConfig()
+	provider := &benchmarkCountingStorageProvider{
+		mockStorageProvider: newMockStorageProvider(),
+		preserveStale:       true,
+	}
+	store := NewExecutionStoreWithProvider(provider, config, nil)
+	lister := store.(ConversationExecutionLister)
+	conversationID := "conversation-provider-stale-benchmark"
+	indexKey := executionConversationIndexKey(config.KeyPrefix, conversationID)
+	for i := 0; i < config.ConversationIndexScanLimit; i++ {
+		if err := provider.AddToIndex(
+			context.Background(),
+			indexKey,
+			float64(i),
+			fmt.Sprintf("provider-stale-%04d", i),
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(config.ConversationIndexScanLimit), "records_scanned/op")
+	b.ResetTimer()
+	var got []ExecutionSummary
+	for i := 0; i < b.N; i++ {
+		var err error
+		got, err = lister.ListByConversationID(
+			context.Background(),
+			conversationID,
+			config.ConversationQueryLimit,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	benchmarkConversationSummariesSink = got
+	b.ReportMetric(float64(provider.commandCount)/float64(b.N), "provider_cmds/op")
+}
+
+func benchmarkDirectConversationQueryLimit(b *testing.B) {
+	config := DefaultExecutionStoreConfig()
+	_, store := newRedisExecutionConversationTestStore(b, config)
+	conversationID := "conversation-direct-query-benchmark"
+	base := time.Unix(1_700_000_000, 0)
+	for i := 0; i < config.ConversationQueryLimit; i++ {
+		if err := store.Store(
+			context.Background(),
+			executionWithConversation(
+				fmt.Sprintf("direct-live-%04d", i),
+				conversationID,
+				base.Add(time.Duration(i)*time.Second),
+			),
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
+	hook := &benchmarkRedisCommandHook{}
+	store.client.AddHook(hook)
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(config.ConversationQueryLimit), "records/op")
+	b.ResetTimer()
+	var got []ExecutionSummary
+	for i := 0; i < b.N; i++ {
+		var err error
+		got, err = store.ListByConversationID(
+			context.Background(),
+			conversationID,
+			config.ConversationQueryLimit,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	benchmarkConversationSummariesSink = got
+	b.ReportMetric(float64(hook.commandCount.Load())/float64(b.N), "redis_cmds/op")
+}
+
+func benchmarkDirectConversationStaleScanCeiling(b *testing.B) {
+	config := DefaultExecutionStoreConfig()
+	_, store := newRedisExecutionConversationTestStore(b, config)
+	conversationID := "conversation-direct-stale-benchmark"
+	indexKey := store.conversationIndexKey(conversationID)
+	members := make([]*redis.Z, 0, config.ConversationIndexScanLimit)
+	for i := 0; i < config.ConversationIndexScanLimit; i++ {
+		members = append(members, &redis.Z{
+			Score:  float64(i),
+			Member: fmt.Sprintf("direct-stale-%04d", i),
+		})
+	}
+	if err := store.client.ZAdd(context.Background(), indexKey, members...).Err(); err != nil {
+		b.Fatal(err)
+	}
+	hook := &benchmarkRedisCommandHook{preserveStale: true}
+	store.client.AddHook(hook)
+
+	b.ReportAllocs()
+	b.ReportMetric(float64(config.ConversationIndexScanLimit), "records_scanned/op")
+	b.ResetTimer()
+	var got []ExecutionSummary
+	for i := 0; i < b.N; i++ {
+		var err error
+		got, err = store.ListByConversationID(
+			context.Background(),
+			conversationID,
+			config.ConversationQueryLimit,
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	benchmarkConversationSummariesSink = got
+	b.ReportMetric(float64(hook.commandCount.Load())/float64(b.N), "redis_cmds/op")
 }
 
 type conversationTTLFailureHook struct {

--- a/orchestration/execution_conversation_store_test.go
+++ b/orchestration/execution_conversation_store_test.go
@@ -1,0 +1,1248 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/truvaagents/truva-g3/core"
+)
+
+func newRedisExecutionConversationTestStore(
+	t *testing.T,
+	config ExecutionStoreConfig,
+) (*miniredis.Miniredis, *RedisExecutionDebugStore) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run: %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	config = normalizeExecutionStoreConfig(config)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return mr, &RedisExecutionDebugStore{
+		client:         client,
+		logger:         &core.NoOpLogger{},
+		keyPrefix:      config.KeyPrefix,
+		ttl:            config.TTL,
+		errorTTL:       config.ErrorTTL,
+		queryLimit:     config.ConversationQueryLimit,
+		indexScanLimit: config.ConversationIndexScanLimit,
+	}
+}
+
+func executionWithConversation(
+	requestID string,
+	conversationID string,
+	createdAt time.Time,
+) *StoredExecution {
+	execution := sampleExecution(requestID, true)
+	execution.CreatedAt = createdAt
+	execution.Metadata = map[string]string{
+		MetadataConversationID: conversationID,
+		"investigation":        "preserved",
+	}
+	return execution
+}
+
+func TestExecutionStoresSanitizeInvalidConversationWithoutMutatingCaller(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(t *testing.T) (ExecutionStore, func() int)
+	}{
+		{
+			name: "provider",
+			store: func(*testing.T) (ExecutionStore, func() int) {
+				provider := newMockStorageProvider()
+				store := NewExecutionStoreWithProvider(
+					provider,
+					DefaultExecutionStoreConfig(),
+					nil,
+				)
+				return store, func() int {
+					count := 0
+					for key := range provider.indexes {
+						if strings.Contains(key, ":conversation:") {
+							count++
+						}
+					}
+					return count
+				}
+			},
+		},
+		{
+			name: "direct redis",
+			store: func(t *testing.T) (ExecutionStore, func() int) {
+				mr, store := newRedisExecutionConversationTestStore(
+					t,
+					DefaultExecutionStoreConfig(),
+				)
+				return store, func() int {
+					count := 0
+					for _, key := range mr.Keys() {
+						if strings.Contains(key, ":conversation:") {
+							count++
+						}
+					}
+					return count
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store, conversationIndexCount := test.store(t)
+			execution := executionWithConversation(
+				"request-invalid-conversation",
+				"invalid conversation",
+				time.Now(),
+			)
+			callerMetadata := execution.Metadata
+
+			if err := store.Store(context.Background(), execution); err != nil {
+				t.Fatalf("Store: %v", err)
+			}
+			if execution.Metadata[MetadataConversationID] != "invalid conversation" {
+				t.Fatalf("caller metadata was mutated: %v", execution.Metadata)
+			}
+			if execution.Metadata != nil &&
+				fmt.Sprintf("%p", execution.Metadata) != fmt.Sprintf("%p", callerMetadata) {
+				t.Fatal("caller metadata map identity changed")
+			}
+
+			stored, err := store.Get(context.Background(), execution.RequestID)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if _, present := stored.Metadata[MetadataConversationID]; present {
+				t.Fatalf("invalid conversation persisted: %v", stored.Metadata)
+			}
+			if stored.Metadata["investigation"] != "preserved" {
+				t.Fatalf("unrelated metadata lost: %v", stored.Metadata)
+			}
+			if got := conversationIndexCount(); got != 0 {
+				t.Fatalf("conversation index count = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestRedisExecutionUpdatePreservesStoredConversationIdentity(t *testing.T) {
+	_, store := newRedisExecutionConversationTestStore(
+		t,
+		DefaultExecutionStoreConfig(),
+	)
+	original := executionWithConversation(
+		"request-update-identity",
+		"conversation-original",
+		time.Now(),
+	)
+	if err := store.Store(context.Background(), original); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	update := executionWithConversation(
+		"request-update-identity",
+		"conversation-replacement",
+		time.Now().Add(time.Minute),
+	)
+	if err := store.Update(context.Background(), update.RequestID, update); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := ExecutionConversationID(update); got != "conversation-replacement" {
+		t.Fatalf("caller update was mutated: %q", got)
+	}
+
+	stored, err := store.Get(context.Background(), update.RequestID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got := ExecutionConversationID(stored); got != "conversation-original" {
+		t.Fatalf("stored conversation was rewritten: %q", got)
+	}
+}
+
+func TestConversationExecutionListerOrderingIsolationAndHierarchy(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(t *testing.T) ExecutionStore
+	}{
+		{
+			name: "provider",
+			store: func(*testing.T) ExecutionStore {
+				return NewExecutionStoreWithProvider(
+					newMockStorageProvider(),
+					DefaultExecutionStoreConfig(),
+					nil,
+				)
+			},
+		},
+		{
+			name: "direct redis",
+			store: func(t *testing.T) ExecutionStore {
+				_, store := newRedisExecutionConversationTestStore(
+					t,
+					DefaultExecutionStoreConfig(),
+				)
+				return store
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := test.store(t)
+			lister, ok := store.(ConversationExecutionLister)
+			if !ok {
+				t.Fatalf("%T does not implement ConversationExecutionLister", store)
+			}
+
+			base := time.Now().Add(-time.Hour)
+			executions := []*StoredExecution{
+				executionWithConversation("turn-1", "conversation-a", base),
+				executionWithConversation("turn-other", "conversation-b", base.Add(time.Minute)),
+				executionWithConversation("turn-2", "conversation-a", base.Add(2*time.Minute)),
+				executionWithConversation("turn-3", "conversation-a", base.Add(3*time.Minute)),
+			}
+			executions[1].OriginalRequestID = "turn-other"
+			executions[2].OriginalRequestID = "turn-1"
+			executions[3].OriginalRequestID = "turn-1"
+			for _, execution := range executions {
+				if err := store.Store(context.Background(), execution); err != nil {
+					t.Fatalf("Store(%s): %v", execution.RequestID, err)
+				}
+			}
+
+			summaries, err := lister.ListByConversationID(
+				context.Background(),
+				"conversation-a",
+				10,
+			)
+			if err != nil {
+				t.Fatalf("ListByConversationID: %v", err)
+			}
+			want := []string{"turn-1", "turn-2", "turn-3"}
+			if len(summaries) != len(want) {
+				t.Fatalf("summary count = %d, want %d", len(summaries), len(want))
+			}
+			for i, summary := range summaries {
+				if summary.RequestID != want[i] {
+					t.Fatalf("summary[%d] = %q, want %q", i, summary.RequestID, want[i])
+				}
+				if ExecutionSummaryConversationID(summary) != "conversation-a" {
+					t.Fatalf("cross-contaminated summary: %+v", summary)
+				}
+				if i > 0 && summary.OriginalRequestID != "turn-1" {
+					t.Fatalf("hierarchy lost: %+v", summary)
+				}
+			}
+		})
+	}
+}
+
+func TestConversationExecutionListerValidatesBeforeBackendAccess(t *testing.T) {
+	provider := newMockStorageProvider()
+	provider.listByScoreDescErr = errors.New("backend must not be called")
+	providerStore := NewExecutionStoreWithProvider(
+		provider,
+		DefaultExecutionStoreConfig(),
+		nil,
+	).(ConversationExecutionLister)
+	directStore := (&RedisExecutionDebugStore{}).ListByConversationID
+
+	invalidIDs := []string{
+		"",
+		"invalid conversation",
+		strings.Repeat("x", core.MaxConversationIDLength+1),
+		"invalid,conversation",
+	}
+	for _, conversationID := range invalidIDs {
+		t.Run(fmt.Sprintf("%q", conversationID), func(t *testing.T) {
+			if _, err := providerStore.ListByConversationID(
+				context.Background(),
+				conversationID,
+				10,
+			); err == nil || strings.Contains(err.Error(), "backend must not be called") {
+				t.Fatalf("provider validation error = %v", err)
+			}
+			if _, err := directStore(
+				context.Background(),
+				conversationID,
+				10,
+			); err == nil {
+				t.Fatal("direct store accepted invalid conversation ID")
+			}
+		})
+	}
+}
+
+func TestConversationExecutionListerClampsLimits(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(t *testing.T, config ExecutionStoreConfig) ExecutionStore
+	}{
+		{
+			name: "provider",
+			store: func(_ *testing.T, config ExecutionStoreConfig) ExecutionStore {
+				return NewExecutionStoreWithProvider(newMockStorageProvider(), config, nil)
+			},
+		},
+		{
+			name: "direct redis",
+			store: func(t *testing.T, config ExecutionStoreConfig) ExecutionStore {
+				_, store := newRedisExecutionConversationTestStore(t, config)
+				return store
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := DefaultExecutionStoreConfig()
+			config.ConversationQueryLimit = 2
+			store := test.store(t, config)
+			lister := store.(ConversationExecutionLister)
+			base := time.Now().Add(-time.Hour)
+			for i := 0; i < 4; i++ {
+				execution := executionWithConversation(
+					fmt.Sprintf("turn-%d", i),
+					"conversation-limit",
+					base.Add(time.Duration(i)*time.Minute),
+				)
+				if err := store.Store(context.Background(), execution); err != nil {
+					t.Fatalf("Store: %v", err)
+				}
+			}
+
+			for _, limit := range []int{0, 100} {
+				summaries, err := lister.ListByConversationID(
+					context.Background(),
+					"conversation-limit",
+					limit,
+				)
+				if err != nil {
+					t.Fatalf("ListByConversationID(%d): %v", limit, err)
+				}
+				if len(summaries) != 2 {
+					t.Fatalf("limit %d returned %d summaries, want 2", limit, len(summaries))
+				}
+			}
+		})
+	}
+}
+
+func TestProviderConversationIndexStaleCleanupHonorsScanCeiling(t *testing.T) {
+	provider := newMockStorageProvider()
+	config := DefaultExecutionStoreConfig()
+	config.ConversationQueryLimit = 2
+	config.ConversationIndexScanLimit = 5
+	store := NewExecutionStoreWithProvider(provider, config, nil)
+	lister := store.(ConversationExecutionLister)
+	conversationID := "conversation-stale"
+	indexKey := executionConversationIndexKey(config.KeyPrefix, conversationID)
+	base := time.Now().Add(-time.Hour)
+
+	for i := 0; i < 2; i++ {
+		execution := executionWithConversation(
+			fmt.Sprintf("live-%d", i),
+			conversationID,
+			base.Add(time.Duration(i)*time.Minute),
+		)
+		if err := store.Store(context.Background(), execution); err != nil {
+			t.Fatalf("Store: %v", err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		if err := provider.AddToIndex(
+			context.Background(),
+			indexKey,
+			float64(base.Add(time.Duration(10+i)*time.Minute).UnixNano()),
+			fmt.Sprintf("stale-%d", i),
+		); err != nil {
+			t.Fatalf("AddToIndex: %v", err)
+		}
+	}
+
+	summaries, err := lister.ListByConversationID(
+		context.Background(),
+		conversationID,
+		2,
+	)
+	if err != nil {
+		t.Fatalf("ListByConversationID: %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("live summaries = %d, want 2", len(summaries))
+	}
+	for i := 0; i < 3; i++ {
+		if _, present := provider.indexes[indexKey][fmt.Sprintf("stale-%d", i)]; present {
+			t.Fatalf("stale-%d was not pruned", i)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := store.Get(context.Background(), fmt.Sprintf("live-%d", i)); err != nil {
+			t.Fatalf("cleanup modified live execution: %v", err)
+		}
+	}
+
+	config.ConversationIndexScanLimit = 2
+	limitedProvider := newMockStorageProvider()
+	limitedStore := NewExecutionStoreWithProvider(limitedProvider, config, nil)
+	limitedLister := limitedStore.(ConversationExecutionLister)
+	if err := limitedStore.Store(
+		context.Background(),
+		executionWithConversation("live-beyond-scan", conversationID, base),
+	); err != nil {
+		t.Fatalf("limited Store: %v", err)
+	}
+	limitedIndexKey := executionConversationIndexKey(config.KeyPrefix, conversationID)
+	for i := 0; i < 3; i++ {
+		_ = limitedProvider.AddToIndex(
+			context.Background(),
+			limitedIndexKey,
+			float64(base.Add(time.Duration(10+i)*time.Minute).UnixNano()),
+			fmt.Sprintf("limited-stale-%d", i),
+		)
+	}
+	limited, err := limitedLister.ListByConversationID(
+		context.Background(),
+		conversationID,
+		1,
+	)
+	if err != nil {
+		t.Fatalf("limited ListByConversationID: %v", err)
+	}
+	if len(limited) != 0 {
+		t.Fatalf("scan ceiling was bypassed: %+v", limited)
+	}
+	staleRemaining := 0
+	for member := range limitedProvider.indexes[limitedIndexKey] {
+		if strings.HasPrefix(member, "limited-stale-") {
+			staleRemaining++
+		}
+	}
+	if staleRemaining != 1 {
+		t.Fatalf("cleanup exceeded scan ceiling: %d stale remain, want 1", staleRemaining)
+	}
+}
+
+func TestDirectConversationIndexStaleCleanupHonorsScanCeiling(t *testing.T) {
+	config := DefaultExecutionStoreConfig()
+	config.ConversationQueryLimit = 2
+	config.ConversationIndexScanLimit = 5
+	mr, store := newRedisExecutionConversationTestStore(t, config)
+	conversationID := "conversation-direct-stale"
+	indexKey := store.conversationIndexKey(conversationID)
+	base := time.Now().Add(-time.Hour)
+
+	for i := 0; i < 2; i++ {
+		execution := executionWithConversation(
+			fmt.Sprintf("direct-live-%d", i),
+			conversationID,
+			base.Add(time.Duration(i)*time.Minute),
+		)
+		if err := store.Store(context.Background(), execution); err != nil {
+			t.Fatalf("Store: %v", err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		if err := store.client.ZAdd(context.Background(), indexKey, &redis.Z{
+			Score:  float64(base.Add(-time.Duration(10-i) * time.Minute).UnixNano()),
+			Member: fmt.Sprintf("direct-stale-%d", i),
+		}).Err(); err != nil {
+			t.Fatalf("seed stale member: %v", err)
+		}
+	}
+
+	summaries, err := store.ListByConversationID(
+		context.Background(),
+		conversationID,
+		2,
+	)
+	if err != nil {
+		t.Fatalf("ListByConversationID: %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("live summaries = %d, want 2", len(summaries))
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := store.client.ZScore(
+			context.Background(),
+			indexKey,
+			fmt.Sprintf("direct-stale-%d", i),
+		).Result(); err != redis.Nil {
+			t.Fatalf("direct-stale-%d was not pruned", i)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if !mr.Exists(store.recordKey(fmt.Sprintf("direct-live-%d", i))) {
+			t.Fatalf("cleanup removed direct-live-%d record", i)
+		}
+	}
+
+	config.ConversationIndexScanLimit = 2
+	_, limitedStore := newRedisExecutionConversationTestStore(t, config)
+	limitedConversationID := "conversation-direct-scan-limit"
+	limitedIndexKey := limitedStore.conversationIndexKey(limitedConversationID)
+	if err := limitedStore.Store(
+		context.Background(),
+		executionWithConversation(
+			"direct-live-beyond-scan",
+			limitedConversationID,
+			base,
+		),
+	); err != nil {
+		t.Fatalf("limited Store: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		_ = limitedStore.client.ZAdd(context.Background(), limitedIndexKey, &redis.Z{
+			Score:  float64(base.Add(-time.Duration(10-i) * time.Minute).UnixNano()),
+			Member: fmt.Sprintf("direct-limited-stale-%d", i),
+		}).Err()
+	}
+	limited, err := limitedStore.ListByConversationID(
+		context.Background(),
+		limitedConversationID,
+		1,
+	)
+	if err != nil {
+		t.Fatalf("limited ListByConversationID: %v", err)
+	}
+	if len(limited) != 0 {
+		t.Fatalf("scan ceiling was bypassed: %+v", limited)
+	}
+	staleRemaining := 0
+	for i := 0; i < 3; i++ {
+		if _, err := limitedStore.client.ZScore(
+			context.Background(),
+			limitedIndexKey,
+			fmt.Sprintf("direct-limited-stale-%d", i),
+		).Result(); err == nil {
+			staleRemaining++
+		}
+	}
+	if staleRemaining != 1 {
+		t.Fatalf("cleanup exceeded direct scan ceiling: %d stale remain, want 1", staleRemaining)
+	}
+}
+
+type conversationCleanupFailProvider struct {
+	*mockStorageProvider
+	err error
+}
+
+func (p *conversationCleanupFailProvider) RemoveFromIndex(
+	context.Context,
+	string,
+	...string,
+) error {
+	return p.err
+}
+
+type conversationZRemFailureHook struct {
+	err error
+}
+
+func (h conversationZRemFailureHook) BeforeProcess(
+	ctx context.Context,
+	cmd redis.Cmder,
+) (context.Context, error) {
+	if cmd.Name() == "zrem" {
+		return ctx, h.err
+	}
+	return ctx, nil
+}
+
+func (conversationZRemFailureHook) AfterProcess(context.Context, redis.Cmder) error {
+	return nil
+}
+
+func (conversationZRemFailureHook) BeforeProcessPipeline(
+	ctx context.Context,
+	_ []redis.Cmder,
+) (context.Context, error) {
+	return ctx, nil
+}
+
+func (conversationZRemFailureHook) AfterProcessPipeline(
+	context.Context,
+	[]redis.Cmder,
+) error {
+	return nil
+}
+
+func TestConversationIndexCleanupFailureIsNonFatalAndSanitized(t *testing.T) {
+	conversationID := "conversation-cleanup-secret"
+	rawErr := errors.New(
+		"redis://user:password@host/8?conversation=" + conversationID,
+	)
+
+	t.Run("provider", func(t *testing.T) {
+		provider := &conversationCleanupFailProvider{
+			mockStorageProvider: newMockStorageProvider(),
+			err:                 rawErr,
+		}
+		logger := &recordingLogger{}
+		store := NewExecutionStoreWithProvider(
+			provider,
+			DefaultExecutionStoreConfig(),
+			logger,
+		).(ConversationExecutionLister)
+		indexKey := executionConversationIndexKey(
+			DefaultExecutionKeyPrefix,
+			conversationID,
+		)
+		if err := provider.AddToIndex(
+			context.Background(),
+			indexKey,
+			1,
+			"stale-provider",
+		); err != nil {
+			t.Fatalf("seed stale member: %v", err)
+		}
+
+		if _, err := store.ListByConversationID(
+			context.Background(),
+			conversationID,
+			1,
+		); err != nil {
+			t.Fatalf("cleanup failure became fatal: %v", err)
+		}
+		assertConversationCleanupWarning(t, logger, conversationID)
+	})
+
+	t.Run("direct redis", func(t *testing.T) {
+		_, store := newRedisExecutionConversationTestStore(
+			t,
+			DefaultExecutionStoreConfig(),
+		)
+		logger := &recordingLogger{}
+		store.logger = logger
+		store.client.AddHook(conversationZRemFailureHook{err: rawErr})
+		indexKey := store.conversationIndexKey(conversationID)
+		if err := store.client.ZAdd(
+			context.Background(),
+			indexKey,
+			&redis.Z{Score: 1, Member: "stale-direct"},
+		).Err(); err != nil {
+			t.Fatalf("seed stale member: %v", err)
+		}
+
+		if _, err := store.ListByConversationID(
+			context.Background(),
+			conversationID,
+			1,
+		); err != nil {
+			t.Fatalf("cleanup failure became fatal: %v", err)
+		}
+		assertConversationCleanupWarning(t, logger, conversationID)
+	})
+}
+
+func assertConversationCleanupWarning(
+	t *testing.T,
+	logger *recordingLogger,
+	rawConversationID string,
+) {
+	t.Helper()
+	if len(logger.warns) != 1 {
+		t.Fatalf("warnings = %d, want 1", len(logger.warns))
+	}
+	fields := logger.warns[0].fields
+	if fields["operation"] != "execution_store_conversation_index_cleanup" ||
+		fields["error_type"] != "index_write" ||
+		fields["error"] != "execution store backend write failed" {
+		t.Fatalf("warning fields = %v", fields)
+	}
+	if strings.Contains(fmt.Sprint(fields), rawConversationID) ||
+		strings.Contains(fmt.Sprint(fields), "password") {
+		t.Fatalf("warning leaked sensitive fields: %v", fields)
+	}
+}
+
+type indexTTLTestProvider struct {
+	*mockStorageProvider
+	indexTTLs map[string]time.Duration
+	ttlCalls  []string
+	err       error
+}
+
+func newIndexTTLTestProvider() *indexTTLTestProvider {
+	return &indexTTLTestProvider{
+		mockStorageProvider: newMockStorageProvider(),
+		indexTTLs:           make(map[string]time.Duration),
+	}
+}
+
+func (p *indexTTLTestProvider) ExtendIndexTTL(
+	_ context.Context,
+	indexKey string,
+	minTTL time.Duration,
+) error {
+	p.ttlCalls = append(p.ttlCalls, indexKey)
+	if p.err != nil {
+		return p.err
+	}
+	if p.indexTTLs[indexKey] < minTTL {
+		p.indexTTLs[indexKey] = minTTL
+	}
+	return nil
+}
+
+func TestProviderConversationIndexTTLDoesNotDowngrade(t *testing.T) {
+	provider := newIndexTTLTestProvider()
+	config := DefaultExecutionStoreConfig()
+	store := NewExecutionStoreWithProvider(provider, config, nil)
+	conversationID := "conversation-provider-ttl"
+	indexKey := executionConversationIndexKey(config.KeyPrefix, conversationID)
+
+	failed := executionWithConversation("failed", conversationID, time.Now())
+	failed.Result.Success = false
+	if err := store.Store(context.Background(), failed); err != nil {
+		t.Fatalf("failed Store: %v", err)
+	}
+	if got := provider.indexTTLs[indexKey]; got != config.ErrorTTL {
+		t.Fatalf("error index TTL = %v, want %v", got, config.ErrorTTL)
+	}
+
+	success := executionWithConversation("success", conversationID, time.Now().Add(time.Minute))
+	if err := store.Store(context.Background(), success); err != nil {
+		t.Fatalf("success Store: %v", err)
+	}
+	if got := provider.indexTTLs[indexKey]; got != config.ErrorTTL {
+		t.Fatalf("index TTL downgraded to %v", got)
+	}
+	if err := store.ExtendTTL(context.Background(), "success", 14*24*time.Hour); err != nil {
+		t.Fatalf("ExtendTTL: %v", err)
+	}
+	if got := provider.indexTTLs[indexKey]; got != 14*24*time.Hour {
+		t.Fatalf("extended index TTL = %v", got)
+	}
+}
+
+func TestProviderWithoutIndexTTLManagerRemainsUsableWithoutWarning(t *testing.T) {
+	provider := newMockStorageProvider()
+	logger := &recordingLogger{}
+	store := NewExecutionStoreWithProvider(
+		provider,
+		DefaultExecutionStoreConfig(),
+		logger,
+	)
+	if err := store.Store(
+		context.Background(),
+		executionWithConversation(
+			"request-no-ttl-capability",
+			"conversation-no-ttl-capability",
+			time.Now(),
+		),
+	); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if len(logger.warns) != 0 {
+		t.Fatalf("missing optional capability emitted warning: %+v", logger.warns)
+	}
+}
+
+func TestProviderConversationIndexTTLFailureIsNonFatalAndSanitized(t *testing.T) {
+	rawConversationID := "conversation-provider-ttl-secret"
+	provider := newIndexTTLTestProvider()
+	provider.err = errors.New(
+		"redis://user:password@host/8?conversation=" + rawConversationID,
+	)
+	logger := &recordingLogger{}
+	store := NewExecutionStoreWithProvider(
+		provider,
+		DefaultExecutionStoreConfig(),
+		logger,
+	)
+	if err := store.Store(
+		context.Background(),
+		executionWithConversation("request-ttl-error", rawConversationID, time.Now()),
+	); err != nil {
+		t.Fatalf("TTL failure became fatal: %v", err)
+	}
+	if len(logger.warns) != 1 {
+		t.Fatalf("warnings = %d, want 1", len(logger.warns))
+	}
+	fields := logger.warns[0].fields
+	if fields["operation"] != "execution_store_conversation_index_ttl" ||
+		fields["request_id"] != "request-ttl-error" ||
+		fields["error_type"] != "ttl_update" ||
+		fields["error"] != "execution store backend write failed" {
+		t.Fatalf("warning fields = %v", fields)
+	}
+	if strings.Contains(fmt.Sprint(fields), rawConversationID) ||
+		strings.Contains(fmt.Sprint(fields), "password") {
+		t.Fatalf("warning leaked sensitive fields: %v", fields)
+	}
+}
+
+func TestDirectRedisConversationIndexTTLDoesNotDowngrade(t *testing.T) {
+	config := DefaultExecutionStoreConfig()
+	mr, store := newRedisExecutionConversationTestStore(t, config)
+	conversationID := "conversation-direct-ttl"
+	indexKey := executionConversationIndexKey(config.KeyPrefix, conversationID)
+
+	failed := executionWithConversation("failed", conversationID, time.Now())
+	failed.Result.Success = false
+	if err := store.Store(context.Background(), failed); err != nil {
+		t.Fatalf("failed Store: %v", err)
+	}
+	if got := mr.TTL(indexKey); got != config.ErrorTTL {
+		t.Fatalf("error index TTL = %v, want %v", got, config.ErrorTTL)
+	}
+
+	success := executionWithConversation("success", conversationID, time.Now().Add(time.Minute))
+	if err := store.Store(context.Background(), success); err != nil {
+		t.Fatalf("success Store: %v", err)
+	}
+	if got := mr.TTL(indexKey); got != config.ErrorTTL {
+		t.Fatalf("index TTL downgraded to %v", got)
+	}
+
+	if err := store.ExtendTTL(context.Background(), "success", time.Hour); err != nil {
+		t.Fatalf("short ExtendTTL: %v", err)
+	}
+	if got := mr.TTL(indexKey); got != config.ErrorTTL {
+		t.Fatalf("short extension downgraded index TTL to %v", got)
+	}
+	if err := store.ExtendTTL(context.Background(), "success", 14*24*time.Hour); err != nil {
+		t.Fatalf("long ExtendTTL: %v", err)
+	}
+	if got := mr.TTL(indexKey); got != 14*24*time.Hour {
+		t.Fatalf("long extension index TTL = %v", got)
+	}
+	if got := mr.TTL(store.recordKey("success")); got != 14*24*time.Hour {
+		t.Fatalf("record TTL = %v", got)
+	}
+	if got := mr.TTL(store.traceKey(success.TraceID)); got != 14*24*time.Hour {
+		t.Fatalf("trace TTL = %v", got)
+	}
+}
+
+func TestDirectRedisIndexTTLHelperHandlesMissingAndPersistentKeys(t *testing.T) {
+	_, store := newRedisExecutionConversationTestStore(
+		t,
+		DefaultExecutionStoreConfig(),
+	)
+	ctx := context.Background()
+
+	if err := store.extendIndexTTLWithoutDowngrade(
+		ctx,
+		"missing-index",
+		time.Hour,
+		false,
+	); err != nil {
+		t.Fatalf("missing index: %v", err)
+	}
+
+	persistentKey := "persistent-index"
+	if err := store.client.ZAdd(
+		ctx,
+		persistentKey,
+		&redis.Z{Score: 1, Member: "member"},
+	).Err(); err != nil {
+		t.Fatalf("seed persistent index: %v", err)
+	}
+	if err := store.extendIndexTTLWithoutDowngrade(
+		ctx,
+		persistentKey,
+		time.Hour,
+		false,
+	); err != nil {
+		t.Fatalf("preserve persistent index: %v", err)
+	}
+	if got, err := store.client.TTL(ctx, persistentKey).Result(); err != nil ||
+		got != redisTTLPersistent {
+		t.Fatalf("persistent TTL = (%v, %v), want Redis persistent sentinel", got, err)
+	}
+
+	if err := store.extendIndexTTLWithoutDowngrade(
+		ctx,
+		persistentKey,
+		time.Hour,
+		true,
+	); err != nil {
+		t.Fatalf("expire newly-created persistent index: %v", err)
+	}
+	if got, err := store.client.TTL(ctx, persistentKey).Result(); err != nil || got != time.Hour {
+		t.Fatalf("initialized TTL = (%v, %v), want 1h", got, err)
+	}
+}
+
+func TestExecutionStoreCanonicalKeysMatchAcrossImplementations(t *testing.T) {
+	for _, prefix := range []string{
+		"tenant:execution:debug",
+		"tenant:execution:debug:",
+		"tenant:execution:debug::",
+	} {
+		config := DefaultExecutionStoreConfig()
+		config.KeyPrefix = prefix
+		providerStore := NewExecutionStoreWithProvider(
+			newMockStorageProvider(),
+			config,
+			nil,
+		).(*executionStoreImpl)
+		directStore := &RedisExecutionDebugStore{keyPrefix: prefix}
+		conversationID := "conversation-key"
+
+		keys := [][2]string{
+			{providerStore.recordKey("request"), directStore.recordKey("request")},
+			{providerStore.indexKey(), directStore.indexKey()},
+			{providerStore.traceKey("trace"), directStore.traceKey("trace")},
+			{
+				providerStore.conversationIndexKey(conversationID),
+				directStore.conversationIndexKey(conversationID),
+			},
+		}
+		for _, pair := range keys {
+			if pair[0] != pair[1] {
+				t.Fatalf("prefix %q key mismatch: %q != %q", prefix, pair[0], pair[1])
+			}
+			if strings.Contains(pair[0], "debug::") {
+				t.Fatalf("prefix %q produced double separator: %q", prefix, pair[0])
+			}
+		}
+		if strings.Contains(
+			providerStore.conversationIndexKey(conversationID),
+			conversationID,
+		) {
+			t.Fatal("conversation index key retained the raw conversation ID")
+		}
+	}
+}
+
+func TestExecutionStoreTraceLookupIsLastWriter(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(t *testing.T) ExecutionStore
+	}{
+		{
+			name: "provider",
+			store: func(*testing.T) ExecutionStore {
+				return NewExecutionStoreWithProvider(
+					newMockStorageProvider(),
+					DefaultExecutionStoreConfig(),
+					nil,
+				)
+			},
+		},
+		{
+			name: "direct redis",
+			store: func(t *testing.T) ExecutionStore {
+				_, store := newRedisExecutionConversationTestStore(
+					t,
+					DefaultExecutionStoreConfig(),
+				)
+				return store
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := test.store(t)
+			first := sampleExecution("trace-first", true)
+			first.TraceID = "shared-trace"
+			second := sampleExecution("trace-second", true)
+			second.TraceID = "shared-trace"
+			if err := store.Store(context.Background(), first); err != nil {
+				t.Fatalf("first Store: %v", err)
+			}
+			if err := store.Store(context.Background(), second); err != nil {
+				t.Fatalf("second Store: %v", err)
+			}
+			got, err := store.GetByTraceID(context.Background(), "shared-trace")
+			if err != nil {
+				t.Fatalf("GetByTraceID: %v", err)
+			}
+			if got.RequestID != "trace-second" {
+				t.Fatalf("trace lookup = %q, want last writer", got.RequestID)
+			}
+		})
+	}
+}
+
+func TestNoOpExecutionStoreDoesNotAdvertiseConversationListing(t *testing.T) {
+	if _, ok := interface{}(NewNoOpExecutionStore()).(ConversationExecutionLister); ok {
+		t.Fatal("NoOpExecutionStore unexpectedly implements ConversationExecutionLister")
+	}
+}
+
+func TestExecutionStoreConversationLimitConfiguration(t *testing.T) {
+	defaults := DefaultExecutionStoreConfig()
+	if defaults.ConversationQueryLimit != defaultConversationQueryLimit ||
+		defaults.ConversationIndexScanLimit != defaultConversationIndexScanLimit {
+		t.Fatalf("conversation defaults = %+v", defaults)
+	}
+
+	t.Setenv("TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT", "17")
+	t.Setenv("TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT", "29")
+	fromEnvironment := DefaultConfig().ExecutionStore
+	if fromEnvironment.ConversationQueryLimit != 17 ||
+		fromEnvironment.ConversationIndexScanLimit != 29 {
+		t.Fatalf("environment config = %+v", fromEnvironment)
+	}
+
+	t.Setenv("TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT", "0")
+	t.Setenv("TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT", "invalid")
+	invalidEnvironment := DefaultConfig().ExecutionStore
+	if invalidEnvironment.ConversationQueryLimit != defaultConversationQueryLimit ||
+		invalidEnvironment.ConversationIndexScanLimit != defaultConversationIndexScanLimit {
+		t.Fatalf("invalid environment changed defaults: %+v", invalidEnvironment)
+	}
+
+	normalized := normalizeExecutionStoreConfig(ExecutionStoreConfig{})
+	if normalized.ConversationQueryLimit != defaultConversationQueryLimit ||
+		normalized.ConversationIndexScanLimit != defaultConversationIndexScanLimit ||
+		normalized.KeyPrefix != DefaultExecutionKeyPrefix {
+		t.Fatalf("zero-value normalization = %+v", normalized)
+	}
+}
+
+func TestRedisExecutionStoreWithConfigUsesExplicitLimits(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run: %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	t.Setenv("TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT", "99")
+	t.Setenv("TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT", "199")
+	config := DefaultExecutionStoreConfig()
+	config.KeyPrefix = "explicit:execution"
+	config.ConversationQueryLimit = 3
+	config.ConversationIndexScanLimit = 7
+	store, err := NewRedisExecutionDebugStoreWithConfig(
+		config,
+		WithExecutionDebugRedisURL("redis://"+mr.Addr()),
+	)
+	if err != nil {
+		t.Fatalf("NewRedisExecutionDebugStoreWithConfig: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	if store.queryLimit != 3 || store.indexScanLimit != 7 {
+		t.Fatalf(
+			"explicit limits = (%d, %d)",
+			store.queryLimit,
+			store.indexScanLimit,
+		)
+	}
+	if store.keyPrefix != "explicit:execution:" {
+		t.Fatalf("normalized prefix = %q", store.keyPrefix)
+	}
+}
+
+type conversationIndexFailProvider struct {
+	*mockStorageProvider
+	err error
+}
+
+func (p *conversationIndexFailProvider) AddToIndex(
+	ctx context.Context,
+	key string,
+	score float64,
+	member string,
+) error {
+	if strings.Contains(key, ":conversation:") {
+		return p.err
+	}
+	return p.mockStorageProvider.AddToIndex(ctx, key, score, member)
+}
+
+func TestProviderConversationIndexFailureIsNonFatalAndSanitized(t *testing.T) {
+	rawConversationID := "conversation-secret"
+	provider := &conversationIndexFailProvider{
+		mockStorageProvider: newMockStorageProvider(),
+		err: errors.New(
+			"redis://user:password@host/8?conversation=" + rawConversationID,
+		),
+	}
+	logger := &recordingLogger{}
+	store := NewExecutionStoreWithProvider(
+		provider,
+		DefaultExecutionStoreConfig(),
+		logger,
+	)
+	if err := store.Store(
+		context.Background(),
+		executionWithConversation("request-index-error", rawConversationID, time.Now()),
+	); err != nil {
+		t.Fatalf("conversation index failure became fatal: %v", err)
+	}
+	if len(logger.warns) != 1 {
+		t.Fatalf("warnings = %d, want 1", len(logger.warns))
+	}
+	fields := logger.warns[0].fields
+	if fields["operation"] != "execution_store_conversation_index" ||
+		fields["request_id"] != "request-index-error" ||
+		fields["error_type"] != "index_write" {
+		t.Fatalf("warning fields = %v", fields)
+	}
+	if got := fmt.Sprint(fields["error"]); got != "execution store backend write failed" {
+		t.Fatalf("sanitized error = %q", got)
+	}
+	if strings.Contains(fmt.Sprint(fields), rawConversationID) ||
+		strings.Contains(fmt.Sprint(fields), "password") {
+		t.Fatalf("warning leaked sensitive fields: %v", fields)
+	}
+}
+
+type conversationZAddFailureHook struct {
+	err error
+}
+
+func (h conversationZAddFailureHook) BeforeProcess(
+	ctx context.Context,
+	cmd redis.Cmder,
+) (context.Context, error) {
+	if cmd.Name() == "zadd" &&
+		len(cmd.Args()) > 1 &&
+		strings.Contains(fmt.Sprint(cmd.Args()[1]), ":conversation:") {
+		return ctx, h.err
+	}
+	return ctx, nil
+}
+
+func (conversationZAddFailureHook) AfterProcess(context.Context, redis.Cmder) error {
+	return nil
+}
+
+func (conversationZAddFailureHook) BeforeProcessPipeline(
+	ctx context.Context,
+	_ []redis.Cmder,
+) (context.Context, error) {
+	return ctx, nil
+}
+
+func (conversationZAddFailureHook) AfterProcessPipeline(
+	context.Context,
+	[]redis.Cmder,
+) error {
+	return nil
+}
+
+func TestDirectConversationIndexFailureIsNonFatalNilSafeAndSanitized(t *testing.T) {
+	config := DefaultExecutionStoreConfig()
+	_, store := newRedisExecutionConversationTestStore(t, config)
+	rawConversationID := "conversation-direct-secret"
+	store.client.AddHook(conversationZAddFailureHook{
+		err: errors.New(
+			"redis://user:password@host/8?conversation=" + rawConversationID,
+		),
+	})
+	logger := &recordingLogger{}
+	store.logger = logger
+
+	execution := executionWithConversation(
+		"request-direct-index-error",
+		rawConversationID,
+		time.Now(),
+	)
+	if err := store.Store(context.Background(), execution); err != nil {
+		t.Fatalf("conversation index failure became fatal: %v", err)
+	}
+	if _, err := store.Get(context.Background(), execution.RequestID); err != nil {
+		t.Fatalf("main execution record was lost: %v", err)
+	}
+	if len(logger.warns) != 1 {
+		t.Fatalf("warnings = %d, want 1", len(logger.warns))
+	}
+	fields := logger.warns[0].fields
+	if fields["operation"] != "execution_store_conversation_index" ||
+		fields["request_id"] != execution.RequestID ||
+		fields["error_type"] != "index_write" ||
+		fields["error"] != "execution store backend write failed" {
+		t.Fatalf("warning fields = %v", fields)
+	}
+	if strings.Contains(fmt.Sprint(fields), rawConversationID) ||
+		strings.Contains(fmt.Sprint(fields), "password") {
+		t.Fatalf("warning leaked sensitive fields: %v", fields)
+	}
+
+	store.logger = nil
+	execution.RequestID = "request-direct-index-error-nil-logger"
+	if err := store.Store(context.Background(), execution); err != nil {
+		t.Fatalf("nil logger made optional index failure fatal: %v", err)
+	}
+}
+
+type conversationTTLFailureHook struct {
+	conversationKey string
+	err             error
+}
+
+func (h conversationTTLFailureHook) BeforeProcess(
+	ctx context.Context,
+	cmd redis.Cmder,
+) (context.Context, error) {
+	if cmd.Name() == "ttl" &&
+		len(cmd.Args()) > 1 &&
+		fmt.Sprint(cmd.Args()[1]) == h.conversationKey {
+		return ctx, h.err
+	}
+	return ctx, nil
+}
+
+func (conversationTTLFailureHook) AfterProcess(context.Context, redis.Cmder) error {
+	return nil
+}
+
+func (conversationTTLFailureHook) BeforeProcessPipeline(
+	ctx context.Context,
+	_ []redis.Cmder,
+) (context.Context, error) {
+	return ctx, nil
+}
+
+func (conversationTTLFailureHook) AfterProcessPipeline(
+	context.Context,
+	[]redis.Cmder,
+) error {
+	return nil
+}
+
+func TestDirectConversationIndexTTLFailureIsNonFatalAndSanitized(t *testing.T) {
+	config := DefaultExecutionStoreConfig()
+	_, store := newRedisExecutionConversationTestStore(t, config)
+	conversationID := "conversation-direct-ttl-error"
+	conversationKey := store.conversationIndexKey(conversationID)
+	store.client.AddHook(conversationTTLFailureHook{
+		conversationKey: conversationKey,
+		err: errors.New(
+			"redis://user:password@host/8?conversation=" + conversationID,
+		),
+	})
+	logger := &recordingLogger{}
+	store.logger = logger
+
+	if err := store.Store(
+		context.Background(),
+		executionWithConversation("request-direct-ttl-error", conversationID, time.Now()),
+	); err != nil {
+		t.Fatalf("TTL failure became fatal: %v", err)
+	}
+	if len(logger.warns) != 1 {
+		t.Fatalf("warnings = %d, want 1", len(logger.warns))
+	}
+	fields := logger.warns[0].fields
+	if fields["operation"] != "execution_store_conversation_index_ttl" ||
+		fields["request_id"] != "request-direct-ttl-error" ||
+		fields["error_type"] != "ttl_update" ||
+		fields["error"] != "execution store backend write failed" {
+		t.Fatalf("warning fields = %v", fields)
+	}
+	if strings.Contains(fmt.Sprint(fields), conversationID) ||
+		strings.Contains(fmt.Sprint(fields), "password") {
+		t.Fatalf("warning leaked sensitive fields: %v", fields)
+	}
+}

--- a/orchestration/execution_conversation_store_test.go
+++ b/orchestration/execution_conversation_store_test.go
@@ -55,6 +55,30 @@ func executionWithConversation(
 	return execution
 }
 
+func TestFilterUnseenConversationMembersDeduplicatesOverlappingScanBatches(
+	t *testing.T,
+) {
+	seen := make(map[string]struct{})
+	first := filterUnseenConversationMembers(
+		[]string{"turn-4", "turn-3", "turn-2"},
+		seen,
+	)
+	second := filterUnseenConversationMembers(
+		[]string{"turn-2", "turn-1"},
+		seen,
+	)
+
+	if got := strings.Join(first, ","); got != "turn-4,turn-3,turn-2" {
+		t.Fatalf("first batch = %q", got)
+	}
+	if got := strings.Join(second, ","); got != "turn-1" {
+		t.Fatalf("overlapping second batch = %q, want only unseen member", got)
+	}
+	if len(seen) != 4 {
+		t.Fatalf("seen member count = %d, want 4", len(seen))
+	}
+}
+
 func TestExecutionStoresSanitizeInvalidConversationWithoutMutatingCaller(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -342,6 +366,68 @@ func TestConversationExecutionListerClampsLimits(t *testing.T) {
 	}
 }
 
+func TestConversationExecutionListerReturnsMostRecentWindowConsistently(t *testing.T) {
+	tests := []struct {
+		name  string
+		store func(t *testing.T, config ExecutionStoreConfig) ExecutionStore
+	}{
+		{
+			name: "provider",
+			store: func(_ *testing.T, config ExecutionStoreConfig) ExecutionStore {
+				return NewExecutionStoreWithProvider(newMockStorageProvider(), config, nil)
+			},
+		},
+		{
+			name: "direct redis",
+			store: func(t *testing.T, config ExecutionStoreConfig) ExecutionStore {
+				_, store := newRedisExecutionConversationTestStore(t, config)
+				return store
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := DefaultExecutionStoreConfig()
+			config.ConversationQueryLimit = 2
+			config.ConversationIndexScanLimit = 3
+			store := test.store(t, config)
+			lister := store.(ConversationExecutionLister)
+			base := time.Now().Add(-time.Hour)
+			for i := 0; i < 4; i++ {
+				if err := store.Store(
+					context.Background(),
+					executionWithConversation(
+						fmt.Sprintf("turn-%d", i),
+						"conversation-most-recent",
+						base.Add(time.Duration(i)*time.Minute),
+					),
+				); err != nil {
+					t.Fatalf("Store: %v", err)
+				}
+			}
+
+			summaries, err := lister.ListByConversationID(
+				context.Background(),
+				"conversation-most-recent",
+				2,
+			)
+			if err != nil {
+				t.Fatalf("ListByConversationID: %v", err)
+			}
+			want := []string{"turn-2", "turn-3"}
+			if len(summaries) != len(want) {
+				t.Fatalf("summary count = %d, want %d", len(summaries), len(want))
+			}
+			for i, summary := range summaries {
+				if summary.RequestID != want[i] {
+					t.Fatalf("summary[%d] = %q, want %q", i, summary.RequestID, want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestProviderConversationIndexStaleCleanupHonorsScanCeiling(t *testing.T) {
 	provider := newMockStorageProvider()
 	config := DefaultExecutionStoreConfig()
@@ -458,7 +544,7 @@ func TestDirectConversationIndexStaleCleanupHonorsScanCeiling(t *testing.T) {
 	}
 	for i := 0; i < 3; i++ {
 		if err := store.client.ZAdd(context.Background(), indexKey, &redis.Z{
-			Score:  float64(base.Add(-time.Duration(10-i) * time.Minute).UnixNano()),
+			Score:  float64(base.Add(time.Duration(10+i) * time.Minute).UnixNano()),
 			Member: fmt.Sprintf("direct-stale-%d", i),
 		}).Err(); err != nil {
 			t.Fatalf("seed stale member: %v", err)
@@ -507,7 +593,7 @@ func TestDirectConversationIndexStaleCleanupHonorsScanCeiling(t *testing.T) {
 	}
 	for i := 0; i < 3; i++ {
 		_ = limitedStore.client.ZAdd(context.Background(), limitedIndexKey, &redis.Z{
-			Score:  float64(base.Add(-time.Duration(10-i) * time.Minute).UnixNano()),
+			Score:  float64(base.Add(time.Duration(10+i) * time.Minute).UnixNano()),
 			Member: fmt.Sprintf("direct-limited-stale-%d", i),
 		}).Err()
 	}
@@ -1108,10 +1194,12 @@ func (h conversationZAddFailureHook) BeforeProcess(
 	ctx context.Context,
 	cmd redis.Cmder,
 ) (context.Context, error) {
-	if cmd.Name() == "zadd" &&
-		len(cmd.Args()) > 1 &&
-		strings.Contains(fmt.Sprint(cmd.Args()[1]), ":conversation:") {
-		return ctx, h.err
+	if cmd.Name() == "eval" || cmd.Name() == "evalsha" {
+		for _, arg := range cmd.Args() {
+			if strings.Contains(fmt.Sprint(arg), ":conversation:") {
+				return ctx, h.err
+			}
+		}
 	}
 	return ctx, nil
 }
@@ -1470,38 +1558,35 @@ func (conversationTTLFailureHook) AfterProcessPipeline(
 	return nil
 }
 
-func TestDirectConversationIndexTTLFailureIsNonFatalAndSanitized(t *testing.T) {
+func TestDirectConversationIndexStoreDoesNotUseRacyTTLProbe(t *testing.T) {
 	config := DefaultExecutionStoreConfig()
-	_, store := newRedisExecutionConversationTestStore(t, config)
-	conversationID := "conversation-direct-ttl-error"
+	mr, store := newRedisExecutionConversationTestStore(t, config)
+	conversationID := "conversation-direct-atomic-ttl"
 	conversationKey := store.conversationIndexKey(conversationID)
 	store.client.AddHook(conversationTTLFailureHook{
 		conversationKey: conversationKey,
-		err: errors.New(
-			"redis://user:password@host/8?conversation=" + conversationID,
-		),
+		err:             errors.New("standalone TTL probe must not run"),
 	})
 	logger := &recordingLogger{}
 	store.logger = logger
 
 	if err := store.Store(
 		context.Background(),
-		executionWithConversation("request-direct-ttl-error", conversationID, time.Now()),
+		executionWithConversation("request-direct-atomic-ttl", conversationID, time.Now()),
 	); err != nil {
-		t.Fatalf("TTL failure became fatal: %v", err)
+		t.Fatalf("Store: %v", err)
 	}
-	if len(logger.warns) != 1 {
-		t.Fatalf("warnings = %d, want 1", len(logger.warns))
+	if len(logger.warns) != 0 {
+		t.Fatalf("unexpected warnings = %+v", logger.warns)
 	}
-	fields := logger.warns[0].fields
-	if fields["operation"] != "execution_store_conversation_index_ttl" ||
-		fields["request_id"] != "request-direct-ttl-error" ||
-		fields["error_type"] != "ttl_update" ||
-		fields["error"] != "execution store backend write failed" {
-		t.Fatalf("warning fields = %v", fields)
+	if got := mr.TTL(conversationKey); got != config.TTL {
+		t.Fatalf("conversation index TTL = %v, want %v", got, config.TTL)
 	}
-	if strings.Contains(fmt.Sprint(fields), conversationID) ||
-		strings.Contains(fmt.Sprint(fields), "password") {
-		t.Fatalf("warning leaked sensitive fields: %v", fields)
+	if _, err := store.client.ZScore(
+		context.Background(),
+		conversationKey,
+		"request-direct-atomic-ttl",
+	).Result(); err != nil {
+		t.Fatalf("conversation member missing after atomic upsert: %v", err)
 	}
 }

--- a/orchestration/execution_store.go
+++ b/orchestration/execution_store.go
@@ -42,8 +42,8 @@ type ExecutionStore interface {
 	// Useful for correlating with Jaeger traces.
 	GetByTraceID(ctx context.Context, traceID string) (*StoredExecution, error)
 
-	// SetMetadata adds metadata to an existing record.
-	// Useful for adding investigation notes or flags.
+	// SetMetadata adds application investigation metadata to an existing
+	// record. Framework-owned reserved correlation keys are rejected.
 	SetMetadata(ctx context.Context, requestID string, key, value string) error
 
 	// ExtendTTL extends retention for investigation.
@@ -120,7 +120,9 @@ type StoredExecution struct {
 	PhaseCount     int            `json:"phase_count,omitempty"`     // Number of phases executed
 	ForcedTerminal bool           `json:"forced_terminal,omitempty"` // Whether max phases forced termination
 
-	// Optional metadata for investigation notes
+	// Metadata contains framework-owned correlation metadata plus optional
+	// application investigation metadata. MetadataConversationID is reserved
+	// for the immutable conversation identity captured at execution time.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
@@ -129,20 +131,36 @@ type StoredExecution struct {
 // Note: Named ExecutionSummary (not ExecutionResultSummary) to avoid
 // collision with existing ExecutionRecord type in interfaces.go:150
 type ExecutionSummary struct {
-	RequestID         string            `json:"request_id"`
-	OriginalRequestID string            `json:"original_request_id,omitempty"`
-	TraceID           string            `json:"trace_id"`
-	AgentName         string            `json:"agent_name,omitempty"`
-	OriginalRequest   string            `json:"original_request"`
-	Success           bool              `json:"success"`
-	Interrupted       bool              `json:"interrupted,omitempty"`
-	StepCount         int               `json:"step_count"`
-	FailedSteps       int               `json:"failed_steps"`
-	TotalDuration     time.Duration     `json:"total_duration"`
-	CreatedAt         time.Time         `json:"created_at"`
-	PhaseCount        int               `json:"phase_count,omitempty"`
-	ForcedTerminal    bool              `json:"forced_terminal,omitempty"`
-	Metadata          map[string]string `json:"metadata,omitempty"`
+	RequestID         string        `json:"request_id"`
+	OriginalRequestID string        `json:"original_request_id,omitempty"`
+	TraceID           string        `json:"trace_id"`
+	AgentName         string        `json:"agent_name,omitempty"`
+	OriginalRequest   string        `json:"original_request"`
+	Success           bool          `json:"success"`
+	Interrupted       bool          `json:"interrupted,omitempty"`
+	StepCount         int           `json:"step_count"`
+	FailedSteps       int           `json:"failed_steps"`
+	TotalDuration     time.Duration `json:"total_duration"`
+	CreatedAt         time.Time     `json:"created_at"`
+	PhaseCount        int           `json:"phase_count,omitempty"`
+	ForcedTerminal    bool          `json:"forced_terminal,omitempty"`
+	// Metadata contains framework-owned correlation metadata plus optional
+	// application investigation metadata. MetadataConversationID is reserved.
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// ExecutionConversationID returns the stored multi-turn correlation ID.
+func ExecutionConversationID(execution *StoredExecution) string {
+	if execution == nil {
+		return ""
+	}
+	return execution.Metadata[MetadataConversationID]
+}
+
+// ExecutionSummaryConversationID returns the summary's multi-turn correlation
+// ID.
+func ExecutionSummaryConversationID(summary ExecutionSummary) string {
+	return summary.Metadata[MetadataConversationID]
 }
 
 // StorageProvider abstracts the underlying storage backend.
@@ -381,6 +399,13 @@ func (s *executionStoreImpl) GetByTraceID(ctx context.Context, traceID string) (
 
 // SetMetadata adds metadata to an existing record.
 func (s *executionStoreImpl) SetMetadata(ctx context.Context, requestID string, key, value string) error {
+	if requestID == "" {
+		return fmt.Errorf("request_id is required")
+	}
+	if key == MetadataConversationID {
+		return fmt.Errorf("%s is framework-owned and cannot be changed", MetadataConversationID)
+	}
+
 	// Get existing record
 	execution, err := s.Get(ctx, requestID)
 	if err != nil {
@@ -487,8 +512,11 @@ func (s *executionStoreImpl) ListRecent(ctx context.Context, limit int) ([]Execu
 			RequestID:         execution.RequestID,
 			OriginalRequestID: execution.OriginalRequestID,
 			TraceID:           execution.TraceID,
+			AgentName:         execution.AgentName,
 			OriginalRequest:   execution.OriginalRequest,
+			Interrupted:       execution.Interrupted,
 			CreatedAt:         execution.CreatedAt,
+			Metadata:          execution.Metadata,
 		}
 
 		if execution.Result != nil {

--- a/orchestration/execution_store.go
+++ b/orchestration/execution_store.go
@@ -58,7 +58,8 @@ type ExecutionStore interface {
 }
 
 // ConversationExecutionLister is an optional execution-store capability for
-// querying executions by a stable multi-turn conversation identifier.
+// querying executions by a stable multi-turn conversation identifier. Results
+// are the most recent bounded window, ordered chronologically within it.
 type ConversationExecutionLister interface {
 	ListByConversationID(
 		ctx context.Context,
@@ -256,8 +257,8 @@ type ExecutionStoreConfig struct {
 	// Per FRAMEWORK_DESIGN_PRINCIPLES.md: "Explicit Override: Always allow explicit configuration"
 	KeyPrefix string `json:"key_prefix"`
 
-	// ConversationQueryLimit bounds the number of executions returned by one
-	// conversation lookup.
+	// ConversationQueryLimit bounds the most recent execution window returned
+	// by one conversation lookup.
 	// Default: 1000. Override via TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT.
 	ConversationQueryLimit int `json:"conversation_query_limit"`
 
@@ -328,6 +329,21 @@ func normalizeExecutionKeyPrefix(prefix string) string {
 		trimmed = strings.TrimRight(DefaultExecutionKeyPrefix, ":")
 	}
 	return trimmed + ":"
+}
+
+func filterUnseenConversationMembers(
+	members []string,
+	seen map[string]struct{},
+) []string {
+	unseen := make([]string, 0, len(members))
+	for _, member := range members {
+		if _, alreadySeen := seen[member]; alreadySeen {
+			continue
+		}
+		seen[member] = struct{}{}
+		unseen = append(unseen, member)
+	}
+	return unseen
 }
 
 // Key building helper methods use a prefix normalized to exactly one trailing
@@ -698,8 +714,8 @@ func (s *executionStoreImpl) ListRecent(ctx context.Context, limit int) ([]Execu
 	return summaries, nil
 }
 
-// ListByConversationID returns a bounded chronological set of executions for
-// one conversation.
+// ListByConversationID returns the most recent bounded window of executions for
+// one conversation, ordered chronologically within that window.
 func (s *executionStoreImpl) ListByConversationID(
 	ctx context.Context,
 	conversationID string,
@@ -714,9 +730,10 @@ func (s *executionStoreImpl) ListByConversationID(
 	indexKey := s.conversationIndexKey(conversationID)
 	summariesNewestFirst := make([]ExecutionSummary, 0, limit)
 	staleMembers := make([]string, 0)
+	seenMembers := make(map[string]struct{})
 
 	var offset int64
-	for scanned := 0; scanned < scanLimit; {
+	for scanned := 0; scanned < scanLimit && len(summariesNewestFirst) < limit; {
 		batchSize := conversationIndexReadBatchSize
 		if remaining := scanLimit - scanned; remaining < batchSize {
 			batchSize = remaining
@@ -735,8 +752,10 @@ func (s *executionStoreImpl) ListByConversationID(
 		if len(requestIDs) == 0 {
 			break
 		}
-		offset += int64(len(requestIDs))
-		scanned += len(requestIDs)
+		batchCount := len(requestIDs)
+		offset += int64(batchCount)
+		scanned += batchCount
+		requestIDs = filterUnseenConversationMembers(requestIDs, seenMembers)
 
 		for _, requestID := range requestIDs {
 			execution, err := s.Get(ctx, requestID)
@@ -752,8 +771,11 @@ func (s *executionStoreImpl) ListByConversationID(
 				summariesNewestFirst,
 				executionSummaryFromStored(execution),
 			)
+			if len(summariesNewestFirst) == limit {
+				break
+			}
 		}
-		if len(requestIDs) < batchSize {
+		if batchCount < batchSize {
 			break
 		}
 	}
@@ -772,9 +794,6 @@ func (s *executionStoreImpl) ListByConversationID(
 	for left, right := 0, len(summariesNewestFirst)-1; left < right; left, right = left+1, right-1 {
 		summariesNewestFirst[left], summariesNewestFirst[right] =
 			summariesNewestFirst[right], summariesNewestFirst[left]
-	}
-	if len(summariesNewestFirst) > limit {
-		summariesNewestFirst = summariesNewestFirst[:limit]
 	}
 	return summariesNewestFirst, nil
 }

--- a/orchestration/execution_store.go
+++ b/orchestration/execution_store.go
@@ -14,8 +14,10 @@ package orchestration
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/truvaagents/truva-g3/core"
@@ -53,6 +55,16 @@ type ExecutionStore interface {
 	// ListRecent returns recent records for UI listing.
 	// Results are ordered by creation time, newest first.
 	ListRecent(ctx context.Context, limit int) ([]ExecutionSummary, error)
+}
+
+// ConversationExecutionLister is an optional execution-store capability for
+// querying executions by a stable multi-turn conversation identifier.
+type ConversationExecutionLister interface {
+	ListByConversationID(
+		ctx context.Context,
+		conversationID string,
+		limit int,
+	) ([]ExecutionSummary, error)
 }
 
 // StoredExecution contains everything needed for DAG visualization.
@@ -206,6 +218,17 @@ type StorageProvider interface {
 	RemoveFromIndex(ctx context.Context, key string, members ...string) error
 }
 
+// IndexTTLManager is an optional provider capability. Implementations extend
+// an existing sorted index's expiry to at least minTTL and must never shorten a
+// longer current TTL. A missing index is a no-op.
+type IndexTTLManager interface {
+	ExtendIndexTTL(
+		ctx context.Context,
+		indexKey string,
+		minTTL time.Duration,
+	) error
+}
+
 // ExecutionStoreConfig holds configuration for execution storage.
 // This is embedded in OrchestratorConfig.
 //
@@ -218,29 +241,42 @@ type ExecutionStoreConfig struct {
 	Enabled bool `json:"enabled"`
 
 	// TTL is the retention period for successful records.
-	// Default: 24h. Override via TRUVAG3_EXECUTION_TTL
+	// Default: 24h. Override via TRUVAG3_EXECUTION_DEBUG_TTL.
 	// This is passed to the StorageProvider implementation.
 	TTL time.Duration `json:"ttl"`
 
 	// ErrorTTL is the retention period for records with errors.
-	// Default: 168h (7 days). Override via TRUVAG3_EXECUTION_ERROR_TTL
+	// Default: 168h (7 days). Override via TRUVAG3_EXECUTION_DEBUG_ERROR_TTL.
 	ErrorTTL time.Duration `json:"error_ttl"`
 
 	// KeyPrefix is the prefix for all storage keys.
-	// Default: "truvag3:execution". Override via TRUVAG3_EXECUTION_KEY_PREFIX
+	// Default: "truvag3:execution:debug:".
+	// Override via TRUVAG3_EXECUTION_DEBUG_KEY_PREFIX.
 	// This allows multi-tenant deployments or custom namespacing.
 	// Per FRAMEWORK_DESIGN_PRINCIPLES.md: "Explicit Override: Always allow explicit configuration"
 	KeyPrefix string `json:"key_prefix"`
+
+	// ConversationQueryLimit bounds the number of executions returned by one
+	// conversation lookup.
+	// Default: 1000. Override via TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT.
+	ConversationQueryLimit int `json:"conversation_query_limit"`
+
+	// ConversationIndexScanLimit bounds stale-index scanning performed by one
+	// conversation lookup.
+	// Default: 5000. Override via TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT.
+	ConversationIndexScanLimit int `json:"conversation_index_scan_limit"`
 }
 
 // DefaultExecutionStoreConfig returns the default configuration.
 // Feature is disabled by default per FRAMEWORK_DESIGN_PRINCIPLES.md.
 func DefaultExecutionStoreConfig() ExecutionStoreConfig {
 	return ExecutionStoreConfig{
-		Enabled:   false,                      // Disabled by default
-		TTL:       24 * time.Hour,             // 24 hours for success
-		ErrorTTL:  7 * 24 * time.Hour,         // 7 days for errors
-		KeyPrefix: "truvag3:execution:debug:", // Default prefix with trailing colon
+		Enabled:                    false,                      // Disabled by default
+		TTL:                        24 * time.Hour,             // 24 hours for success
+		ErrorTTL:                   7 * 24 * time.Hour,         // 7 days for errors
+		KeyPrefix:                  "truvag3:execution:debug:", // Default prefix with trailing colon
+		ConversationQueryLimit:     defaultConversationQueryLimit,
+		ConversationIndexScanLimit: defaultConversationIndexScanLimit,
 	}
 }
 
@@ -248,6 +284,11 @@ func DefaultExecutionStoreConfig() ExecutionStoreConfig {
 const (
 	// DefaultExecutionKeyPrefix is the default prefix for execution debug storage keys
 	DefaultExecutionKeyPrefix = "truvag3:execution:debug:"
+
+	defaultConversationQueryLimit     = 1000
+	defaultConversationIndexScanLimit = 5000
+	defaultConversationPageSize       = 50
+	conversationIndexReadBatchSize    = 100
 )
 
 // executionStoreImpl is the default implementation of ExecutionStore
@@ -262,10 +303,7 @@ type executionStoreImpl struct {
 // This is the recommended way to create an ExecutionStore - the application provides
 // the storage backend implementation (Redis, PostgreSQL, etc.).
 func NewExecutionStoreWithProvider(provider StorageProvider, config ExecutionStoreConfig, logger core.Logger) ExecutionStore {
-	// Ensure KeyPrefix has a default value
-	if config.KeyPrefix == "" {
-		config.KeyPrefix = DefaultExecutionKeyPrefix
-	}
+	config = normalizeExecutionStoreConfig(config)
 	return &executionStoreImpl{
 		provider: provider,
 		config:   config,
@@ -273,22 +311,125 @@ func NewExecutionStoreWithProvider(provider StorageProvider, config ExecutionSto
 	}
 }
 
-// Key building helper methods using configurable KeyPrefix
-// These follow the pattern: {KeyPrefix}:{suffix}
+func normalizeExecutionStoreConfig(config ExecutionStoreConfig) ExecutionStoreConfig {
+	config.KeyPrefix = normalizeExecutionKeyPrefix(config.KeyPrefix)
+	if config.ConversationQueryLimit <= 0 {
+		config.ConversationQueryLimit = defaultConversationQueryLimit
+	}
+	if config.ConversationIndexScanLimit <= 0 {
+		config.ConversationIndexScanLimit = defaultConversationIndexScanLimit
+	}
+	return config
+}
+
+func normalizeExecutionKeyPrefix(prefix string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(prefix), ":")
+	if trimmed == "" {
+		trimmed = strings.TrimRight(DefaultExecutionKeyPrefix, ":")
+	}
+	return trimmed + ":"
+}
+
+// Key building helper methods use a prefix normalized to exactly one trailing
+// separator.
 
 // recordKey returns the key for storing an execution record
 func (s *executionStoreImpl) recordKey(requestID string) string {
-	return s.config.KeyPrefix + ":" + requestID
+	return s.config.KeyPrefix + requestID
 }
 
 // indexKey returns the key for the sorted index of recent executions
 func (s *executionStoreImpl) indexKey() string {
-	return s.config.KeyPrefix + ":index"
+	return s.config.KeyPrefix + "index"
 }
 
 // traceKey returns the key for trace ID → request ID mapping
 func (s *executionStoreImpl) traceKey(traceID string) string {
-	return s.config.KeyPrefix + ":trace:" + traceID
+	return s.config.KeyPrefix + "trace:" + traceID
+}
+
+func (s *executionStoreImpl) conversationIndexKey(conversationID string) string {
+	return executionConversationIndexKey(s.config.KeyPrefix, conversationID)
+}
+
+func executionConversationIndexKey(prefix, conversationID string) string {
+	digest := sha256.Sum256([]byte(conversationID))
+	return normalizeExecutionKeyPrefix(prefix) + fmt.Sprintf("conversation:%x", digest)
+}
+
+func sanitizeExecutionConversationMetadata(
+	execution *StoredExecution,
+) (*StoredExecution, string) {
+	if execution == nil {
+		return nil, ""
+	}
+
+	cloned := *execution
+	if execution.Metadata != nil {
+		cloned.Metadata = make(map[string]string, len(execution.Metadata))
+		for key, value := range execution.Metadata {
+			cloned.Metadata[key] = value
+		}
+	}
+
+	conversationID, present := cloned.Metadata[MetadataConversationID]
+	if !present {
+		return &cloned, ""
+	}
+	if core.ValidateConversationID(conversationID) != core.ConversationIDValidationNone {
+		delete(cloned.Metadata, MetadataConversationID)
+		return &cloned, ""
+	}
+	return &cloned, conversationID
+}
+
+func executionSummaryFromStored(execution *StoredExecution) ExecutionSummary {
+	summary := ExecutionSummary{
+		RequestID:         execution.RequestID,
+		OriginalRequestID: execution.OriginalRequestID,
+		TraceID:           execution.TraceID,
+		AgentName:         execution.AgentName,
+		OriginalRequest:   execution.OriginalRequest,
+		Interrupted:       execution.Interrupted,
+		CreatedAt:         execution.CreatedAt,
+		PhaseCount:        execution.PhaseCount,
+		ForcedTerminal:    execution.ForcedTerminal,
+		Metadata:          execution.Metadata,
+	}
+	if execution.Result != nil {
+		summary.Success = execution.Result.Success
+		summary.TotalDuration = execution.Result.TotalDuration
+		summary.StepCount = len(execution.Result.Steps)
+		for _, step := range execution.Result.Steps {
+			if !step.Success {
+				summary.FailedSteps++
+			}
+		}
+	}
+	return summary
+}
+
+func normalizeConversationQueryLimit(limit, configuredLimit int) int {
+	if configuredLimit <= 0 {
+		configuredLimit = defaultConversationQueryLimit
+	}
+	if limit <= 0 {
+		if configuredLimit < defaultConversationPageSize {
+			return configuredLimit
+		}
+		return defaultConversationPageSize
+	}
+	if limit > configuredLimit {
+		return configuredLimit
+	}
+	return limit
+}
+
+func validateConversationQueryID(conversationID string) error {
+	if reason := core.ValidateConversationID(conversationID); reason != core.ConversationIDValidationNone {
+		return fmt.Errorf("invalid conversation_id: %s", reason)
+	}
+	return nil
 }
 
 // Store saves a complete execution record (plan + result).
@@ -299,9 +440,10 @@ func (s *executionStoreImpl) Store(ctx context.Context, execution *StoredExecuti
 	if execution.RequestID == "" {
 		return fmt.Errorf("request_id is required")
 	}
+	storedExecution, conversationID := sanitizeExecutionConversationMetadata(execution)
 
 	// Serialize to JSON
-	data, err := json.Marshal(execution)
+	data, err := json.Marshal(storedExecution)
 	if err != nil {
 		return fmt.Errorf("failed to marshal execution: %w", err)
 	}
@@ -312,38 +454,67 @@ func (s *executionStoreImpl) Store(ctx context.Context, execution *StoredExecuti
 	// them out so pending HITL approvals keep the default TTL rather than the
 	// shorter ErrorTTL.
 	ttl := s.config.TTL
-	if execution.Result != nil && !execution.Result.Success && !execution.Interrupted {
+	if storedExecution.Result != nil && !storedExecution.Result.Success && !storedExecution.Interrupted {
 		ttl = s.config.ErrorTTL
 	}
 
 	// Store the main record
-	key := s.recordKey(execution.RequestID)
+	key := s.recordKey(storedExecution.RequestID)
 	if err := s.provider.Set(ctx, key, string(data), ttl); err != nil {
 		return fmt.Errorf("failed to store execution: %w", err)
 	}
 
 	// Add to index (sorted set by timestamp)
-	score := float64(execution.CreatedAt.UnixNano())
-	if err := s.provider.AddToIndex(ctx, s.indexKey(), score, execution.RequestID); err != nil {
+	score := float64(storedExecution.CreatedAt.UnixNano())
+	if err := s.provider.AddToIndex(ctx, s.indexKey(), score, storedExecution.RequestID); err != nil {
 		if s.logger != nil {
-			s.logger.Warn("Failed to add execution to index", map[string]interface{}{
+			s.logger.WarnWithContext(ctx, "Failed to add execution to index", map[string]interface{}{
 				"operation":  "execution_store_index",
-				"request_id": execution.RequestID,
-				"error":      err.Error(),
+				"request_id": storedExecution.RequestID,
+				"error_type": "index_write",
+				"error":      safeExecutionStoreError(err),
 			})
 		}
 		// Continue - main record is stored
 	}
 
+	if conversationID != "" {
+		conversationKey := s.conversationIndexKey(conversationID)
+		if err := s.provider.AddToIndex(
+			ctx,
+			conversationKey,
+			score,
+			storedExecution.RequestID,
+		); err != nil {
+			if s.logger != nil {
+				s.logger.WarnWithContext(ctx, "Failed to update conversation execution index", map[string]interface{}{
+					"operation":  "execution_store_conversation_index",
+					"request_id": storedExecution.RequestID,
+					"error_type": "index_write",
+					"error":      safeExecutionStoreError(err),
+				})
+			}
+		} else if ttlManager, ok := s.provider.(IndexTTLManager); ok {
+			if err := ttlManager.ExtendIndexTTL(ctx, conversationKey, ttl); err != nil && s.logger != nil {
+				s.logger.WarnWithContext(ctx, "Failed to extend conversation index TTL", map[string]interface{}{
+					"operation":  "execution_store_conversation_index_ttl",
+					"request_id": storedExecution.RequestID,
+					"error_type": "ttl_update",
+					"error":      safeExecutionStoreError(err),
+				})
+			}
+		}
+	}
+
 	// Store trace ID mapping if available
-	if execution.TraceID != "" {
-		traceKey := s.traceKey(execution.TraceID)
-		if err := s.provider.Set(ctx, traceKey, execution.RequestID, ttl); err != nil {
+	if storedExecution.TraceID != "" {
+		traceKey := s.traceKey(storedExecution.TraceID)
+		if err := s.provider.Set(ctx, traceKey, storedExecution.RequestID, ttl); err != nil {
 			if s.logger != nil {
 				s.logger.Warn("Failed to store trace ID mapping", map[string]interface{}{
 					"operation":  "execution_store_trace",
-					"request_id": execution.RequestID,
-					"trace_id":   execution.TraceID,
+					"request_id": storedExecution.RequestID,
+					"trace_id":   storedExecution.TraceID,
 					"error":      err.Error(),
 				})
 			}
@@ -472,6 +643,20 @@ func (s *executionStoreImpl) ExtendTTL(ctx context.Context, requestID string, du
 		}
 	}
 
+	if conversationID := ExecutionConversationID(execution); conversationID != "" {
+		if ttlManager, ok := s.provider.(IndexTTLManager); ok {
+			conversationKey := s.conversationIndexKey(conversationID)
+			if err := ttlManager.ExtendIndexTTL(ctx, conversationKey, duration); err != nil && s.logger != nil {
+				s.logger.WarnWithContext(ctx, "Failed to extend conversation index TTL", map[string]interface{}{
+					"operation":  "execution_store_conversation_index_ttl",
+					"request_id": requestID,
+					"error_type": "ttl_update",
+					"error":      safeExecutionStoreError(err),
+				})
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -507,38 +692,95 @@ func (s *executionStoreImpl) ListRecent(ctx context.Context, limit int) ([]Execu
 			continue
 		}
 
-		// Build summary
-		summary := ExecutionSummary{
-			RequestID:         execution.RequestID,
-			OriginalRequestID: execution.OriginalRequestID,
-			TraceID:           execution.TraceID,
-			AgentName:         execution.AgentName,
-			OriginalRequest:   execution.OriginalRequest,
-			Interrupted:       execution.Interrupted,
-			CreatedAt:         execution.CreatedAt,
-			Metadata:          execution.Metadata,
-		}
-
-		if execution.Result != nil {
-			summary.Success = execution.Result.Success
-			summary.TotalDuration = execution.Result.TotalDuration
-			summary.StepCount = len(execution.Result.Steps)
-			for _, step := range execution.Result.Steps {
-				if !step.Success {
-					summary.FailedSteps++
-				}
-			}
-		}
-
-		// Multi-phase execution data (Step 16 F1)
-		summary.PhaseCount = execution.PhaseCount
-		summary.ForcedTerminal = execution.ForcedTerminal
-
-		summaries = append(summaries, summary)
+		summaries = append(summaries, executionSummaryFromStored(execution))
 	}
 
 	return summaries, nil
 }
 
+// ListByConversationID returns a bounded chronological set of executions for
+// one conversation.
+func (s *executionStoreImpl) ListByConversationID(
+	ctx context.Context,
+	conversationID string,
+	limit int,
+) ([]ExecutionSummary, error) {
+	if err := validateConversationQueryID(conversationID); err != nil {
+		return nil, err
+	}
+
+	limit = normalizeConversationQueryLimit(limit, s.config.ConversationQueryLimit)
+	scanLimit := s.config.ConversationIndexScanLimit
+	indexKey := s.conversationIndexKey(conversationID)
+	summariesNewestFirst := make([]ExecutionSummary, 0, limit)
+	staleMembers := make([]string, 0)
+
+	var offset int64
+	for scanned := 0; scanned < scanLimit; {
+		batchSize := conversationIndexReadBatchSize
+		if remaining := scanLimit - scanned; remaining < batchSize {
+			batchSize = remaining
+		}
+		requestIDs, err := s.provider.ListByScoreDesc(
+			ctx,
+			indexKey,
+			"-inf",
+			"+inf",
+			offset,
+			int64(batchSize),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list conversation executions: %w", err)
+		}
+		if len(requestIDs) == 0 {
+			break
+		}
+		offset += int64(len(requestIDs))
+		scanned += len(requestIDs)
+
+		for _, requestID := range requestIDs {
+			execution, err := s.Get(ctx, requestID)
+			if err != nil {
+				staleMembers = append(staleMembers, requestID)
+				continue
+			}
+			if ExecutionConversationID(execution) != conversationID {
+				staleMembers = append(staleMembers, requestID)
+				continue
+			}
+			summariesNewestFirst = append(
+				summariesNewestFirst,
+				executionSummaryFromStored(execution),
+			)
+		}
+		if len(requestIDs) < batchSize {
+			break
+		}
+	}
+
+	if len(staleMembers) > 0 {
+		if err := s.provider.RemoveFromIndex(ctx, indexKey, staleMembers...); err != nil && s.logger != nil {
+			s.logger.WarnWithContext(ctx, "Failed to prune stale conversation index entries", map[string]interface{}{
+				"operation":  "execution_store_conversation_index_cleanup",
+				"request_id": staleMembers[0],
+				"error_type": "index_write",
+				"error":      safeExecutionStoreError(err),
+			})
+		}
+	}
+
+	for left, right := 0, len(summariesNewestFirst)-1; left < right; left, right = left+1, right-1 {
+		summariesNewestFirst[left], summariesNewestFirst[right] =
+			summariesNewestFirst[right], summariesNewestFirst[left]
+	}
+	if len(summariesNewestFirst) > limit {
+		summariesNewestFirst = summariesNewestFirst[:limit]
+	}
+	return summariesNewestFirst, nil
+}
+
 // Ensure executionStoreImpl implements ExecutionStore
-var _ ExecutionStore = (*executionStoreImpl)(nil)
+var (
+	_ ExecutionStore              = (*executionStoreImpl)(nil)
+	_ ConversationExecutionLister = (*executionStoreImpl)(nil)
+)

--- a/orchestration/execution_store_test.go
+++ b/orchestration/execution_store_test.go
@@ -327,6 +327,36 @@ func TestExecutionStore_SetMetadata(t *testing.T) {
 	}
 }
 
+func TestExecutionStore_SetMetadataRejectsReservedConversationID(t *testing.T) {
+	provider := newMockStorageProvider()
+	store := NewExecutionStoreWithProvider(provider, DefaultExecutionStoreConfig(), nil)
+	execution := sampleExecution("req-reserved-metadata", true)
+	execution.Metadata = map[string]string{
+		MetadataConversationID: "conversation-original",
+	}
+	if err := store.Store(context.Background(), execution); err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+
+	err := store.SetMetadata(
+		context.Background(),
+		execution.RequestID,
+		MetadataConversationID,
+		"conversation-replacement",
+	)
+	if err == nil {
+		t.Fatal("expected reserved metadata validation error")
+	}
+
+	got, getErr := store.Get(context.Background(), execution.RequestID)
+	if getErr != nil {
+		t.Fatalf("Get() error = %v", getErr)
+	}
+	if conversationID := ExecutionConversationID(got); conversationID != "conversation-original" {
+		t.Fatalf("conversation ID = %q, want conversation-original", conversationID)
+	}
+}
+
 func TestExecutionStore_ExtendTTL(t *testing.T) {
 	provider := newMockStorageProvider()
 	config := DefaultExecutionStoreConfig()
@@ -386,6 +416,46 @@ func TestExecutionStore_ListRecent(t *testing.T) {
 		if summaries[0].CreatedAt.Before(summaries[1].CreatedAt) {
 			t.Error("ListRecent not sorted by newest first")
 		}
+	}
+}
+
+func TestExecutionStore_ListRecentSummaryParity(t *testing.T) {
+	provider := newMockStorageProvider()
+	store := NewExecutionStoreWithProvider(provider, DefaultExecutionStoreConfig(), nil)
+	execution := sampleExecution("req-summary-parity", false)
+	execution.AgentName = "travel-chat-agent"
+	execution.Interrupted = true
+	execution.OriginalRequestID = "req-summary-root"
+	execution.PhaseCount = 3
+	execution.ForcedTerminal = true
+	execution.Metadata = map[string]string{
+		MetadataConversationID: "conversation-summary",
+		"investigation":        "keep",
+	}
+	if err := store.Store(context.Background(), execution); err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+
+	summaries, err := store.ListRecent(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ListRecent() error = %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("summary count = %d, want 1", len(summaries))
+	}
+	summary := summaries[0]
+	if summary.AgentName != execution.AgentName ||
+		summary.Interrupted != execution.Interrupted ||
+		summary.OriginalRequestID != execution.OriginalRequestID ||
+		summary.PhaseCount != execution.PhaseCount ||
+		summary.ForcedTerminal != execution.ForcedTerminal {
+		t.Fatalf("summary parity mismatch: %+v", summary)
+	}
+	if got := ExecutionSummaryConversationID(summary); got != "conversation-summary" {
+		t.Fatalf("summary conversation ID = %q", got)
+	}
+	if summary.Metadata["investigation"] != "keep" {
+		t.Fatalf("summary metadata = %v", summary.Metadata)
 	}
 }
 

--- a/orchestration/execution_store_test.go
+++ b/orchestration/execution_store_test.go
@@ -188,18 +188,18 @@ func TestExecutionStore_Store(t *testing.T) {
 	}
 
 	// Verify data was stored
-	key := DefaultExecutionKeyPrefix + ":" + execution.RequestID
+	key := DefaultExecutionKeyPrefix + execution.RequestID
 	if provider.data[key] == "" {
 		t.Error("Execution record not stored")
 	}
 
 	// Verify index was updated
-	if len(provider.indexes[DefaultExecutionKeyPrefix+":index"]) != 1 {
-		t.Errorf("Index not updated: got %d entries, want 1", len(provider.indexes[DefaultExecutionKeyPrefix+":index"]))
+	if len(provider.indexes[DefaultExecutionKeyPrefix+"index"]) != 1 {
+		t.Errorf("Index not updated: got %d entries, want 1", len(provider.indexes[DefaultExecutionKeyPrefix+"index"]))
 	}
 
 	// Verify trace mapping was stored
-	traceKey := DefaultExecutionKeyPrefix + ":trace:" + execution.TraceID
+	traceKey := DefaultExecutionKeyPrefix + "trace:" + execution.TraceID
 	if provider.data[traceKey] != execution.RequestID {
 		t.Errorf("Trace mapping not stored: got %q, want %q", provider.data[traceKey], execution.RequestID)
 	}

--- a/orchestration/executor.go
+++ b/orchestration/executor.go
@@ -4400,13 +4400,16 @@ func (e *SmartExecutor) callComponentWithBody(ctx context.Context, url string, b
 		}
 	}
 
-	// Propagate orchestration context as explicit headers.
-	// The executor's httpClient does not use otelhttp.NewTransport(), so OTel baggage
-	// is NOT automatically set as HTTP headers. These explicit headers are required.
+	// Propagate orchestration context as explicit framework headers. The traced
+	// HTTP client also propagates W3C baggage; these headers are the
+	// telemetry-independent fallback for framework receivers.
 	if baggage := telemetry.GetBaggage(ctx); baggage != nil {
 		if reqID := baggage["request_id"]; reqID != "" {
 			req.Header.Set("X-TruvaG3-Request-ID", reqID)
 		}
+	}
+	if conversationID := conversationIDForOutboundHeader(ctx); conversationID != "" {
+		req.Header.Set("X-TruvaG3-Conversation-ID", conversationID)
 	}
 	if stepID := core.GetStepID(ctx); stepID != "" {
 		req.Header.Set("X-TruvaG3-Step-ID", stepID)
@@ -4489,6 +4492,25 @@ func (e *SmartExecutor) callComponentWithBody(ctx context.Context, url string, b
 	}
 
 	return string(responseBytes), respBodyStr, nil
+}
+
+func conversationIDForOutboundHeader(ctx context.Context) string {
+	coreCandidate := core.GetConversationIDCandidate(ctx)
+	if coreCandidate.Present {
+		if coreCandidate.RejectionReason != core.ConversationIDValidationNone {
+			return ""
+		}
+		if core.ValidateConversationID(coreCandidate.Value) != core.ConversationIDValidationNone {
+			return ""
+		}
+		return coreCandidate.Value
+	}
+
+	conversationID := telemetry.GetBaggage(ctx)[MetadataConversationID]
+	if core.ValidateConversationID(conversationID) != core.ConversationIDValidationNone {
+		return ""
+	}
+	return conversationID
 }
 
 // callTool sends an HTTP request to a tool with raw parameters.

--- a/orchestration/executor_headers_test.go
+++ b/orchestration/executor_headers_test.go
@@ -4,7 +4,13 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/truvaagents/truva-g3/core"
+	"github.com/truvaagents/truva-g3/telemetry"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 func TestSmartExecutor_PropagatedHeaders(t *testing.T) {
@@ -176,4 +182,166 @@ func TestSmartExecutor_PropagatedHeaders(t *testing.T) {
 			t.Errorf("Expected tenant-ok (non-reserved), got %q", capturedTenantID)
 		}
 	})
+}
+
+func TestSmartExecutor_ConversationIDHeaders(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  func(t *testing.T) context.Context
+		want string
+	}{
+		{
+			name: "core candidate",
+			ctx: func(*testing.T) context.Context {
+				return core.WithConversationID(context.Background(), "conversation-core")
+			},
+			want: "conversation-core",
+		},
+		{
+			name: "validated baggage fallback",
+			ctx: func(t *testing.T) context.Context {
+				ctx, err := telemetry.WithBaggageExact(
+					context.Background(),
+					MetadataConversationID,
+					"conversation-baggage",
+				)
+				if err != nil {
+					t.Fatalf("WithBaggageExact() error = %v", err)
+				}
+				return ctx
+			},
+			want: "conversation-baggage",
+		},
+		{
+			name: "invalid core candidate blocks baggage fallback",
+			ctx: func(t *testing.T) context.Context {
+				ctx, err := telemetry.WithBaggageExact(
+					context.Background(),
+					MetadataConversationID,
+					"conversation-baggage",
+				)
+				if err != nil {
+					t.Fatalf("WithBaggageExact() error = %v", err)
+				}
+				return core.WithConversationID(ctx, "invalid conversation")
+			},
+		},
+		{
+			name: "invalid baggage fallback",
+			ctx: func(*testing.T) context.Context {
+				return telemetry.WithBaggage(
+					context.Background(),
+					MetadataConversationID,
+					"invalid conversation",
+				)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var headerValue, downstreamCoreValue string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				headerValue = r.Header.Get("X-TruvaG3-Conversation-ID")
+				downstreamCoreValue = core.GetConversationID(
+					core.ExtractRequestContext(r.Context(), r),
+				)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"status":"ok"}`))
+			}))
+			defer server.Close()
+
+			executor := NewSmartExecutor(nil)
+			_, _, err := executor.callComponentWithBody(
+				test.ctx(t),
+				server.URL+"/process",
+				[]byte(`{"query":"test"}`),
+			)
+			if err != nil {
+				t.Fatalf("callComponentWithBody() error = %v", err)
+			}
+			if headerValue != test.want {
+				t.Fatalf("conversation header = %q, want %q", headerValue, test.want)
+			}
+			if downstreamCoreValue != test.want {
+				t.Fatalf("downstream core conversation ID = %q, want %q", downstreamCoreValue, test.want)
+			}
+		})
+	}
+}
+
+func TestSmartExecutor_ConversationHeaderIsReserved(t *testing.T) {
+	var captured string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("X-TruvaG3-Conversation-ID")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	executor := NewSmartExecutor(nil)
+	executor.SetPropagatedHeaders(map[string]string{
+		"X-TruvaG3-Conversation-ID": "config-override",
+	})
+	ctx := core.WithConversationID(context.Background(), "conversation-framework")
+	ctx = WithPropagatedHeaders(ctx, map[string]string{
+		"x-truvag3-conversation-id": "context-override",
+	})
+
+	_, _, err := executor.callComponentWithBody(
+		ctx,
+		server.URL+"/process",
+		[]byte(`{"query":"test"}`),
+	)
+	if err != nil {
+		t.Fatalf("callComponentWithBody() error = %v", err)
+	}
+	if captured != "conversation-framework" {
+		t.Fatalf("conversation header = %q, want framework value", captured)
+	}
+}
+
+func TestSmartExecutor_PropagatesConversationIDThroughW3CBaggage(t *testing.T) {
+	originalPropagator := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	t.Cleanup(func() {
+		otel.SetTextMapPropagator(originalPropagator)
+	})
+
+	var baggageHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baggageHeader = r.Header.Get("baggage")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	ctx, err := telemetry.WithBaggageExact(
+		context.Background(),
+		MetadataConversationID,
+		"conversation-w3c",
+		telemetry.WithMetricLabelEligibility(false),
+	)
+	if err != nil {
+		t.Fatalf("WithBaggageExact() error = %v", err)
+	}
+
+	executor := NewSmartExecutor(nil)
+	_, _, err = executor.callComponentWithBody(
+		ctx,
+		server.URL+"/process",
+		[]byte(`{"query":"test"}`),
+	)
+	if err != nil {
+		t.Fatalf("callComponentWithBody() error = %v", err)
+	}
+	if !strings.Contains(baggageHeader, "conversation_id=conversation-w3c") {
+		t.Fatalf("W3C baggage header = %q", baggageHeader)
+	}
+	if !strings.Contains(baggageHeader, "truvag3_metric_label=false") {
+		t.Fatalf("metric-label property missing from W3C baggage header = %q", baggageHeader)
+	}
 }

--- a/orchestration/factory.go
+++ b/orchestration/factory.go
@@ -306,6 +306,7 @@ func CreateOrchestrator(config *OrchestratorConfig, deps OrchestratorDependencie
 	// Auto-configures from environment (same pattern as LLM Debug Store).
 	// Enable via TRUVAG3_EXECUTION_DEBUG_STORE_ENABLED=true
 	if config.ExecutionStore.Enabled {
+		config.ExecutionStore = normalizeExecutionStoreConfig(config.ExecutionStore)
 		if config.ExecutionStoreBackend != nil {
 			// Custom backend provided - use it
 			orchestrator.SetExecutionStore(config.ExecutionStoreBackend)
@@ -316,12 +317,10 @@ func CreateOrchestrator(config *OrchestratorConfig, deps OrchestratorDependencie
 			})
 		} else {
 			// Auto-configure Redis store from environment (same pattern as LLM Debug Store)
-			store, err := NewRedisExecutionDebugStore(
+			store, err := NewRedisExecutionDebugStoreWithConfig(
+				config.ExecutionStore,
 				WithExecutionDebugRedisDB(core.RedisDBExecutionDebug),
 				WithExecutionDebugLogger(deps.Logger),
-				WithExecutionDebugTTL(config.ExecutionStore.TTL),
-				WithExecutionDebugErrorTTL(config.ExecutionStore.ErrorTTL),
-				WithExecutionDebugKeyPrefix(config.ExecutionStore.KeyPrefix),
 			)
 			if err != nil {
 				// Resilient behavior - use NoOp store if Redis unavailable
@@ -334,11 +333,13 @@ func CreateOrchestrator(config *OrchestratorConfig, deps OrchestratorDependencie
 			} else {
 				orchestrator.SetExecutionStore(store)
 				factoryLogger.Info("Redis execution debug store initialized", map[string]interface{}{
-					"operation":  "execution_debug_store_initialization",
-					"redis_db":   core.RedisDBExecutionDebug,
-					"key_prefix": config.ExecutionStore.KeyPrefix,
-					"ttl":        config.ExecutionStore.TTL.String(),
-					"error_ttl":  config.ExecutionStore.ErrorTTL.String(),
+					"operation":                     "execution_debug_store_initialization",
+					"redis_db":                      core.RedisDBExecutionDebug,
+					"key_prefix":                    config.ExecutionStore.KeyPrefix,
+					"ttl":                           config.ExecutionStore.TTL.String(),
+					"error_ttl":                     config.ExecutionStore.ErrorTTL.String(),
+					"conversation_query_limit":      config.ExecutionStore.ConversationQueryLimit,
+					"conversation_index_scan_limit": config.ExecutionStore.ConversationIndexScanLimit,
 				})
 			}
 		}

--- a/orchestration/hitl_helpers.go
+++ b/orchestration/hitl_helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/truvaagents/truva-g3/core"
 	"github.com/truvaagents/truva-g3/telemetry"
 )
 
@@ -177,18 +178,32 @@ func BuildResumeContext(ctx context.Context, checkpoint *ExecutionCheckpoint) (c
 		originalRequestID = checkpoint.RequestID
 	}
 
+	spanBaseCtx, conversationID, resumeMetadata := prepareResumeConversationContext(
+		ctx,
+		checkpoint.UserContext,
+		emitResumeConversationIDRejection,
+	)
+
+	linkedSpanAttributes := map[string]string{
+		"checkpoint_id":       checkpoint.CheckpointID,
+		"interrupt_point":     string(checkpoint.InterruptPoint),
+		"request_id":          checkpoint.RequestID,
+		"original_request_id": originalRequestID,
+		"link.type":           "hitl_resume",
+	}
+	if conversationID != "" {
+		linkedSpanAttributes[MetadataConversationID] = conversationID
+	}
+
 	// StartLinkedSpan creates a new span linked (not child) to the original trace.
 	// Degrades gracefully when traceID/spanID are empty — creates an unlinked root span.
 	// SpanKindInternal is correct here; queue workers use SpanKindConsumer upstream (RC6).
 	resumeCtx, endSpan := telemetry.StartLinkedSpan(
-		ctx, "hitl.resume", traceID, spanID,
-		map[string]string{
-			"checkpoint_id":       checkpoint.CheckpointID,
-			"interrupt_point":     string(checkpoint.InterruptPoint),
-			"request_id":          checkpoint.RequestID,
-			"original_request_id": originalRequestID,
-			"link.type":           "hitl_resume",
-		},
+		spanBaseCtx,
+		"hitl.resume",
+		traceID,
+		spanID,
+		linkedSpanAttributes,
 	)
 	// Fire a span event so the trace link is visible in the Jaeger event timeline.
 	telemetry.AddSpanEvent(resumeCtx, "hitl.trace_link_created",
@@ -226,10 +241,83 @@ func BuildResumeContext(ctx context.Context, checkpoint *ExecutionCheckpoint) (c
 		resumeCtx = WithRequestMode(resumeCtx, checkpoint.RequestMode)
 	}
 
-	// Preserve metadata if set
-	if len(checkpoint.UserContext) > 0 {
-		resumeCtx = WithMetadata(resumeCtx, checkpoint.UserContext)
+	// Preserve the sanitized checkpoint metadata. The inherited metadata
+	// context was shadowed before the span started so a rejected checkpoint
+	// identity cannot reappear in chained checkpoints.
+	if len(resumeMetadata) > 0 {
+		resumeCtx = WithMetadata(resumeCtx, resumeMetadata)
 	}
 
 	return resumeCtx, endSpan, nil
+}
+
+type conversationIDRejectionEmitter func(source, reason string)
+
+func prepareResumeConversationContext(
+	ctx context.Context,
+	checkpointMetadata map[string]interface{},
+	emitRejection conversationIDRejectionEmitter,
+) (context.Context, string, map[string]interface{}) {
+	resumeMetadata := cloneMetadata(checkpointMetadata)
+	if len(checkpointMetadata) == 0 {
+		// Preserve the prior behavior for checkpoints without application
+		// metadata: unrelated metadata already on the resume context survives.
+		resumeMetadata = cloneMetadata(GetMetadata(ctx))
+	}
+	delete(resumeMetadata, MetadataConversationID)
+
+	spanBaseCtx := core.WithoutConversationID(ctx)
+	spanBaseCtx = telemetry.WithoutBaggageMember(
+		spanBaseCtx,
+		MetadataConversationID,
+	)
+	// Shadow inherited application metadata. Only the checkpoint copy below
+	// is authoritative for a resumed execution.
+	spanBaseCtx = WithMetadata(spanBaseCtx, map[string]interface{}{})
+
+	candidate := conversationIDCandidateFromMetadata(checkpointMetadata)
+	if !candidate.Present {
+		return spanBaseCtx, "", resumeMetadata
+	}
+	if candidate.Reason != core.ConversationIDValidationNone {
+		if emitRejection != nil {
+			emitRejection(conversationIDSourceCheckpointMetadata, string(candidate.Reason))
+		}
+		return spanBaseCtx, "", resumeMetadata
+	}
+
+	baggageCtx, err := telemetry.WithBaggageExact(
+		spanBaseCtx,
+		MetadataConversationID,
+		candidate.Value,
+		telemetry.WithMetricLabelEligibility(false),
+	)
+	if err != nil {
+		if emitRejection != nil {
+			emitRejection(
+				conversationIDSourceBaggageExact,
+				conversationIDBaggageRejectionReason(err),
+			)
+		}
+		return spanBaseCtx, "", resumeMetadata
+	}
+
+	if resumeMetadata == nil {
+		resumeMetadata = make(map[string]interface{})
+	}
+	resumeMetadata[MetadataConversationID] = candidate.Value
+	return core.WithConversationID(baggageCtx, candidate.Value),
+		candidate.Value,
+		resumeMetadata
+}
+
+const conversationIDSourceCheckpointMetadata = "checkpoint_metadata"
+
+func emitResumeConversationIDRejection(source, reason string) {
+	telemetry.Counter(
+		conversationIDRejectionMetric,
+		"source", source,
+		"reason", reason,
+		"module", telemetry.ModuleOrchestration,
+	)
 }

--- a/orchestration/hitl_helpers_test.go
+++ b/orchestration/hitl_helpers_test.go
@@ -2,9 +2,17 @@ package orchestration
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/truvaagents/truva-g3/core"
+	"github.com/truvaagents/truva-g3/telemetry"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // =============================================================================
@@ -811,4 +819,305 @@ func TestBuildResumeContext_TraceLinking(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildResumeContext_RestoresConversationBeforeLinkedSpan(t *testing.T) {
+	recorder := setupHITLResumeTestTracer(t)
+	checkpoint := &ExecutionCheckpoint{
+		CheckpointID:      "cp-conversation",
+		RequestID:         "request-resume",
+		OriginalRequestID: "request-original",
+		Status:            CheckpointStatusApproved,
+		UserContext: map[string]interface{}{
+			MetadataConversationID: "conversation-resume",
+			"session_id":           "application-session",
+		},
+	}
+
+	resumeCtx, endSpan, err := BuildResumeContext(context.Background(), checkpoint)
+	if err != nil {
+		t.Fatalf("BuildResumeContext() error = %v", err)
+	}
+
+	if got := core.GetConversationID(resumeCtx); got != "conversation-resume" {
+		t.Fatalf("core conversation ID = %q", got)
+	}
+	if got := telemetry.GetBaggage(resumeCtx)[MetadataConversationID]; got != "conversation-resume" {
+		t.Fatalf("baggage conversation ID = %q", got)
+	}
+	if got := GetMetadata(resumeCtx)[MetadataConversationID]; got != "conversation-resume" {
+		t.Fatalf("resume metadata conversation ID = %v", got)
+	}
+	if got := GetMetadata(resumeCtx)["session_id"]; got != "application-session" {
+		t.Fatalf("application metadata was not preserved: %v", GetMetadata(resumeCtx))
+	}
+	if got := telemetry.GetBaggage(resumeCtx)["original_request_id"]; got != "request-original" {
+		t.Fatalf("original request ID = %q", got)
+	}
+
+	orchestrator := &AIOrchestrator{telemetry: &conversationCaptureTelemetry{}}
+	ingressCtx, ingressID, ingressMetadata := orchestrator.resolveConversationContext(
+		resumeCtx,
+		nil,
+	)
+	if ingressID != "conversation-resume" ||
+		core.GetConversationID(ingressCtx) != "conversation-resume" ||
+		ingressMetadata[MetadataConversationID] != "conversation-resume" {
+		t.Fatalf(
+			"resume ingress lost identity: id=%q core=%q metadata=%v",
+			ingressID,
+			core.GetConversationID(ingressCtx),
+			ingressMetadata,
+		)
+	}
+
+	chainedCtx := withCheckpointMetadata(ingressCtx, nil, ingressID)
+	chained := (&DefaultInterruptController{logger: &core.NoOpLogger{}}).createCheckpoint(
+		chainedCtx,
+		&RoutingPlan{OriginalRequest: "resume request"},
+		nil,
+		nil,
+		&InterruptDecision{},
+		InterruptPointPlanGenerated,
+	)
+	if got := chained.UserContext[MetadataConversationID]; got != "conversation-resume" {
+		t.Fatalf("chained checkpoint conversation ID = %v", got)
+	}
+
+	endSpan()
+	ended := recorder.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(ended))
+	}
+	if got, ok := readOnlySpanStringAttribute(ended[0], MetadataConversationID); !ok || got != "conversation-resume" {
+		t.Fatalf("hitl.resume conversation attribute = %q, %v", got, ok)
+	}
+}
+
+func TestBuildResumeContext_RejectedConversationScrubsInheritedIdentity(t *testing.T) {
+	tests := []struct {
+		name         string
+		base         func(t *testing.T) context.Context
+		conversation interface{}
+	}{
+		{
+			name: "invalid checkpoint metadata",
+			base: func(t *testing.T) context.Context {
+				ctx, err := telemetry.WithBaggageExact(
+					context.Background(),
+					MetadataConversationID,
+					"conversation-inherited",
+				)
+				if err != nil {
+					t.Fatalf("WithBaggageExact() error = %v", err)
+				}
+				return core.WithConversationID(ctx, "conversation-inherited")
+			},
+			conversation: "invalid conversation",
+		},
+		{
+			name: "exact baggage capacity rejection",
+			base: func(t *testing.T) context.Context {
+				ctx := core.WithConversationID(
+					context.Background(),
+					"conversation-inherited",
+				)
+				labels := make([]string, 0, telemetry.MaxBaggageItems*2)
+				for i := 0; i < telemetry.MaxBaggageItems; i++ {
+					labels = append(labels, fmt.Sprintf("item_%02d", i), "value")
+				}
+				ctx = telemetry.WithBaggage(ctx, labels...)
+				if got := len(telemetry.GetBaggage(ctx)); got != telemetry.MaxBaggageItems {
+					t.Fatalf("baggage items = %d, want %d", got, telemetry.MaxBaggageItems)
+				}
+				return ctx
+			},
+			conversation: "conversation-checkpoint",
+		},
+		{
+			name: "over-limit checkpoint metadata",
+			base: func(*testing.T) context.Context {
+				return core.WithConversationID(
+					context.Background(),
+					"conversation-inherited",
+				)
+			},
+			conversation: strings.Repeat("x", core.MaxConversationIDLength+1),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := setupHITLResumeTestTracer(t)
+			baseCtx := WithMetadata(test.base(t), map[string]interface{}{
+				MetadataConversationID: "conversation-inherited",
+				"inherited_only":       true,
+			})
+			checkpoint := &ExecutionCheckpoint{
+				CheckpointID: "cp-rejected-conversation",
+				RequestID:    "request-resume",
+				Status:       CheckpointStatusApproved,
+				UserContext: map[string]interface{}{
+					MetadataConversationID: test.conversation,
+					"checkpoint_only":      true,
+				},
+			}
+
+			resumeCtx, endSpan, err := BuildResumeContext(baseCtx, checkpoint)
+			if err != nil {
+				t.Fatalf("BuildResumeContext() error = %v", err)
+			}
+
+			if got := core.GetConversationID(resumeCtx); got != "" {
+				t.Fatalf("inherited core conversation leaked: %q", got)
+			}
+			if _, present := telemetry.GetBaggage(resumeCtx)[MetadataConversationID]; present {
+				t.Fatal("inherited conversation baggage leaked")
+			}
+			if _, present := GetMetadata(resumeCtx)[MetadataConversationID]; present {
+				t.Fatalf("rejected conversation metadata leaked: %v", GetMetadata(resumeCtx))
+			}
+			if GetMetadata(resumeCtx)["checkpoint_only"] != true {
+				t.Fatalf("checkpoint metadata was not preserved: %v", GetMetadata(resumeCtx))
+			}
+			if _, present := GetMetadata(resumeCtx)["inherited_only"]; present {
+				t.Fatalf("inherited metadata was not shadowed: %v", GetMetadata(resumeCtx))
+			}
+
+			endSpan()
+			ended := recorder.Ended()
+			if len(ended) != 1 {
+				t.Fatalf("ended spans = %d, want 1", len(ended))
+			}
+			if got, present := readOnlySpanStringAttribute(ended[0], MetadataConversationID); present {
+				t.Fatalf("rejected conversation reached span: %q", got)
+			}
+			if status := ended[0].Status(); status.Code != codes.Unset {
+				t.Fatalf("span status = %v (%q), want unset", status.Code, status.Description)
+			}
+			for _, event := range ended[0].Events() {
+				if event.Name == "exception" {
+					t.Fatalf("conversation rejection recorded an exception: %+v", event)
+				}
+			}
+		})
+	}
+}
+
+func TestPrepareResumeConversationContext_ReportsBoundedRejections(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctx        func(t *testing.T) context.Context
+		metadata   map[string]interface{}
+		wantSource string
+		wantReason string
+	}{
+		{
+			name: "metadata validation",
+			ctx:  func(*testing.T) context.Context { return context.Background() },
+			metadata: map[string]interface{}{
+				MetadataConversationID: "invalid conversation",
+			},
+			wantSource: conversationIDSourceCheckpointMetadata,
+			wantReason: string(core.ConversationIDValidationInvalidCharacter),
+		},
+		{
+			name: "baggage capacity",
+			ctx: func(t *testing.T) context.Context {
+				labels := make([]string, 0, telemetry.MaxBaggageItems*2)
+				for i := 0; i < telemetry.MaxBaggageItems; i++ {
+					labels = append(labels, fmt.Sprintf("item_%02d", i), "value")
+				}
+				return telemetry.WithBaggage(context.Background(), labels...)
+			},
+			metadata: map[string]interface{}{
+				MetadataConversationID: "conversation-checkpoint",
+			},
+			wantSource: conversationIDSourceBaggageExact,
+			wantReason: "item_limit",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var gotSource, gotReason string
+			gotCtx, gotID, gotMetadata := prepareResumeConversationContext(
+				test.ctx(t),
+				test.metadata,
+				func(source, reason string) {
+					gotSource = source
+					gotReason = reason
+				},
+			)
+
+			if gotSource != test.wantSource || gotReason != test.wantReason {
+				t.Fatalf(
+					"diagnostic = (%q, %q), want (%q, %q)",
+					gotSource,
+					gotReason,
+					test.wantSource,
+					test.wantReason,
+				)
+			}
+			if gotID != "" || core.GetConversationID(gotCtx) != "" {
+				t.Fatalf("rejected identity survived: id=%q core=%q", gotID, core.GetConversationID(gotCtx))
+			}
+			if _, present := gotMetadata[MetadataConversationID]; present {
+				t.Fatalf("rejected identity survived in metadata: %v", gotMetadata)
+			}
+		})
+	}
+}
+
+func TestBuildResumeContext_EmptyCheckpointMetadataPreservesOnlyUnrelatedInheritedMetadata(t *testing.T) {
+	ctx, err := telemetry.WithBaggageExact(
+		context.Background(),
+		MetadataConversationID,
+		"conversation-inherited",
+	)
+	if err != nil {
+		t.Fatalf("WithBaggageExact() error = %v", err)
+	}
+	ctx = core.WithConversationID(ctx, "conversation-inherited")
+	ctx = WithMetadata(ctx, map[string]interface{}{
+		MetadataConversationID: "conversation-inherited",
+		"application_key":      "preserved",
+	})
+
+	resumeCtx, endSpan, err := BuildResumeContext(ctx, &ExecutionCheckpoint{
+		CheckpointID: "cp-empty-metadata",
+		RequestID:    "request-resume",
+		Status:       CheckpointStatusApproved,
+	})
+	if err != nil {
+		t.Fatalf("BuildResumeContext() error = %v", err)
+	}
+	defer endSpan()
+
+	if core.GetConversationID(resumeCtx) != "" {
+		t.Fatalf("inherited core conversation leaked: %q", core.GetConversationID(resumeCtx))
+	}
+	if _, present := telemetry.GetBaggage(resumeCtx)[MetadataConversationID]; present {
+		t.Fatal("inherited conversation baggage leaked")
+	}
+	metadata := GetMetadata(resumeCtx)
+	if _, present := metadata[MetadataConversationID]; present {
+		t.Fatalf("inherited conversation metadata leaked: %v", metadata)
+	}
+	if metadata["application_key"] != "preserved" {
+		t.Fatalf("unrelated inherited metadata was lost: %v", metadata)
+	}
+}
+
+func setupHITLResumeTestTracer(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	originalProvider := otel.GetTracerProvider()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(originalProvider)
+		_ = provider.Shutdown(context.Background())
+	})
+	return recorder
 }

--- a/orchestration/interfaces.go
+++ b/orchestration/interfaces.go
@@ -1346,6 +1346,16 @@ func DefaultConfig() *OrchestratorConfig {
 	if keyPrefix := os.Getenv("TRUVAG3_EXECUTION_DEBUG_KEY_PREFIX"); keyPrefix != "" {
 		config.ExecutionStore.KeyPrefix = keyPrefix
 	}
+	if value := os.Getenv("TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT"); value != "" {
+		if limit, err := strconv.Atoi(value); err == nil && limit > 0 {
+			config.ExecutionStore.ConversationQueryLimit = limit
+		}
+	}
+	if value := os.Getenv("TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT"); value != "" {
+		if limit, err := strconv.Atoi(value); err == nil && limit > 0 {
+			config.ExecutionStore.ConversationIndexScanLimit = limit
+		}
+	}
 
 	// Agent name from environment (for DAG visualization and HITL isolation)
 	// Falls back to RequestIDPrefix if Name is not set, then "orchestrator"

--- a/orchestration/llm_call_recorder_adapter_test.go
+++ b/orchestration/llm_call_recorder_adapter_test.go
@@ -24,10 +24,11 @@ type mockLLMDebugStore struct {
 	mu           sync.Mutex
 	interactions []LLMInteraction
 	requestIDs   []string
+	contexts     []context.Context
 	err          error // injected error for failure testing
 }
 
-func (m *mockLLMDebugStore) RecordInteraction(_ context.Context, requestID string, interaction LLMInteraction) error {
+func (m *mockLLMDebugStore) RecordInteraction(ctx context.Context, requestID string, interaction LLMInteraction) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.err != nil {
@@ -35,6 +36,7 @@ func (m *mockLLMDebugStore) RecordInteraction(_ context.Context, requestID strin
 	}
 	m.interactions = append(m.interactions, interaction)
 	m.requestIDs = append(m.requestIDs, requestID)
+	m.contexts = append(m.contexts, ctx)
 	return nil
 }
 

--- a/orchestration/llm_debug_store.go
+++ b/orchestration/llm_debug_store.go
@@ -13,6 +13,9 @@ package orchestration
 import (
 	"context"
 	"time"
+
+	"github.com/truvaagents/truva-g3/core"
+	"github.com/truvaagents/truva-g3/telemetry"
 )
 
 // LLMDebugStore stores LLM interaction payloads for debugging.
@@ -74,8 +77,36 @@ type LLMDebugRecord struct {
 	// first writer wins. Empty for records written before this field was added.
 	OriginatingAgent string `json:"originating_agent,omitempty"`
 
-	// Metadata contains additional key-value pairs for investigation
+	// Metadata contains framework-owned correlation metadata plus optional
+	// application investigation metadata. MetadataConversationID is reserved
+	// for the immutable conversation identity captured by the first valid
+	// writer.
 	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// LLMDebugConversationID returns the record's multi-turn correlation ID.
+func LLMDebugConversationID(record *LLMDebugRecord) string {
+	if record == nil {
+		return ""
+	}
+	return record.Metadata[MetadataConversationID]
+}
+
+func llmDebugConversationIDFromContext(ctx context.Context) string {
+	coreCandidate := core.GetConversationIDCandidate(ctx)
+	if coreCandidate.Present {
+		if coreCandidate.RejectionReason != core.ConversationIDValidationNone ||
+			core.ValidateConversationID(coreCandidate.Value) != core.ConversationIDValidationNone {
+			return ""
+		}
+		return coreCandidate.Value
+	}
+
+	conversationID := telemetry.GetBaggage(ctx)[MetadataConversationID]
+	if core.ValidateConversationID(conversationID) != core.ConversationIDValidationNone {
+		return ""
+	}
+	return conversationID
 }
 
 // Hook execution phases used in LLMInteraction.HookPhase.

--- a/orchestration/memory_llm_debug_store.go
+++ b/orchestration/memory_llm_debug_store.go
@@ -52,17 +52,31 @@ func (s *MemoryLLMDebugStore) RecordInteraction(ctx context.Context, requestID s
 			OriginatingAgent:  originatingAgent,
 			Metadata:          make(map[string]string),
 		}
+		if conversationID := llmDebugConversationIDFromContext(ctx); conversationID != "" {
+			record.Metadata[MetadataConversationID] = conversationID
+		}
 		s.records[requestID] = record
-	} else if record.OriginatingAgent == "" {
+	} else {
+		if LLMDebugConversationID(record) == "" {
+			if conversationID := llmDebugConversationIDFromContext(ctx); conversationID != "" {
+				if record.Metadata == nil {
+					record.Metadata = make(map[string]string)
+				}
+				record.Metadata[MetadataConversationID] = conversationID
+			}
+		}
+
 		// "First writer with a value wins" — mirrors RedisLLMDebugStore, which gates
 		// its HSetNX call on non-empty baggage so an empty first write never locks
 		// the field. A later write that carries agent_name baggage backfills it
 		// here; once non-empty, it sticks. See the two
 		// TestXxxLLMDebugStore_OriginatingAgent_BackfillOnLaterWrite tests for the
 		// parity assertion.
-		if bag := telemetry.GetBaggage(ctx); bag != nil {
-			if name := bag["agent_name"]; name != "" {
-				record.OriginatingAgent = name
+		if record.OriginatingAgent == "" {
+			if bag := telemetry.GetBaggage(ctx); bag != nil {
+				if name := bag["agent_name"]; name != "" {
+					record.OriginatingAgent = name
+				}
 			}
 		}
 	}
@@ -98,6 +112,10 @@ func (s *MemoryLLMDebugStore) GetRecord(ctx context.Context, requestID string) (
 
 // SetMetadata adds metadata to an existing record.
 func (s *MemoryLLMDebugStore) SetMetadata(ctx context.Context, requestID string, key, value string) error {
+	if key == MetadataConversationID {
+		return fmt.Errorf("%s is framework-owned and cannot be changed", MetadataConversationID)
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/orchestration/metadata_keys.go
+++ b/orchestration/metadata_keys.go
@@ -4,7 +4,12 @@ import "github.com/truvaagents/truva-g3/core"
 
 const (
 	MetadataConversationTurns = "conversation_turns"
-	MetadataConversationID    = "conversation_id"
+
+	// MetadataConversationID is the framework-owned canonical correlation key
+	// for all turns and delegated executions in one multi-turn conversation.
+	// Applications may supply it at orchestration ingress, but execution-store
+	// investigation metadata must not mutate it after persistence.
+	MetadataConversationID = "conversation_id"
 )
 
 type conversationIDCandidate struct {

--- a/orchestration/metadata_keys.go
+++ b/orchestration/metadata_keys.go
@@ -1,6 +1,42 @@
 package orchestration
 
+import "github.com/truvaagents/truva-g3/core"
+
 const (
-	MetadataConversationTurns      = "conversation_turns"
-	MetadataConversationSessionKey = "conversation_session_key"
+	MetadataConversationTurns = "conversation_turns"
+	MetadataConversationID    = "conversation_id"
 )
+
+type conversationIDCandidate struct {
+	Present bool
+	Value   string
+	Reason  core.ConversationIDValidationReason
+}
+
+func conversationIDCandidateFromMetadata(metadata map[string]interface{}) conversationIDCandidate {
+	raw, present := metadata[MetadataConversationID]
+	if !present {
+		return conversationIDCandidate{}
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return conversationIDCandidate{
+			Present: true,
+			Reason:  core.ConversationIDValidationInvalidType,
+		}
+	}
+	if reason := core.ValidateConversationID(value); reason != core.ConversationIDValidationNone {
+		return conversationIDCandidate{
+			Present: true,
+			Reason:  reason,
+		}
+	}
+	return conversationIDCandidate{
+		Present: true,
+		Value:   value,
+	}
+}
+
+func conversationIDFromMetadata(metadata map[string]interface{}) string {
+	return conversationIDCandidateFromMetadata(metadata).Value
+}

--- a/orchestration/metadata_keys_test.go
+++ b/orchestration/metadata_keys_test.go
@@ -1,0 +1,92 @@
+package orchestration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/truvaagents/truva-g3/core"
+)
+
+func TestConversationIDCandidateFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		metadata  map[string]interface{}
+		candidate conversationIDCandidate
+	}{
+		{
+			name:     "absent",
+			metadata: map[string]interface{}{},
+		},
+		{
+			name: "valid",
+			metadata: map[string]interface{}{
+				MetadataConversationID: "conversation-1",
+			},
+			candidate: conversationIDCandidate{
+				Present: true,
+				Value:   "conversation-1",
+			},
+		},
+		{
+			name: "wrong type",
+			metadata: map[string]interface{}{
+				MetadataConversationID: 42,
+			},
+			candidate: conversationIDCandidate{
+				Present: true,
+				Reason:  core.ConversationIDValidationInvalidType,
+			},
+		},
+		{
+			name: "empty",
+			metadata: map[string]interface{}{
+				MetadataConversationID: "",
+			},
+			candidate: conversationIDCandidate{
+				Present: true,
+				Reason:  core.ConversationIDValidationEmpty,
+			},
+		},
+		{
+			name: "invalid character",
+			metadata: map[string]interface{}{
+				MetadataConversationID: "conversation 1",
+			},
+			candidate: conversationIDCandidate{
+				Present: true,
+				Reason:  core.ConversationIDValidationInvalidCharacter,
+			},
+		},
+		{
+			name: "too long",
+			metadata: map[string]interface{}{
+				MetadataConversationID: strings.Repeat("a", core.MaxConversationIDLength+1),
+			},
+			candidate: conversationIDCandidate{
+				Present: true,
+				Reason:  core.ConversationIDValidationTooLong,
+			},
+		},
+		{
+			name: "session ID is not promoted",
+			metadata: map[string]interface{}{
+				"session_id": "application-session",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			candidate := conversationIDCandidateFromMetadata(tt.metadata)
+			if candidate != tt.candidate {
+				t.Fatalf("candidate = %+v, want %+v", candidate, tt.candidate)
+			}
+			if value := conversationIDFromMetadata(tt.metadata); value != tt.candidate.Value {
+				t.Fatalf("conversationIDFromMetadata() = %q, want %q", value, tt.candidate.Value)
+			}
+		})
+	}
+}

--- a/orchestration/orch_022_test.go
+++ b/orchestration/orch_022_test.go
@@ -352,7 +352,7 @@ func TestStore_InterruptedUsesDefaultTTL(t *testing.T) {
 		t.Fatalf("Store failed: %v", err)
 	}
 
-	got := provider.lastTTL("truvag3:execution:debug::req-interrupt")
+	got := provider.lastTTL("truvag3:execution:debug:req-interrupt")
 	if got != 24*time.Hour {
 		t.Errorf("interrupted TTL = %v, want 24h (default); got errorTTL-routing regression", got)
 	}
@@ -373,7 +373,7 @@ func TestStore_ErrorUsesErrorTTL(t *testing.T) {
 		t.Fatalf("Store failed: %v", err)
 	}
 
-	got := provider.lastTTL("truvag3:execution:debug::req-error")
+	got := provider.lastTTL("truvag3:execution:debug:req-error")
 	if got != 1*time.Hour {
 		t.Errorf("errored TTL = %v, want 1h (errorTTL)", got)
 	}
@@ -393,7 +393,7 @@ func TestStore_SuccessUsesDefaultTTL(t *testing.T) {
 		t.Fatalf("Store failed: %v", err)
 	}
 
-	got := provider.lastTTL("truvag3:execution:debug::req-success")
+	got := provider.lastTTL("truvag3:execution:debug:req-success")
 	if got != 24*time.Hour {
 		t.Errorf("success TTL = %v, want 24h", got)
 	}
@@ -421,7 +421,7 @@ func TestSetMetadata_InterruptedUsesDefaultTTL(t *testing.T) {
 	if err := store.SetMetadata(ctx, "req-sm-interrupt", "note", "approved"); err != nil {
 		t.Fatalf("SetMetadata failed: %v", err)
 	}
-	got := provider.lastTTL("truvag3:execution:debug::req-sm-interrupt")
+	got := provider.lastTTL("truvag3:execution:debug:req-sm-interrupt")
 	if got != 24*time.Hour {
 		t.Errorf("interrupted SetMetadata TTL = %v, want 24h", got)
 	}
@@ -444,7 +444,7 @@ func TestSetMetadata_ErrorUsesErrorTTL(t *testing.T) {
 	if err := store.SetMetadata(ctx, "req-sm-error", "note", "probed"); err != nil {
 		t.Fatalf("SetMetadata failed: %v", err)
 	}
-	got := provider.lastTTL("truvag3:execution:debug::req-sm-error")
+	got := provider.lastTTL("truvag3:execution:debug:req-sm-error")
 	if got != 1*time.Hour {
 		t.Errorf("errored SetMetadata TTL = %v, want 1h (errorTTL)", got)
 	}
@@ -468,7 +468,7 @@ func redisTTLStoreFixture(t *testing.T) (*miniredis.Miniredis, *RedisExecutionDe
 	store := &RedisExecutionDebugStore{
 		client:    client,
 		logger:    &core.NoOpLogger{},
-		keyPrefix: executionDebugKeyPrefix, // "truvag3:execution:debug:" (trailing colon required — recordKey just concatenates)
+		keyPrefix: executionDebugKeyPrefix,
 		ttl:       24 * time.Hour,
 		errorTTL:  1 * time.Hour, // shorter than ttl so carve-out is observable
 	}

--- a/orchestration/orchestrator.go
+++ b/orchestration/orchestrator.go
@@ -294,6 +294,7 @@ var reservedPropagationHeaders = map[string]bool{
 	"Content-Type":                  true, // Always application/json (set by executor)
 	"X-Truvag3-Request-Id":          true, // Distributed tracing (set by executor)
 	"X-Truvag3-Original-Request-Id": true, // Original request id across HITL resume (set by executor)
+	"X-Truvag3-Conversation-Id":     true, // Multi-turn conversation correlation (set by executor)
 	"X-Truvag3-Step-Id":             true, // Step correlation (set by executor)
 	"X-Truvag3-Phase-Number":        true, // Phase correlation (set by executor)
 	"X-Truvag3-Plan-Id":             true, // Plan correlation (set by executor)

--- a/orchestration/orchestrator.go
+++ b/orchestration/orchestrator.go
@@ -1283,6 +1283,17 @@ func (o *AIOrchestrator) storeExecutionAsync(
 	// The parent context may be canceled after the HTTP handler returns,
 	// but we still want the async recording to complete.
 	bag := telemetry.GetBaggage(ctx)
+	traceID := telemetry.GetTraceContext(ctx).TraceID
+	conversationID := core.GetConversationID(ctx)
+	if core.ValidateConversationID(conversationID) != core.ConversationIDValidationNone {
+		conversationID = ""
+	}
+	originalRequestID := requestID
+	if bag != nil {
+		if origID := bag["original_request_id"]; origID != "" {
+			originalRequestID = origID
+		}
+	}
 
 	// Capture agentName now (accesses o.config which should be immutable)
 	agentName := o.getAgentName()
@@ -1297,18 +1308,6 @@ func (o *AIOrchestrator) storeExecutionAsync(
 		storeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 
-		// Extract trace correlation from baggage
-		traceID := ""
-		originalRequestID := requestID
-		if bag != nil {
-			if tid, ok := bag["trace_id"]; ok {
-				traceID = tid
-			}
-			if origID, ok := bag["original_request_id"]; ok && origID != "" {
-				originalRequestID = origID
-			}
-		}
-
 		stored := &StoredExecution{
 			RequestID:         requestID,
 			OriginalRequestID: originalRequestID,
@@ -1320,6 +1319,12 @@ func (o *AIOrchestrator) storeExecutionAsync(
 			Interrupted:       checkpoint != nil,
 			Checkpoint:        checkpoint,
 			CreatedAt:         createdAt,
+		}
+
+		if conversationID != "" {
+			stored.Metadata = map[string]string{
+				MetadataConversationID: conversationID,
+			}
 		}
 
 		// Tag resumed executions so the registry viewer can link them to the interrupted one.
@@ -1366,10 +1371,14 @@ func (o *AIOrchestrator) storeExecutionAsync(
 					"operation":   "execution_store",
 					"request_id":  requestID,
 					"interrupted": checkpoint != nil,
-					"error":       storeErr.Error(),
+					"error_type":  "store_write",
+					"error":       safeExecutionStoreError(storeErr),
 				}
 				if traceID != "" {
 					logFields["trace_id"] = traceID
+				}
+				if conversationID != "" {
+					logFields[MetadataConversationID] = conversationID
 				}
 				if checkpoint != nil && checkpoint.CheckpointID != "" {
 					logFields["checkpoint_id"] = checkpoint.CheckpointID
@@ -1378,6 +1387,19 @@ func (o *AIOrchestrator) storeExecutionAsync(
 			}
 		}
 	}()
+}
+
+func safeExecutionStoreError(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, context.DeadlineExceeded):
+		return "execution store write timed out"
+	case errors.Is(err, context.Canceled):
+		return "execution store write canceled"
+	default:
+		return "execution store backend write failed"
+	}
 }
 
 // SetInterruptController sets the HITL interrupt controller.
@@ -2741,6 +2763,9 @@ func (o *AIOrchestrator) ProcessRequest(ctx context.Context, request string, met
 	// can access it via telemetry.GetBaggage() and include it in their logs
 	ctx = telemetry.WithBaggage(ctx, "request_id", requestID)
 
+	ctx, conversationID, requestMetadata := o.resolveConversationContext(ctx, metadata)
+	metadata = requestMetadata
+
 	// Propagate agent name so downstream tool calls can identify the
 	// requesting agent (used by schedule_task to default target_agent).
 	if o.config.Name != "" {
@@ -2758,17 +2783,25 @@ func (o *AIOrchestrator) ProcessRequest(ctx context.Context, request string, met
 	// when creating checkpoints during execution (e.g., step-level interrupts)
 	ctx = WithRequestID(ctx, requestID)
 
-	// Store metadata in context for HITL checkpoint creation
-	// This preserves session_id, user_id, etc. when creating checkpoints
-	ctx = WithMetadata(ctx, metadata)
+	// Store a merged clone for HITL checkpoint creation. Existing resume
+	// metadata survives nil request metadata, and only the validated canonical
+	// conversation ID is restored under the framework-owned key.
+	ctx = withCheckpointMetadata(ctx, metadata, conversationID)
 
 	// CRITICAL: Add request_id to the PARENT span (HTTP span) for trace searchability
 	// This must be done BEFORE creating the child orchestrator span, while the HTTP span
 	// is still the current span in context. This enables searching by request_id in distributed
 	// tracing tools to show the correct root operation name (e.g., "HTTP POST /chat/stream")
-	telemetry.SetSpanAttributes(ctx,
+	parentSpanAttributes := []attribute.KeyValue{
 		attribute.String("request_id", requestID),
-	)
+	}
+	if conversationID != "" {
+		parentSpanAttributes = append(
+			parentSpanAttributes,
+			attribute.String(MetadataConversationID, conversationID),
+		)
+	}
+	telemetry.SetSpanAttributes(ctx, parentSpanAttributes...)
 	// Also set original_request_id on parent span for trace correlation
 	if bag := telemetry.GetBaggage(ctx); bag != nil && bag["original_request_id"] != "" {
 		telemetry.SetSpanAttributes(ctx,
@@ -2798,6 +2831,9 @@ func (o *AIOrchestrator) ProcessRequest(ctx context.Context, request string, met
 	if span != nil {
 		span.SetAttribute("request_id", requestID)
 		span.SetAttribute("request_length", len(request))
+		if conversationID != "" {
+			span.SetAttribute(MetadataConversationID, conversationID)
+		}
 		// Set original_request_id for trace correlation - will be same as request_id on initial,
 		// or the original value on resumes (preserved from baggage set by handler)
 		if bag := telemetry.GetBaggage(ctx); bag != nil && bag["original_request_id"] != "" {
@@ -2991,6 +3027,9 @@ func (o *AIOrchestrator) ProcessRequestStreaming(
 	// can access it via telemetry.GetBaggage() and include it in their logs
 	ctx = telemetry.WithBaggage(ctx, "request_id", requestID)
 
+	ctx, conversationID, requestMetadata := o.resolveConversationContext(ctx, metadata)
+	metadata = requestMetadata
+
 	// Propagate agent name so downstream tool calls can identify the
 	// requesting agent (used by schedule_task to default target_agent).
 	if o.config.Name != "" {
@@ -3008,17 +3047,25 @@ func (o *AIOrchestrator) ProcessRequestStreaming(
 	// when creating checkpoints during execution (e.g., step-level interrupts)
 	ctx = WithRequestID(ctx, requestID)
 
-	// Store metadata in context for HITL checkpoint creation
-	// This preserves session_id, user_id, etc. when creating checkpoints
-	ctx = WithMetadata(ctx, metadata)
+	// Store a merged clone for HITL checkpoint creation. Existing resume
+	// metadata survives nil request metadata, and only the validated canonical
+	// conversation ID is restored under the framework-owned key.
+	ctx = withCheckpointMetadata(ctx, metadata, conversationID)
 
 	// CRITICAL: Add request_id to the PARENT span (HTTP span) for trace searchability
 	// This must be done BEFORE creating the child orchestrator span, while the HTTP span
 	// is still the current span in context. This enables searching by request_id in distributed
 	// tracing tools to show the correct root operation name (e.g., "HTTP POST /chat/stream")
-	telemetry.SetSpanAttributes(ctx,
+	parentSpanAttributes := []attribute.KeyValue{
 		attribute.String("request_id", requestID),
-	)
+	}
+	if conversationID != "" {
+		parentSpanAttributes = append(
+			parentSpanAttributes,
+			attribute.String(MetadataConversationID, conversationID),
+		)
+	}
+	telemetry.SetSpanAttributes(ctx, parentSpanAttributes...)
 	// Also set original_request_id on parent span for trace correlation
 	if bag := telemetry.GetBaggage(ctx); bag != nil && bag["original_request_id"] != "" {
 		telemetry.SetSpanAttributes(ctx,
@@ -3037,6 +3084,9 @@ func (o *AIOrchestrator) ProcessRequestStreaming(
 
 	span.SetAttribute("request_id", requestID)
 	span.SetAttribute("streaming", true)
+	if conversationID != "" {
+		span.SetAttribute(MetadataConversationID, conversationID)
+	}
 	// Set original_request_id for trace correlation - will be same as request_id on initial,
 	// or the original value on resumes (preserved from baggage set by handler)
 	if bag := telemetry.GetBaggage(ctx); bag != nil && bag["original_request_id"] != "" {

--- a/orchestration/pipeline_hooks.go
+++ b/orchestration/pipeline_hooks.go
@@ -48,14 +48,14 @@ func prepareKnownEnrichments(
 	}
 
 	if historyPreparer != nil {
+		conversationID := conversationIDFromMetadata(metadata)
 		if turns, ok := conversationTurnsFromMetadata(metadata[MetadataConversationTurns]); ok {
-			sessionKey, _ := metadata[MetadataConversationSessionKey].(string)
-			prepared, _, _ := historyPreparer.PrepareFromTurns(ctx, sessionKey, turns)
+			prepared, _, _ := historyPreparer.PrepareFromTurns(ctx, conversationID, turns)
 			if prepared != "" {
 				enrichments[core.EnrichmentConversationHistory] = prepared
 			}
 		} else if raw, ok := metadata[core.EnrichmentConversationHistory].(string); ok && raw != "" {
-			prepared, _, _ := historyPreparer.PrepareFromText(ctx, "", raw)
+			prepared, _, _ := historyPreparer.PrepareFromText(ctx, conversationID, raw)
 			if prepared != "" {
 				enrichments[core.EnrichmentConversationHistory] = prepared
 			}

--- a/orchestration/pipeline_hooks_test.go
+++ b/orchestration/pipeline_hooks_test.go
@@ -6,23 +6,24 @@ import (
 	"testing"
 
 	"github.com/truvaagents/truva-g3/core"
+	"github.com/truvaagents/truva-g3/telemetry"
 )
 
 type stubConversationHistoryPreparer struct {
-	lastSessionKey string
-	lastTurns      []core.ConversationTurn
-	lastText       string
-	prepared       string
+	lastConversationID string
+	lastTurns          []core.ConversationTurn
+	lastText           string
+	prepared           string
 }
 
 func (s *stubConversationHistoryPreparer) PrepareFromText(ctx context.Context, sessionKey string, formatted string) (string, HistoryPreparationResult, error) {
-	s.lastSessionKey = sessionKey
+	s.lastConversationID = sessionKey
 	s.lastText = formatted
 	return s.prepared, HistoryPreparationResult{Path: "metadata_text"}, nil
 }
 
 func (s *stubConversationHistoryPreparer) PrepareFromTurns(ctx context.Context, sessionKey string, turns []core.ConversationTurn) (string, HistoryPreparationResult, error) {
-	s.lastSessionKey = sessionKey
+	s.lastConversationID = sessionKey
 	s.lastTurns = turns
 	return s.prepared, HistoryPreparationResult{Path: "metadata_turns"}, nil
 }
@@ -221,7 +222,7 @@ func TestPrepareKnownEnrichments_PreparesConversationTurns(t *testing.T) {
 		MetadataConversationTurns: []core.ConversationTurn{
 			{Role: "user", Content: "hello"},
 		},
-		MetadataConversationSessionKey: "session-123",
+		MetadataConversationID: "conversation-123",
 	}
 
 	prepareKnownEnrichments(context.Background(), metadata, enrichments, preparer)
@@ -229,11 +230,76 @@ func TestPrepareKnownEnrichments_PreparesConversationTurns(t *testing.T) {
 	if enrichments[core.EnrichmentConversationHistory] != "prepared history" {
 		t.Fatalf("expected prepared conversation history, got %v", enrichments[core.EnrichmentConversationHistory])
 	}
-	if preparer.lastSessionKey != "session-123" {
-		t.Fatalf("expected session key to be forwarded, got %q", preparer.lastSessionKey)
+	if preparer.lastConversationID != "conversation-123" {
+		t.Fatalf("expected conversation ID to be forwarded, got %q", preparer.lastConversationID)
 	}
 	if len(preparer.lastTurns) != 1 {
 		t.Fatalf("expected turns to be forwarded, got %d", len(preparer.lastTurns))
+	}
+}
+
+func TestPrepareKnownEnrichments_PreparesConversationTextWithCanonicalID(t *testing.T) {
+	preparer := &stubConversationHistoryPreparer{prepared: "prepared text"}
+	enrichments := map[string]interface{}{}
+	metadata := map[string]interface{}{
+		MetadataConversationID:             "conversation-text-1",
+		core.EnrichmentConversationHistory: "User: hello\nAssistant: hi",
+	}
+
+	prepareKnownEnrichments(context.Background(), metadata, enrichments, preparer)
+
+	if enrichments[core.EnrichmentConversationHistory] != "prepared text" {
+		t.Fatalf("expected prepared conversation history, got %v", enrichments[core.EnrichmentConversationHistory])
+	}
+	if preparer.lastConversationID != "conversation-text-1" {
+		t.Fatalf("expected canonical ID to be forwarded, got %q", preparer.lastConversationID)
+	}
+	if preparer.lastText != "User: hello\nAssistant: hi" {
+		t.Fatalf("expected formatted history to be forwarded, got %q", preparer.lastText)
+	}
+}
+
+func TestPrepareKnownEnrichments_DoesNotUseInvalidConversationID(t *testing.T) {
+	preparer := &stubConversationHistoryPreparer{prepared: "prepared text"}
+	enrichments := map[string]interface{}{}
+	metadata := map[string]interface{}{
+		MetadataConversationID:             "invalid conversation",
+		core.EnrichmentConversationHistory: "User: hello",
+	}
+
+	prepareKnownEnrichments(context.Background(), metadata, enrichments, preparer)
+
+	if preparer.lastConversationID != "" {
+		t.Fatalf("expected invalid conversation ID to be omitted, got %q", preparer.lastConversationID)
+	}
+}
+
+func TestPrepareKnownEnrichments_KeepsConversationCacheKeysSeparate(t *testing.T) {
+	preparer := &stubConversationHistoryPreparer{prepared: "prepared text"}
+
+	for _, conversationID := range []string{"conversation-a", "conversation-b"} {
+		prepareKnownEnrichments(
+			context.Background(),
+			map[string]interface{}{
+				MetadataConversationID:             conversationID,
+				core.EnrichmentConversationHistory: "User: hello",
+			},
+			map[string]interface{}{},
+			preparer,
+		)
+		if preparer.lastConversationID != conversationID {
+			t.Fatalf("cache key = %q, want %q", preparer.lastConversationID, conversationID)
+		}
+	}
+}
+
+func TestMaxConversationIDLengthMatchesBaggageValueLimit(t *testing.T) {
+	if core.MaxConversationIDLength != telemetry.MaxBaggageValueLength {
+		t.Fatalf(
+			"core.MaxConversationIDLength = %d, telemetry.MaxBaggageValueLength = %d",
+			core.MaxConversationIDLength,
+			telemetry.MaxBaggageValueLength,
+		)
 	}
 }
 
@@ -264,7 +330,7 @@ func TestPrepareKnownEnrichments_DecodesJSONRoundTrippedConversationTurns(t *tes
 				"content": "welcome back",
 			},
 		},
-		MetadataConversationSessionKey: "session-resume-1",
+		MetadataConversationID: "conversation-resume-1",
 	}
 
 	prepareKnownEnrichments(context.Background(), metadata, enrichments, preparer)
@@ -272,8 +338,8 @@ func TestPrepareKnownEnrichments_DecodesJSONRoundTrippedConversationTurns(t *tes
 	if enrichments[core.EnrichmentConversationHistory] != "prepared from decoded turns" {
 		t.Fatalf("expected decoded conversation turns to be prepared, got %v", enrichments[core.EnrichmentConversationHistory])
 	}
-	if preparer.lastSessionKey != "session-resume-1" {
-		t.Fatalf("expected session key to survive resume decoding, got %q", preparer.lastSessionKey)
+	if preparer.lastConversationID != "conversation-resume-1" {
+		t.Fatalf("expected conversation ID to survive resume decoding, got %q", preparer.lastConversationID)
 	}
 	if len(preparer.lastTurns) != 2 {
 		t.Fatalf("expected 2 decoded turns, got %d", len(preparer.lastTurns))

--- a/orchestration/redis_execution_store.go
+++ b/orchestration/redis_execution_store.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -27,6 +28,16 @@ const (
 	redisTTLKeyMissing time.Duration = -2
 	redisTTLPersistent time.Duration = -1
 )
+
+var conversationIndexUpsertScript = redis.NewScript(`
+local previous_ttl = redis.call("PTTL", KEYS[1])
+redis.call("ZADD", KEYS[1], ARGV[1], ARGV[2])
+local requested_ttl = tonumber(ARGV[3])
+if previous_ttl == -2 or (previous_ttl >= 0 and previous_ttl < requested_ttl) then
+	redis.call("PEXPIRE", KEYS[1], requested_ttl)
+end
+return previous_ttl
+`)
 
 // RedisExecutionDebugStoreOption configures the Redis execution debug store
 type RedisExecutionDebugStoreOption func(*redisExecutionDebugStoreConfig)
@@ -276,11 +287,13 @@ func (s *RedisExecutionDebugStore) Store(ctx context.Context, execution *StoredE
 
 		if conversationID != "" {
 			conversationKey := s.conversationIndexKey(conversationID)
-			previousTTL, ttlReadErr := s.client.TTL(ctx, conversationKey).Result()
-			if err := s.client.ZAdd(ctx, conversationKey, &redis.Z{
-				Score:  float64(storedExecution.CreatedAt.UnixNano()),
-				Member: storedExecution.RequestID,
-			}).Err(); err != nil {
+			if err := s.upsertConversationIndex(
+				ctx,
+				conversationKey,
+				float64(storedExecution.CreatedAt.UnixNano()),
+				storedExecution.RequestID,
+				ttl,
+			); err != nil {
 				if s.logger != nil {
 					s.logger.WarnWithContext(ctx, "Failed to update conversation execution index", map[string]interface{}{
 						"operation":  "execution_store_conversation_index",
@@ -289,18 +302,6 @@ func (s *RedisExecutionDebugStore) Store(ctx context.Context, execution *StoredE
 						"error":      safeExecutionStoreError(err),
 					})
 				}
-			} else if err := s.extendIndexTTLWithoutDowngrade(
-				ctx,
-				conversationKey,
-				ttl,
-				ttlReadErr == nil && previousTTL == redisTTLKeyMissing,
-			); err != nil && s.logger != nil {
-				s.logger.WarnWithContext(ctx, "Failed to extend conversation index TTL", map[string]interface{}{
-					"operation":  "execution_store_conversation_index_ttl",
-					"request_id": storedExecution.RequestID,
-					"error_type": "ttl_update",
-					"error":      safeExecutionStoreError(err),
-				})
 			}
 		}
 
@@ -555,8 +556,8 @@ func (s *RedisExecutionDebugStore) ListRecent(ctx context.Context, limit int) ([
 	return summaries, nil
 }
 
-// ListByConversationID returns a bounded chronological set of executions for
-// one conversation.
+// ListByConversationID returns the most recent bounded window of executions for
+// one conversation, ordered chronologically within that window.
 func (s *RedisExecutionDebugStore) ListByConversationID(
 	ctx context.Context,
 	conversationID string,
@@ -574,6 +575,7 @@ func (s *RedisExecutionDebugStore) ListByConversationID(
 	indexKey := s.conversationIndexKey(conversationID)
 	summaries := make([]ExecutionSummary, 0, limit)
 	staleMembers := make([]interface{}, 0)
+	seenMembers := make(map[string]struct{})
 
 	var offset int64
 	for scanned := 0; scanned < scanLimit && len(summaries) < limit; {
@@ -581,7 +583,7 @@ func (s *RedisExecutionDebugStore) ListByConversationID(
 		if remaining := scanLimit - scanned; remaining < batchSize {
 			batchSize = remaining
 		}
-		requestIDs, err := s.client.ZRange(
+		requestIDs, err := s.client.ZRevRange(
 			ctx,
 			indexKey,
 			offset,
@@ -593,42 +595,46 @@ func (s *RedisExecutionDebugStore) ListByConversationID(
 		if len(requestIDs) == 0 {
 			break
 		}
-		offset += int64(len(requestIDs))
-		scanned += len(requestIDs)
+		batchCount := len(requestIDs)
+		offset += int64(batchCount)
+		scanned += batchCount
+		requestIDs = filterUnseenConversationMembers(requestIDs, seenMembers)
 
-		recordKeys := make([]string, len(requestIDs))
-		for i, requestID := range requestIDs {
-			recordKeys[i] = s.recordKey(requestID)
+		if len(requestIDs) > 0 {
+			recordKeys := make([]string, len(requestIDs))
+			for i, requestID := range requestIDs {
+				recordKeys[i] = s.recordKey(requestID)
+			}
+			rawRecords, err := s.client.MGet(ctx, recordKeys...).Result()
+			if err != nil {
+				return nil, fmt.Errorf("failed to load conversation executions: %w", err)
+			}
+			for i, rawRecord := range rawRecords {
+				requestID := requestIDs[i]
+				if rawRecord == nil {
+					staleMembers = append(staleMembers, requestID)
+					continue
+				}
+				serialized, ok := rawRecord.(string)
+				if !ok {
+					staleMembers = append(staleMembers, requestID)
+					continue
+				}
+				execution, err := s.deserialize([]byte(serialized))
+				if err != nil || ExecutionConversationID(execution) != conversationID {
+					staleMembers = append(staleMembers, requestID)
+					continue
+				}
+				summaries = append(
+					summaries,
+					executionSummaryFromStored(execution),
+				)
+				if len(summaries) == limit {
+					break
+				}
+			}
 		}
-		rawRecords, err := s.client.MGet(ctx, recordKeys...).Result()
-		if err != nil {
-			return nil, fmt.Errorf("failed to load conversation executions: %w", err)
-		}
-		for i, rawRecord := range rawRecords {
-			requestID := requestIDs[i]
-			if rawRecord == nil {
-				staleMembers = append(staleMembers, requestID)
-				continue
-			}
-			serialized, ok := rawRecord.(string)
-			if !ok {
-				staleMembers = append(staleMembers, requestID)
-				continue
-			}
-			execution, err := s.deserialize([]byte(serialized))
-			if err != nil || ExecutionConversationID(execution) != conversationID {
-				staleMembers = append(staleMembers, requestID)
-				continue
-			}
-			summaries = append(
-				summaries,
-				executionSummaryFromStored(execution),
-			)
-			if len(summaries) == limit {
-				break
-			}
-		}
-		if len(requestIDs) < batchSize {
+		if batchCount < batchSize {
 			break
 		}
 	}
@@ -644,6 +650,9 @@ func (s *RedisExecutionDebugStore) ListByConversationID(
 		}
 	}
 
+	for left, right := 0, len(summaries)-1; left < right; left, right = left+1, right-1 {
+		summaries[left], summaries[right] = summaries[right], summaries[left]
+	}
 	return summaries, nil
 }
 
@@ -668,6 +677,27 @@ func (s *RedisExecutionDebugStore) traceKey(traceID string) string {
 
 func (s *RedisExecutionDebugStore) conversationIndexKey(conversationID string) string {
 	return executionConversationIndexKey(s.keyPrefix, conversationID)
+}
+
+func (s *RedisExecutionDebugStore) upsertConversationIndex(
+	ctx context.Context,
+	key string,
+	score float64,
+	requestID string,
+	minTTL time.Duration,
+) error {
+	ttlMilliseconds := minTTL.Milliseconds()
+	if ttlMilliseconds <= 0 {
+		ttlMilliseconds = 1
+	}
+	return conversationIndexUpsertScript.Run(
+		ctx,
+		s.client,
+		[]string{key},
+		strconv.FormatFloat(score, 'g', -1, 64),
+		requestID,
+		strconv.FormatInt(ttlMilliseconds, 10),
+	).Err()
 }
 
 func (s *RedisExecutionDebugStore) extendIndexTTLWithoutDowngrade(

--- a/orchestration/redis_execution_store.go
+++ b/orchestration/redis_execution_store.go
@@ -382,6 +382,9 @@ func (s *RedisExecutionDebugStore) SetMetadata(ctx context.Context, requestID st
 	if requestID == "" {
 		return fmt.Errorf("request_id is required")
 	}
+	if key == MetadataConversationID {
+		return fmt.Errorf("%s is framework-owned and cannot be changed", MetadataConversationID)
+	}
 
 	operation := func() error {
 		// Get existing record

--- a/orchestration/redis_execution_store.go
+++ b/orchestration/redis_execution_store.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -17,15 +16,16 @@ import (
 const (
 	// Redis key patterns for execution debug store
 	executionDebugKeyPrefix = "truvag3:execution:debug:"
-	executionDebugIndexKey  = "truvag3:execution:debug:index"
 
 	// Size thresholds for compression (same as LLM Debug Store)
 	executionCompressionThreshold = 100 * 1024  // 100KB
 	executionMaxPayloadSize       = 1024 * 1024 // 1MB
 
-	// Default TTLs (same as LLM Debug Store)
-	defaultExecutionDebugTTL = 24 * time.Hour
-	errorExecutionDebugTTL   = 7 * 24 * time.Hour
+	// go-redis/v8 preserves the Redis TTL sentinel integers as raw duration
+	// values rather than multiplying them by the command's one-second
+	// precision.
+	redisTTLKeyMissing time.Duration = -2
+	redisTTLPersistent time.Duration = -1
 )
 
 // RedisExecutionDebugStoreOption configures the Redis execution debug store
@@ -39,6 +39,8 @@ type redisExecutionDebugStoreConfig struct {
 	keyPrefix      string
 	ttl            time.Duration
 	errorTTL       time.Duration
+	queryLimit     int
+	indexScanLimit int
 }
 
 // WithExecutionDebugRedisURL sets the Redis connection URL
@@ -108,6 +110,8 @@ type RedisExecutionDebugStore struct {
 	keyPrefix      string
 	ttl            time.Duration
 	errorTTL       time.Duration
+	queryLimit     int
+	indexScanLimit int
 
 	// Layer 1 resilience state (simple failure tracking)
 	failureCount int
@@ -124,6 +128,8 @@ type RedisExecutionDebugStore struct {
 //   - TRUVAG3_EXECUTION_DEBUG_TTL: TTL for successful records (default: 24h)
 //   - TRUVAG3_EXECUTION_DEBUG_ERROR_TTL: TTL for error records (default: 168h)
 //   - TRUVAG3_EXECUTION_DEBUG_KEY_PREFIX: Key prefix (default: truvag3:execution:debug)
+//   - TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT: per-query result ceiling (default: 1000)
+//   - TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT: per-query index scan ceiling (default: 5000)
 //
 // Usage:
 //
@@ -136,20 +142,37 @@ type RedisExecutionDebugStore struct {
 //	    orchestration.WithExecutionDebugTTL(48 * time.Hour),
 //	)
 func NewRedisExecutionDebugStore(opts ...RedisExecutionDebugStoreOption) (*RedisExecutionDebugStore, error) {
-	// Apply intelligent defaults from environment variables
+	return NewRedisExecutionDebugStoreWithConfig(
+		DefaultConfig().ExecutionStore,
+		opts...,
+	)
+}
+
+// NewRedisExecutionDebugStoreWithConfig creates a direct Redis execution
+// store using the same normalized framework configuration as provider-backed
+// stores. Redis connection settings remain configurable through the existing
+// Redis-specific options.
+func NewRedisExecutionDebugStoreWithConfig(
+	config ExecutionStoreConfig,
+	opts ...RedisExecutionDebugStoreOption,
+) (*RedisExecutionDebugStore, error) {
+	config = normalizeExecutionStoreConfig(config)
 	cfg := &redisExecutionDebugStoreConfig{
-		redisURL:  getRedisURLWithFallback(),
-		redisDB:   getEnvInt("TRUVAG3_EXECUTION_DEBUG_REDIS_DB", core.RedisDBExecutionDebug),
-		logger:    &core.NoOpLogger{},
-		keyPrefix: getEnvString("TRUVAG3_EXECUTION_DEBUG_KEY_PREFIX", executionDebugKeyPrefix),
-		ttl:       getEnvDuration("TRUVAG3_EXECUTION_DEBUG_TTL", defaultExecutionDebugTTL),
-		errorTTL:  getEnvDuration("TRUVAG3_EXECUTION_DEBUG_ERROR_TTL", errorExecutionDebugTTL),
+		redisURL:       getRedisURLWithFallback(),
+		redisDB:        getEnvInt("TRUVAG3_EXECUTION_DEBUG_REDIS_DB", core.RedisDBExecutionDebug),
+		logger:         &core.NoOpLogger{},
+		keyPrefix:      config.KeyPrefix,
+		ttl:            config.TTL,
+		errorTTL:       config.ErrorTTL,
+		queryLimit:     config.ConversationQueryLimit,
+		indexScanLimit: config.ConversationIndexScanLimit,
 	}
 
 	// Apply explicit options (override defaults)
 	for _, opt := range opts {
 		opt(cfg)
 	}
+	cfg.keyPrefix = normalizeExecutionKeyPrefix(cfg.keyPrefix)
 
 	// Parse Redis URL and create client
 	redisOpt, err := redis.ParseURL(cfg.redisURL)
@@ -176,13 +199,15 @@ func NewRedisExecutionDebugStore(opts ...RedisExecutionDebugStoreOption) (*Redis
 	// If not provided, built-in Layer 1 resilience (simple retry) is used
 
 	cfg.logger.Info("Redis execution debug store initialized", map[string]interface{}{
-		"redis_addr":      redisOpt.Addr,
-		"redis_db":        cfg.redisDB,
-		"key_prefix":      cfg.keyPrefix,
-		"ttl":             cfg.ttl.String(),
-		"error_ttl":       cfg.errorTTL.String(),
-		"circuit_breaker": cfg.circuitBreaker != nil,
-		"resilience":      "layer1_builtin", // Always has Layer 1
+		"redis_addr":                    redisOpt.Addr,
+		"redis_db":                      cfg.redisDB,
+		"key_prefix":                    cfg.keyPrefix,
+		"ttl":                           cfg.ttl.String(),
+		"error_ttl":                     cfg.errorTTL.String(),
+		"conversation_query_limit":      cfg.queryLimit,
+		"conversation_index_scan_limit": cfg.indexScanLimit,
+		"circuit_breaker":               cfg.circuitBreaker != nil,
+		"resilience":                    "layer1_builtin", // Always has Layer 1
 	})
 
 	return &RedisExecutionDebugStore{
@@ -192,6 +217,8 @@ func NewRedisExecutionDebugStore(opts ...RedisExecutionDebugStoreOption) (*Redis
 		keyPrefix:      cfg.keyPrefix,
 		ttl:            cfg.ttl,
 		errorTTL:       cfg.errorTTL,
+		queryLimit:     cfg.queryLimit,
+		indexScanLimit: cfg.indexScanLimit,
 	}, nil
 }
 
@@ -204,10 +231,11 @@ func (s *RedisExecutionDebugStore) Store(ctx context.Context, execution *StoredE
 	if execution.RequestID == "" {
 		return fmt.Errorf("request_id is required")
 	}
+	storedExecution, conversationID := sanitizeExecutionConversationMetadata(execution)
 
 	operation := func() error {
 		// Serialize with optional compression
-		data, err := s.serialize(execution)
+		data, err := s.serialize(storedExecution)
 		if err != nil {
 			return fmt.Errorf("serialization failed: %w", err)
 		}
@@ -217,12 +245,14 @@ func (s *RedisExecutionDebugStore) Store(ctx context.Context, execution *StoredE
 		// pre-fix, bypassing this branch). Carve them out so pending HITL approvals
 		// keep the default TTL rather than the shorter errorTTL.
 		ttl := s.ttl
-		if execution.Result != nil && !execution.Result.Success && !execution.Interrupted {
+		if storedExecution.Result != nil &&
+			!storedExecution.Result.Success &&
+			!storedExecution.Interrupted {
 			ttl = s.errorTTL
 		}
 
 		// Store the main record
-		key := s.recordKey(execution.RequestID)
+		key := s.recordKey(storedExecution.RequestID)
 		if err := s.client.Set(ctx, key, data, ttl).Err(); err != nil {
 			return fmt.Errorf("redis set failed: %w", err)
 		}
@@ -230,25 +260,61 @@ func (s *RedisExecutionDebugStore) Store(ctx context.Context, execution *StoredE
 		// Update index for listing (sorted set by timestamp) - best effort
 		indexKey := s.indexKey()
 		if err := s.client.ZAdd(ctx, indexKey, &redis.Z{
-			Score:  float64(execution.CreatedAt.UnixNano()),
-			Member: execution.RequestID,
+			Score:  float64(storedExecution.CreatedAt.UnixNano()),
+			Member: storedExecution.RequestID,
 		}).Err(); err != nil {
-			s.logger.Warn("Failed to update execution debug index", map[string]interface{}{
-				"request_id": execution.RequestID,
-				"error":      err.Error(),
-			})
+			if s.logger != nil {
+				s.logger.WarnWithContext(ctx, "Failed to update execution debug index", map[string]interface{}{
+					"operation":  "execution_store_index",
+					"request_id": storedExecution.RequestID,
+					"error_type": "index_write",
+					"error":      safeExecutionStoreError(err),
+				})
+			}
 			// Don't fail - index is for convenience, not critical
 		}
 
-		// Store trace ID mapping if available - best effort
-		if execution.TraceID != "" {
-			traceKey := s.traceKey(execution.TraceID)
-			if err := s.client.Set(ctx, traceKey, execution.RequestID, ttl).Err(); err != nil {
-				s.logger.Warn("Failed to store trace ID mapping", map[string]interface{}{
-					"request_id": execution.RequestID,
-					"trace_id":   execution.TraceID,
-					"error":      err.Error(),
+		if conversationID != "" {
+			conversationKey := s.conversationIndexKey(conversationID)
+			previousTTL, ttlReadErr := s.client.TTL(ctx, conversationKey).Result()
+			if err := s.client.ZAdd(ctx, conversationKey, &redis.Z{
+				Score:  float64(storedExecution.CreatedAt.UnixNano()),
+				Member: storedExecution.RequestID,
+			}).Err(); err != nil {
+				if s.logger != nil {
+					s.logger.WarnWithContext(ctx, "Failed to update conversation execution index", map[string]interface{}{
+						"operation":  "execution_store_conversation_index",
+						"request_id": storedExecution.RequestID,
+						"error_type": "index_write",
+						"error":      safeExecutionStoreError(err),
+					})
+				}
+			} else if err := s.extendIndexTTLWithoutDowngrade(
+				ctx,
+				conversationKey,
+				ttl,
+				ttlReadErr == nil && previousTTL == redisTTLKeyMissing,
+			); err != nil && s.logger != nil {
+				s.logger.WarnWithContext(ctx, "Failed to extend conversation index TTL", map[string]interface{}{
+					"operation":  "execution_store_conversation_index_ttl",
+					"request_id": storedExecution.RequestID,
+					"error_type": "ttl_update",
+					"error":      safeExecutionStoreError(err),
 				})
+			}
+		}
+
+		// Store trace ID mapping if available - best effort
+		if storedExecution.TraceID != "" {
+			traceKey := s.traceKey(storedExecution.TraceID)
+			if err := s.client.Set(ctx, traceKey, storedExecution.RequestID, ttl).Err(); err != nil {
+				if s.logger != nil {
+					s.logger.Warn("Failed to store trace ID mapping", map[string]interface{}{
+						"request_id": storedExecution.RequestID,
+						"trace_id":   storedExecution.TraceID,
+						"error":      err.Error(),
+					})
+				}
 				// Don't fail - trace mapping is for convenience
 			}
 		}
@@ -313,18 +379,23 @@ func (s *RedisExecutionDebugStore) Update(ctx context.Context, requestID string,
 	}
 
 	operation := func() error {
-		// Verify record exists
-		key := s.recordKey(requestID)
-		exists, err := s.client.Exists(ctx, key).Result()
+		existing, err := s.Get(ctx, requestID)
 		if err != nil {
-			return fmt.Errorf("failed to check existence: %w", err)
+			return err
 		}
-		if exists == 0 {
-			return fmt.Errorf("execution not found: %s", requestID)
+
+		storedExecution, _ := sanitizeExecutionConversationMetadata(execution)
+		if existingConversationID := ExecutionConversationID(existing); existingConversationID != "" {
+			if storedExecution.Metadata == nil {
+				storedExecution.Metadata = make(map[string]string)
+			}
+			storedExecution.Metadata[MetadataConversationID] = existingConversationID
+		} else {
+			delete(storedExecution.Metadata, MetadataConversationID)
 		}
 
 		// Serialize with optional compression
-		data, err := s.serialize(execution)
+		data, err := s.serialize(storedExecution)
 		if err != nil {
 			return fmt.Errorf("serialization failed: %w", err)
 		}
@@ -334,11 +405,13 @@ func (s *RedisExecutionDebugStore) Update(ctx context.Context, requestID string,
 		// orchestrator fix — carve them out so pending HITL approvals keep the
 		// default TTL rather than the shorter errorTTL.
 		ttl := s.ttl
-		if execution.Result != nil && !execution.Result.Success && !execution.Interrupted {
+		if storedExecution.Result != nil &&
+			!storedExecution.Result.Success &&
+			!storedExecution.Interrupted {
 			ttl = s.errorTTL
 		}
 
-		return s.client.Set(ctx, key, data, ttl).Err()
+		return s.client.Set(ctx, s.recordKey(requestID), data, ttl).Err()
 	}
 
 	// Layer 2: Use injected circuit breaker if available
@@ -352,24 +425,51 @@ func (s *RedisExecutionDebugStore) Update(ctx context.Context, requestID string,
 
 // ExtendTTL extends retention for investigation.
 func (s *RedisExecutionDebugStore) ExtendTTL(ctx context.Context, requestID string, duration time.Duration) error {
+	if requestID == "" {
+		return fmt.Errorf("request_id is required")
+	}
+	if duration <= 0 {
+		return fmt.Errorf("duration must be positive")
+	}
+
+	execution, err := s.Get(ctx, requestID)
+	if err != nil {
+		return err
+	}
 	key := s.recordKey(requestID)
 
-	// Extend main record TTL
-	if err := s.client.Expire(ctx, key, duration).Err(); err != nil {
+	if err := s.extendIndexTTLWithoutDowngrade(ctx, key, duration, false); err != nil {
 		return err
 	}
 
-	// Try to extend trace ID mapping TTL if present
-	execution, err := s.Get(ctx, requestID)
-	if err == nil && execution.TraceID != "" {
+	if execution.TraceID != "" {
 		traceKey := s.traceKey(execution.TraceID)
-		if err := s.client.Expire(ctx, traceKey, duration).Err(); err != nil {
-			s.logger.Warn("Failed to extend trace ID mapping TTL", map[string]interface{}{
-				"request_id": requestID,
-				"trace_id":   execution.TraceID,
-				"error":      err.Error(),
-			})
+		if err := s.extendIndexTTLWithoutDowngrade(ctx, traceKey, duration, false); err != nil {
+			if s.logger != nil {
+				s.logger.Warn("Failed to extend trace ID mapping TTL", map[string]interface{}{
+					"request_id": requestID,
+					"trace_id":   execution.TraceID,
+					"error":      err.Error(),
+				})
+			}
 			// Don't fail - trace mapping TTL extension is best effort
+		}
+	}
+
+	if conversationID := ExecutionConversationID(execution); conversationID != "" {
+		conversationKey := s.conversationIndexKey(conversationID)
+		if err := s.extendIndexTTLWithoutDowngrade(
+			ctx,
+			conversationKey,
+			duration,
+			false,
+		); err != nil && s.logger != nil {
+			s.logger.WarnWithContext(ctx, "Failed to extend conversation index TTL", map[string]interface{}{
+				"operation":  "execution_store_conversation_index_ttl",
+				"request_id": requestID,
+				"error_type": "ttl_update",
+				"error":      safeExecutionStoreError(err),
+			})
 		}
 	}
 
@@ -449,35 +549,99 @@ func (s *RedisExecutionDebugStore) ListRecent(ctx context.Context, limit int) ([
 			continue // Skip missing records (TTL expired)
 		}
 
-		// Build summary
-		summary := ExecutionSummary{
-			RequestID:         execution.RequestID,
-			OriginalRequestID: execution.OriginalRequestID,
-			TraceID:           execution.TraceID,
-			AgentName:         execution.AgentName,
-			OriginalRequest:   execution.OriginalRequest,
-			Interrupted:       execution.Interrupted,
-			CreatedAt:         execution.CreatedAt,
-		}
+		summaries = append(summaries, executionSummaryFromStored(execution))
+	}
 
-		// Extract step count and success from result
-		if execution.Result != nil {
-			summary.Success = execution.Result.Success
-			summary.TotalDuration = execution.Result.TotalDuration
-			summary.StepCount = len(execution.Result.Steps)
-			for _, step := range execution.Result.Steps {
-				if !step.Success {
-					summary.FailedSteps++
-				}
+	return summaries, nil
+}
+
+// ListByConversationID returns a bounded chronological set of executions for
+// one conversation.
+func (s *RedisExecutionDebugStore) ListByConversationID(
+	ctx context.Context,
+	conversationID string,
+	limit int,
+) ([]ExecutionSummary, error) {
+	if err := validateConversationQueryID(conversationID); err != nil {
+		return nil, err
+	}
+
+	limit = normalizeConversationQueryLimit(limit, s.queryLimit)
+	scanLimit := s.indexScanLimit
+	if scanLimit <= 0 {
+		scanLimit = defaultConversationIndexScanLimit
+	}
+	indexKey := s.conversationIndexKey(conversationID)
+	summaries := make([]ExecutionSummary, 0, limit)
+	staleMembers := make([]interface{}, 0)
+
+	var offset int64
+	for scanned := 0; scanned < scanLimit && len(summaries) < limit; {
+		batchSize := conversationIndexReadBatchSize
+		if remaining := scanLimit - scanned; remaining < batchSize {
+			batchSize = remaining
+		}
+		requestIDs, err := s.client.ZRange(
+			ctx,
+			indexKey,
+			offset,
+			offset+int64(batchSize)-1,
+		).Result()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list conversation executions: %w", err)
+		}
+		if len(requestIDs) == 0 {
+			break
+		}
+		offset += int64(len(requestIDs))
+		scanned += len(requestIDs)
+
+		recordKeys := make([]string, len(requestIDs))
+		for i, requestID := range requestIDs {
+			recordKeys[i] = s.recordKey(requestID)
+		}
+		rawRecords, err := s.client.MGet(ctx, recordKeys...).Result()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load conversation executions: %w", err)
+		}
+		for i, rawRecord := range rawRecords {
+			requestID := requestIDs[i]
+			if rawRecord == nil {
+				staleMembers = append(staleMembers, requestID)
+				continue
+			}
+			serialized, ok := rawRecord.(string)
+			if !ok {
+				staleMembers = append(staleMembers, requestID)
+				continue
+			}
+			execution, err := s.deserialize([]byte(serialized))
+			if err != nil || ExecutionConversationID(execution) != conversationID {
+				staleMembers = append(staleMembers, requestID)
+				continue
+			}
+			summaries = append(
+				summaries,
+				executionSummaryFromStored(execution),
+			)
+			if len(summaries) == limit {
+				break
 			}
 		}
+		if len(requestIDs) < batchSize {
+			break
+		}
+	}
 
-		// Multi-phase execution data (Step 16 F1)
-		summary.PhaseCount = execution.PhaseCount
-		summary.ForcedTerminal = execution.ForcedTerminal
-		summary.Metadata = execution.Metadata
-
-		summaries = append(summaries, summary)
+	if len(staleMembers) > 0 {
+		if err := s.client.ZRem(ctx, indexKey, staleMembers...).Err(); err != nil && s.logger != nil {
+			s.logger.WarnWithContext(ctx, "Failed to prune stale conversation index entries", map[string]interface{}{
+				"operation":  "execution_store_conversation_index_cleanup",
+				"request_id": fmt.Sprint(staleMembers[0]),
+				"error_type": "index_write",
+				"error":      safeExecutionStoreError(err),
+			})
+		}
 	}
 
 	return summaries, nil
@@ -491,15 +655,44 @@ func (s *RedisExecutionDebugStore) Close() error {
 // Key building helper methods using configurable keyPrefix
 
 func (s *RedisExecutionDebugStore) recordKey(requestID string) string {
-	return s.keyPrefix + requestID
+	return normalizeExecutionKeyPrefix(s.keyPrefix) + requestID
 }
 
 func (s *RedisExecutionDebugStore) indexKey() string {
-	return s.keyPrefix + "index"
+	return normalizeExecutionKeyPrefix(s.keyPrefix) + "index"
 }
 
 func (s *RedisExecutionDebugStore) traceKey(traceID string) string {
-	return s.keyPrefix + "trace:" + traceID
+	return normalizeExecutionKeyPrefix(s.keyPrefix) + "trace:" + traceID
+}
+
+func (s *RedisExecutionDebugStore) conversationIndexKey(conversationID string) string {
+	return executionConversationIndexKey(s.keyPrefix, conversationID)
+}
+
+func (s *RedisExecutionDebugStore) extendIndexTTLWithoutDowngrade(
+	ctx context.Context,
+	key string,
+	minTTL time.Duration,
+	expirePersistent bool,
+) error {
+	currentTTL, err := s.client.TTL(ctx, key).Result()
+	if err != nil {
+		return err
+	}
+	switch {
+	case currentTTL == redisTTLKeyMissing:
+		return nil
+	case currentTTL == redisTTLPersistent:
+		if !expirePersistent {
+			return nil
+		}
+		return s.client.Expire(ctx, key, minTTL).Err()
+	case currentTTL >= minTTL:
+		return nil
+	default:
+		return s.client.Expire(ctx, key, minTTL).Err()
+	}
 }
 
 // Layer 1 Resilience Constants (same as LLM Debug Store)
@@ -639,16 +832,11 @@ func (s *RedisExecutionDebugStore) deserialize(data []byte) (*StoredExecution, e
 	return &execution, nil
 }
 
-// Ensure RedisExecutionDebugStore implements ExecutionStore
-var _ ExecutionStore = (*RedisExecutionDebugStore)(nil)
-
-// getEnvString returns an environment variable value or a default
-func getEnvString(key, defaultVal string) string {
-	if val := os.Getenv(key); val != "" {
-		return val
-	}
-	return defaultVal
-}
+// Ensure RedisExecutionDebugStore implements its framework contracts.
+var (
+	_ ExecutionStore              = (*RedisExecutionDebugStore)(nil)
+	_ ConversationExecutionLister = (*RedisExecutionDebugStore)(nil)
+)
 
 // Deprecated option function aliases for backwards compatibility
 // These will be removed in a future version

--- a/orchestration/redis_llm_debug_store.go
+++ b/orchestration/redis_llm_debug_store.go
@@ -189,6 +189,7 @@ func (s *RedisLLMDebugStore) RecordInteraction(ctx context.Context, requestID st
 		// Extract trace context from baggage
 		traceID := telemetry.GetTraceContext(ctx).TraceID
 		originalRequestID := requestID
+		conversationID := llmDebugConversationIDFromContext(ctx)
 		// originatingAgent is the agent whose orchestrator (or background job) initiated
 		// this request. The orchestrator stamps this into baggage as "agent_name" from
 		// o.config.Name (orchestrator.go). HSetNX below ensures first writer wins, so when
@@ -223,6 +224,9 @@ func (s *RedisLLMDebugStore) RecordInteraction(ctx context.Context, requestID st
 		pipe.HSet(ctx, metaKey, "trace_id", traceID)
 		pipe.HSet(ctx, metaKey, "request_id", requestID)
 		pipe.HSet(ctx, metaKey, "original_request_id", originalRequestID)
+		if conversationID != "" {
+			pipe.HSetNX(ctx, metaKey, "meta:"+MetadataConversationID, conversationID)
+		}
 		if interaction.SourceComponent != "" {
 			pipe.HSetNX(ctx, metaKey, "source_component", interaction.SourceComponent)
 		}
@@ -348,6 +352,10 @@ func (s *RedisLLMDebugStore) getRecordFromString(ctx context.Context, requestID,
 // SetMetadata adds metadata to an existing record.
 // Uses Layer 2 circuit breaker if injected, otherwise falls back to Layer 1 simple retry.
 func (s *RedisLLMDebugStore) SetMetadata(ctx context.Context, requestID string, key, value string) error {
+	if key == MetadataConversationID {
+		return fmt.Errorf("%s is framework-owned and cannot be changed", MetadataConversationID)
+	}
+
 	operation := func() error {
 		metaKey := llmDebugKeyPrefix + requestID + llmDebugMetaSuffix
 

--- a/orchestration/streaming_test.go
+++ b/orchestration/streaming_test.go
@@ -291,6 +291,67 @@ func TestProcessRequestStreaming_FallbackToSimulated(t *testing.T) {
 	}
 }
 
+func TestProcessRequestStreaming_FallbackDoesNotDuplicateConversationRejection(t *testing.T) {
+	discovery := NewMockDiscovery()
+	aiClient := NewMockAIClient()
+
+	_ = discovery.Register(context.Background(), &core.ServiceRegistration{
+		ID:           "test-conversation-fallback",
+		Name:         "stock-analyzer",
+		Address:      "localhost",
+		Port:         8080,
+		Capabilities: []core.Capability{{Name: "analyze_stock"}},
+	})
+
+	orchestrator := NewAIOrchestrator(DefaultConfig(), discovery, aiClient)
+	orchestrator.catalog.agents = map[string]*AgentInfo{
+		"test-conversation-fallback": {
+			Registration: &core.ServiceRegistration{
+				ID:           "test-conversation-fallback",
+				Name:         "stock-analyzer",
+				Address:      "localhost",
+				Port:         8080,
+				Capabilities: []core.Capability{{Name: "analyze_stock"}},
+			},
+			Capabilities: []EnhancedCapability{
+				{Name: "analyze_stock", Description: "Analyzes stocks"},
+			},
+		},
+	}
+	orchestrator.executor = NewSmartExecutor(orchestrator.catalog)
+	capture := &conversationCaptureTelemetry{}
+	orchestrator.SetTelemetry(capture)
+
+	response, err := orchestrator.ProcessRequestStreaming(
+		context.Background(),
+		"Analyze AAPL stock",
+		map[string]interface{}{
+			MetadataConversationID: "invalid conversation",
+			"application_key":      "preserved",
+		},
+		func(core.StreamChunk) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("ProcessRequestStreaming() error = %v", err)
+	}
+	if response == nil || !response.StreamCompleted {
+		t.Fatalf("fallback business result = %+v, want completed response", response)
+	}
+
+	rejectionCount := 0
+	for _, record := range capture.records {
+		if record.name == conversationIDRejectionMetric {
+			rejectionCount++
+		}
+	}
+	if rejectionCount != 1 {
+		t.Fatalf(
+			"conversation rejection count = %d, want 1 across streaming fallback re-entry",
+			rejectionCount,
+		)
+	}
+}
+
 // TestProcessRequestStreaming_CallbackStop tests callback can stop streaming
 func TestProcessRequestStreaming_CallbackStop(t *testing.T) {
 	discovery := NewMockDiscovery()

--- a/telemetry/ARCHITECTURE.md
+++ b/telemetry/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # TruvaG3 Telemetry Module Architecture
 
-**Version**: 1.0
+**Version**: 1.1
 **Module**: `github.com/truvaagents/truva-g3/telemetry`
 **Purpose**: Production-grade observability with OpenTelemetry integration
 **Audience**: Framework developers, application developers, operations teams
@@ -16,13 +16,17 @@
    - [Progressive Disclosure API Design](#3-progressive-disclosure-api-design)
    - [Module Boundaries for Metrics](#4-module-boundaries-for-metrics)
    - [HTTP Middleware Extensibility](#5-http-middleware-extensibility-generic-mechanisms)
-3. [Global Singleton Pattern](#global-singleton-pattern)
-4. [OpenTelemetry Integration](#opentelemetry-integration)
-5. [Integration Patterns](#integration-patterns)
-6. [OTLP Pipeline Architecture](#otlp-pipeline-architecture)
-7. [Production Deployment](#production-deployment)
-8. [Common Pitfalls](#common-pitfalls)
-9. [Troubleshooting Guide](#troubleshooting-guide)
+3. [LLM Call Recording](#llm-call-recording)
+4. [Baggage Correlation Contract](#baggage-correlation-contract)
+5. [Global Singleton Pattern](#global-singleton-pattern)
+6. [OpenTelemetry Integration](#opentelemetry-integration)
+7. [Integration Patterns](#integration-patterns)
+8. [OTLP Pipeline Architecture](#otlp-pipeline-architecture)
+9. [Production Deployment](#production-deployment)
+10. [Common Pitfalls](#common-pitfalls)
+11. [Troubleshooting Guide](#troubleshooting-guide)
+12. [Performance Characteristics](#performance-characteristics)
+13. [Version History](#version-history)
 
 ---
 
@@ -366,7 +370,7 @@ By placing the recorder interface and Redis implementation in telemetry, agents 
 │  3. Builds telemetry.LLMCallRecord                           │
 │  4. Fires async goroutine → recorder.RecordLLMCall()         │
 └──────────────────────┬───────────────────────────────────────┘
-                       │ RPUSH (atomic, async)
+                       │ Pipeline: RPUSH interaction + HSETNX metadata + index
                        ↓
 ┌─────────────────────────────────────────────────────────────┐
 │ Redis DB 7                                                   │
@@ -387,15 +391,27 @@ created by those factories are wrapped normally.
 
 ### Key Design Decisions
 
-1. **Write-only**: `RedisLLMCallRecorder` only appends interactions (RPUSH). Reading is done by `orchestration.RedisLLMDebugStore.GetRecord()` via the registry-viewer.
+1. **Write-only**: `RedisLLMCallRecorder` writes interactions and their
+   format-compatible metadata/index entries. Reading is done by
+   `orchestration.RedisLLMDebugStore.GetRecord()` via the registry-viewer.
 
 2. **Format-compatible**: The JSON structure written by `RedisLLMCallRecorder` matches `orchestration.LLMInteraction` exactly. Both writers produce records that the registry-viewer can read seamlessly.
 
-3. **Atomic writes**: Uses Redis RPUSH (no read-modify-write), safe for concurrent writes from multiple processes (orchestrator + agents writing to the same request's record).
+3. **No read-modify-write**: A Redis pipeline appends the interaction and
+   performs first-valid metadata backfill with `HSETNX`, then updates the
+   listing index and TTLs. Concurrent orchestration and agent writers share the
+   same format without replacing an established conversation ID.
 
 4. **Layer 1 resilience**: Built-in retry with exponential backoff (3 attempts, 100ms→2s) and failure cooldown (5 failures in 30s triggers 30s pause). Recording failures never impact the LLM call path.
 
-5. **Request ID propagation**: The orchestrator's executor sends `X-TruvaG3-Request-ID` and `X-TruvaG3-Step-ID` as HTTP headers. Agents extract these via `core.ExtractRequestContext()`, making them available to `InstrumentedAIClient.resolveRequestID()`.
+5. **Request context propagation**: The orchestrator's executor sends
+   framework-managed request, step, plan, phase, original-request,
+   conversation, agent, and investigation headers. Agents extract the request,
+   step, plan, phase, original-request, conversation, and agent headers via
+   `core.ExtractRequestContext()`; investigation-owner propagation is not part
+   of that helper. An initialized `otelhttp` transport also carries standard
+   W3C Trace Context and W3C Baggage; the explicit conversation header is a
+   framework fallback, not a replacement for standard propagation.
 
 6. **Phase number propagation**: For multi-phase iterative planning, the executor also sends `X-TruvaG3-Phase-Number` as an HTTP header. `core.ExtractRequestContext()` extracts it into context, and `InstrumentedAIClient.resolvePhaseNumber()` reads it (with OTel baggage fallback). The `LLMCallRecord.PhaseNumber` field (`omitempty`, 0 = single-phase/Phase 1) enables the registry-viewer to correlate agent LLM calls to specific planning phases.
 
@@ -419,9 +435,55 @@ type NoOpLLMCallRecorder struct{}
 | `telemetry` | Defines `LLMCallRecorder` interface; provides `RedisLLMCallRecorder` (write-only) and `NoOpLLMCallRecorder` |
 | `ai` | `InstrumentedAIClient` wraps any `core.AIClient` and calls `RecordLLMCall()` after each LLM call |
 | `orchestration` | `LLMCallRecorderAdapter` bridges `LLMDebugStore` → `LLMCallRecorder`; `RedisLLMDebugStore` reads what both writers produce |
-| `core` | `ExtractRequestContext()` extracts request/step IDs from HTTP headers into context |
+| `core` | `ExtractRequestContext()` extracts framework-managed request, lineage, conversation, and agent headers into context |
 
 ---
+
+## Baggage Correlation Contract
+
+`WithBaggage` remains the convenience API for ordinary telemetry enrichment.
+It accepts multiple key/value pairs, truncates an overlong key or value,
+silently skips invalid members, and applies the 64-member limit to each
+candidate as it is added. `WithBaggageExact` is the lossless API for identity:
+it adds or replaces one member, never truncates, and returns the original
+context plus a bounded `BaggageExactError` on rejection.
+
+Both construction paths enforce the same limits:
+
+| Limit | Value |
+|---|---:|
+| Members | 64 |
+| Key length | 128 bytes |
+| Value length | 512 bytes |
+| Complete serialized W3C baggage value | 8192 bytes |
+
+The total includes separators, encoding, and member properties; it is not a
+loose sum of raw key/value lengths. Replacing a member is allowed at the item
+limit when the complete serialized value remains within the total limit.
+
+`WithMetricLabelEligibility(false)` stores a generic W3C member property.
+That property propagates across standard inject/extract and tells
+context-aware metric enrichment to omit the member. It does not remove the
+member from traces, structured logs, or downstream context. The framework uses
+this for `conversation_id` because conversation identity is high-cardinality.
+Unmarked baggage retains existing metric-enrichment behavior.
+
+`CopyBaggage(dst, src)` copies the complete OpenTelemetry baggage object,
+including member properties, while preserving destination cancellation,
+deadlines, and values. `WithoutBaggageMember` removes one member while
+preserving all other properties. These helpers do not rebuild individual
+members. Exact-helper rejection updates bounded baggage statistics; removal and
+copy do not increment add/drop counters.
+
+HTTP middleware validates an explicit `X-TruvaG3-Conversation-ID` header before
+setting it on the server span. Baggage-sourced common span enrichment propagates
+the member as provided; framework orchestration places `conversation_id` into
+baggage only after canonical validation. Applications that add
+`conversation_id` through generic baggage APIs are responsible for supplying a
+valid value. JSON context-aware logging may include the framework-validated
+value; text logging keeps its existing format. Metric enrichment honors the
+metric-eligibility property, so correlation can remain available to traces and
+logs without creating a metric series per conversation.
 
 ## Global Singleton Pattern
 
@@ -1560,6 +1622,7 @@ BenchmarkBaggagePropagation-10          5000000   234.1 ns/op    128 B/op    3 a
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.1 | 2026-07-27 | Established exact/property-preserving baggage, metric-eligibility, conversation propagation, and format-twin LLM-recording contracts |
 | 1.0 | 2025-09-28 | Initial architecture documentation |
 
 ---

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -199,6 +199,40 @@ telemetry.Counter("api.request",
 
 **Why does cardinality matter?** Each unique combination of labels creates a new metric series. Too many series = memory explosion!
 
+### Exact correlation baggage
+
+Use `WithBaggageExact` when an identifier must never be truncated:
+
+```go
+ctx, err := telemetry.WithBaggageExact(
+    ctx,
+    "conversation_id",
+    conversationID,
+    telemetry.WithMetricLabelEligibility(false),
+)
+if err != nil {
+    reason, _ := telemetry.BaggageExactErrorReasonOf(err)
+    // Treat optional correlation as absent; do not log the rejected value.
+    log.Printf("conversation correlation rejected: %s", reason)
+}
+```
+
+The metric-eligibility option is stored as a W3C baggage-member property, so
+it survives inject/extract. The member remains available for traces,
+context-aware JSON logs, and downstream correlation, but is omitted from
+automatic metric labels. Unmarked baggage retains the existing metric
+behavior.
+
+Both `WithBaggage` and `WithBaggageExact` enforce 64 members, 128-byte keys,
+512-byte values, and an 8192-byte complete serialized W3C baggage value.
+`WithBaggage` keeps its convenience semantics (per-item truncation and silent
+drop); `WithBaggageExact` rejects atomically with a typed bounded error.
+
+Use `WithoutBaggageMember(ctx, key)` to remove one member without disturbing
+other member properties. Use `CopyBaggage(dst, src)` to preserve the entire
+baggage object while retaining the destination context's cancellation,
+deadline, and ordinary values.
+
 ## 5. Progressive Disclosure: From Simple to Advanced
 
 The telemetry module follows the principle of progressive disclosure - start simple, add complexity only when needed.
@@ -1296,6 +1330,15 @@ telemetry.Duration("metric.name", startTime, "label", "value")
 ```go
 ctx = telemetry.WithBaggage(ctx, "key", "value")
 telemetry.EmitWithContext(ctx, "metric.name", 123.45)
+
+ctx, err := telemetry.WithBaggageExact(
+    ctx,
+    "conversation_id",
+    conversationID,
+    telemetry.WithMetricLabelEligibility(false),
+)
+detached := telemetry.CopyBaggage(context.Background(), ctx)
+ctx = telemetry.WithoutBaggageMember(ctx, "conversation_id")
 ```
 
 ### Health Check

--- a/telemetry/context.go
+++ b/telemetry/context.go
@@ -2,9 +2,11 @@ package telemetry
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"sync"
 	"sync/atomic"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/otel/baggage"
 )
@@ -31,7 +33,63 @@ const (
 
 	// MaxBaggageTotalSize is the maximum total size (8KB) for all baggage
 	MaxBaggageTotalSize = 8192
+
+	metricLabelEligibilityProperty = "truvag3_metric_label"
+	metricLabelExcludedValue       = "false"
 )
+
+// BaggageExactErrorReason is a bounded classification for exact-baggage
+// validation and capacity failures. It never contains the rejected key or
+// value.
+type BaggageExactErrorReason string
+
+const (
+	BaggageExactInvalidUTF8  BaggageExactErrorReason = "invalid_utf8"
+	BaggageExactInvalidKey   BaggageExactErrorReason = "invalid_baggage_key"
+	BaggageExactKeyTooLong   BaggageExactErrorReason = "key_too_long"
+	BaggageExactValueTooLong BaggageExactErrorReason = "value_too_long"
+	BaggageExactItemLimit    BaggageExactErrorReason = "item_limit"
+	BaggageExactTotalSize    BaggageExactErrorReason = "total_size"
+)
+
+// BaggageExactError reports why WithBaggageExact rejected a member without
+// retaining or exposing the rejected data.
+type BaggageExactError struct {
+	Reason BaggageExactErrorReason
+}
+
+func (e *BaggageExactError) Error() string {
+	if e == nil {
+		return "exact baggage rejected"
+	}
+	return "exact baggage rejected: " + string(e.Reason)
+}
+
+// BaggageExactErrorReasonOf returns the bounded reason carried by an exact
+// baggage error.
+func BaggageExactErrorReasonOf(err error) (BaggageExactErrorReason, bool) {
+	var exactErr *BaggageExactError
+	if !errors.As(err, &exactErr) {
+		return "", false
+	}
+	return exactErr.Reason, true
+}
+
+type baggageMemberOptions struct {
+	metricLabelEligible *bool
+}
+
+// BaggageMemberOption configures generic baggage-member behavior.
+type BaggageMemberOption func(*baggageMemberOptions)
+
+// WithMetricLabelEligibility controls whether a baggage member may
+// automatically enrich context-aware metric labels. The decision is stored as
+// a W3C baggage-member property so it survives standard propagation.
+func WithMetricLabelEligibility(eligible bool) BaggageMemberOption {
+	return func(options *baggageMemberOptions) {
+		options.metricLabelEligible = &eligible
+	}
+}
 
 // Metrics for baggage usage (internal telemetry).
 // These help identify when limits are being hit in production.
@@ -86,18 +144,12 @@ func WithBaggage(ctx context.Context, labels ...string) context.Context {
 	currentSize := len(members)
 	if currentSize >= MaxBaggageItems {
 		baggageOverLimit.Add(1)
+		updateBaggageTotalSize(bag)
 		// Could log warning here, but keeping it silent as per original design
 		return ctx // Return unchanged context when at limit
 	}
 
-	// Track total size
-	totalSize := 0
-	for _, m := range members {
-		totalSize += len(m.Key()) + len(m.Value())
-	}
-
-	// Process new labels
-	var newMembers []baggage.Member
+	newBag := bag
 	for i := 0; i < len(labels)-1; i += 2 {
 		key := labels[i]
 		value := labels[i+1]
@@ -115,13 +167,6 @@ func WithBaggage(ctx context.Context, labels ...string) context.Context {
 			value = value[:MaxBaggageValueLength]
 		}
 
-		// Check total size
-		newItemSize := len(key) + len(value)
-		if totalSize+newItemSize > MaxBaggageTotalSize {
-			baggageItemsDropped.Add(1)
-			continue // Skip items that would exceed total size
-		}
-
 		// Create baggage member
 		member, err := baggage.NewMember(key, value)
 		if err != nil {
@@ -129,27 +174,170 @@ func WithBaggage(ctx context.Context, labels ...string) context.Context {
 			continue
 		}
 
-		newMembers = append(newMembers, member)
-		totalSize += newItemSize
-		baggageItemsAdded.Add(1)
-	}
-
-	// Create new baggage with all members
-	newBag := bag
-	for _, member := range newMembers {
-		var err error
-		newBag, err = newBag.SetMember(member)
+		replacing := newBag.Member(key).Key() != ""
+		if !replacing && newBag.Len() >= MaxBaggageItems {
+			baggageItemsDropped.Add(1)
+			baggageOverLimit.Add(1)
+			continue
+		}
+		candidateBag, err := newBag.SetMember(member)
 		if err != nil {
 			// Skip members that fail to set
 			continue
 		}
+		if serializedBaggageSize(candidateBag) > MaxBaggageTotalSize {
+			baggageItemsDropped.Add(1)
+			continue
+		}
+
+		newBag = candidateBag
+		baggageItemsAdded.Add(1)
 	}
 
-	// Safe conversion: totalSize is bounded by MaxBaggageTotalSize (8192)
-	if totalSize >= 0 {
-		baggageTotalSize.Store(uint64(totalSize))
-	}
+	updateBaggageTotalSize(newBag)
 	return baggage.ContextWithBaggage(ctx, newBag)
+}
+
+// WithBaggageExact adds or replaces one baggage member without truncation.
+// It validates the complete result against the framework's baggage limits and
+// returns the original context with a typed error on rejection.
+func WithBaggageExact(
+	ctx context.Context,
+	key string,
+	rawValue string,
+	options ...BaggageMemberOption,
+) (context.Context, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	bag := baggage.FromContext(ctx)
+	reject := func(reason BaggageExactErrorReason, overLimit bool) (context.Context, error) {
+		baggageItemsDropped.Add(1)
+		if overLimit {
+			baggageOverLimit.Add(1)
+		}
+		updateBaggageTotalSize(bag)
+		return ctx, &BaggageExactError{Reason: reason}
+	}
+
+	if !utf8.ValidString(key) || !utf8.ValidString(rawValue) {
+		return reject(BaggageExactInvalidUTF8, false)
+	}
+	if key == "" {
+		return reject(BaggageExactInvalidKey, false)
+	}
+	if len(key) > MaxBaggageKeyLength {
+		return reject(BaggageExactKeyTooLong, false)
+	}
+	if len(rawValue) > MaxBaggageValueLength {
+		return reject(BaggageExactValueTooLong, false)
+	}
+	if _, err := baggage.NewMember(key, ""); err != nil {
+		return reject(BaggageExactInvalidKey, false)
+	}
+
+	memberOptions := baggageMemberOptions{}
+	for _, option := range options {
+		if option != nil {
+			option(&memberOptions)
+		}
+	}
+
+	properties := make([]baggage.Property, 0, 1)
+	if memberOptions.metricLabelEligible != nil {
+		propertyValue := "true"
+		if !*memberOptions.metricLabelEligible {
+			propertyValue = metricLabelExcludedValue
+		}
+		property, err := baggage.NewKeyValueProperty(
+			metricLabelEligibilityProperty,
+			propertyValue,
+		)
+		if err != nil {
+			return reject(BaggageExactInvalidKey, false)
+		}
+		properties = append(properties, property)
+	}
+
+	member, err := baggage.NewMemberRaw(key, rawValue, properties...)
+	if err != nil {
+		return reject(BaggageExactInvalidKey, false)
+	}
+
+	replacing := bag.Member(key).Key() != ""
+	if !replacing && bag.Len() >= MaxBaggageItems {
+		return reject(BaggageExactItemLimit, true)
+	}
+
+	updatedBag, err := bag.SetMember(member)
+	if err != nil {
+		return reject(BaggageExactInvalidKey, false)
+	}
+	updatedSize := serializedBaggageSize(updatedBag)
+	if updatedSize > MaxBaggageTotalSize {
+		return reject(BaggageExactTotalSize, true)
+	}
+
+	if !replacing {
+		baggageItemsAdded.Add(1)
+	}
+	updateBaggageTotalSize(updatedBag)
+	return baggage.ContextWithBaggage(ctx, updatedBag), nil
+}
+
+// WithoutBaggageMember removes one member while preserving every other member
+// and its W3C properties.
+func WithoutBaggageMember(ctx context.Context, key string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if key == "" {
+		return ctx
+	}
+
+	bag := baggage.FromContext(ctx).DeleteMember(key)
+	updateBaggageTotalSize(bag)
+	return baggage.ContextWithBaggage(ctx, bag)
+}
+
+// CopyBaggage copies the complete OTel baggage object, including member
+// properties, from src to dst. It preserves destination cancellation and
+// deadlines and does not change baggage usage counters.
+func CopyBaggage(dst, src context.Context) context.Context {
+	if dst == nil {
+		dst = context.Background()
+	}
+	if src == nil {
+		return dst
+	}
+	bag := baggage.FromContext(src)
+	if bag.Len() == 0 {
+		return dst
+	}
+	return baggage.ContextWithBaggage(dst, bag)
+}
+
+func serializedBaggageSize(bag baggage.Baggage) int {
+	return len(bag.String())
+}
+
+func updateBaggageTotalSize(bag baggage.Baggage) {
+	size := serializedBaggageSize(bag)
+	if size >= 0 {
+		baggageTotalSize.Store(uint64(size))
+	}
+}
+
+func metricLabelEligible(member baggage.Member) bool {
+	for _, property := range member.Properties() {
+		if property.Key() != metricLabelEligibilityProperty {
+			continue
+		}
+		value, hasValue := property.Value()
+		return !hasValue || value != metricLabelExcludedValue
+	}
+	return true
 }
 
 // GetBaggage retrieves the current baggage from context as a map.
@@ -201,6 +389,9 @@ func appendBaggageToLabels(ctx context.Context, labels []string) []string {
 
 	// Add baggage (overrides explicit labels with same key)
 	for _, m := range members {
+		if !metricLabelEligible(m) {
+			continue
+		}
 		labelMap[m.Key()] = m.Value()
 	}
 

--- a/telemetry/context_exact_test.go
+++ b/telemetry/context_exact_test.go
@@ -1,0 +1,482 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+type baggageContextTestKey struct{}
+
+func TestBaggageExactError_ErrorIsBounded(t *testing.T) {
+	var nilError *BaggageExactError
+	if got := nilError.Error(); got != "exact baggage rejected" {
+		t.Fatalf("nil error message = %q", got)
+	}
+
+	err := &BaggageExactError{Reason: BaggageExactTotalSize}
+	if got := err.Error(); got != "exact baggage rejected: total_size" {
+		t.Fatalf("typed error message = %q", got)
+	}
+}
+
+func TestWithBaggageExact_RoundTripsAndExcludesMetricLabel(t *testing.T) {
+	values := []string{
+		"550e8400-e29b-41d4-a716-446655440000",
+		"tenant:550e8400-e29b-41d4-a716-446655440000",
+		"conversation%2Fopaque",
+		strings.Repeat("x", MaxBaggageValueLength),
+	}
+
+	for _, value := range values {
+		t.Run(fmt.Sprintf("length_%d", len(value)), func(t *testing.T) {
+			ctx, err := WithBaggageExact(
+				context.Background(),
+				"conversation_id",
+				value,
+				WithMetricLabelEligibility(false),
+			)
+			if err != nil {
+				t.Fatalf("WithBaggageExact() error = %v", err)
+			}
+
+			carrier := propagation.MapCarrier{}
+			propagator := propagation.Baggage{}
+			propagator.Inject(ctx, carrier)
+			extracted := propagator.Extract(context.Background(), carrier)
+
+			if got := GetBaggage(extracted)["conversation_id"]; got != value {
+				t.Fatalf("round-trip value = %q, want %q", got, value)
+			}
+			if labelsContainKey(appendBaggageToLabels(extracted, nil), "conversation_id") {
+				t.Fatal("metric-ineligible member was copied into metric labels")
+			}
+		})
+	}
+}
+
+func TestWithBaggageExact_UnmarkedMemberRemainsMetricEligible(t *testing.T) {
+	ctx, err := WithBaggageExact(context.Background(), "custom_id", "value")
+	if err != nil {
+		t.Fatalf("WithBaggageExact() error = %v", err)
+	}
+	if !labelsContainKey(appendBaggageToLabels(ctx, nil), "custom_id") {
+		t.Fatal("unmarked member should retain existing metric enrichment behavior")
+	}
+}
+
+func TestWithBaggageExact_ValidationFailureIsTypedAndUnchanged(t *testing.T) {
+	base := WithBaggage(context.Background(), "preserved", "value")
+	ResetBaggageStats()
+
+	got, err := WithBaggageExact(base, "conversation_id", string([]byte{0xff}))
+	if err == nil {
+		t.Fatal("expected invalid UTF-8 error")
+	}
+	if got != base {
+		t.Fatal("rejected exact baggage should return the original context")
+	}
+	reason, ok := BaggageExactErrorReasonOf(err)
+	if !ok || reason != BaggageExactInvalidUTF8 {
+		t.Fatalf("error reason = %q, %v; want %q, true", reason, ok, BaggageExactInvalidUTF8)
+	}
+	if !errors.As(err, new(*BaggageExactError)) {
+		t.Fatalf("error type = %T, want *BaggageExactError", err)
+	}
+	stats := GetBaggageStats()
+	if stats.ItemsDropped != 1 || stats.OverLimit != 0 {
+		t.Fatalf("stats = %+v, want one validation drop and no capacity hit", stats)
+	}
+	if gotBag := GetBaggage(got); gotBag["preserved"] != "value" {
+		t.Fatalf("existing baggage changed: %v", gotBag)
+	}
+}
+
+func TestWithBaggageExact_RejectsInvalidW3CKey(t *testing.T) {
+	for _, key := range []string{"", "invalid key"} {
+		t.Run(fmt.Sprintf("key_%q", key), func(t *testing.T) {
+			ctx, err := WithBaggageExact(context.Background(), key, "value")
+			assertExactReason(t, err, BaggageExactInvalidKey)
+			if len(GetBaggage(ctx)) != 0 {
+				t.Fatalf("invalid key changed baggage: %v", GetBaggage(ctx))
+			}
+		})
+	}
+}
+
+func TestWithBaggageExact_LengthRejectionsAndSuccessfulAddStats(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+		want  BaggageExactErrorReason
+	}{
+		{
+			name:  "key too long",
+			key:   strings.Repeat("k", MaxBaggageKeyLength+1),
+			value: "value",
+			want:  BaggageExactKeyTooLong,
+		},
+		{
+			name:  "value too long",
+			key:   "key",
+			value: strings.Repeat("v", MaxBaggageValueLength+1),
+			want:  BaggageExactValueTooLong,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ResetBaggageStats()
+			ctx, err := WithBaggageExact(context.Background(), test.key, test.value)
+			assertExactReason(t, err, test.want)
+			if len(GetBaggage(ctx)) != 0 {
+				t.Fatalf("rejected member changed baggage: %v", GetBaggage(ctx))
+			}
+			if stats := GetBaggageStats(); stats.ItemsDropped != 1 {
+				t.Fatalf("rejection stats = %+v", stats)
+			}
+		})
+	}
+
+	ResetBaggageStats()
+	ctx, err := WithBaggageExact(nil, "key", "value", WithMetricLabelEligibility(true))
+	if err != nil {
+		t.Fatalf("WithBaggageExact(nil) error = %v", err)
+	}
+	if GetBaggage(ctx)["key"] != "value" {
+		t.Fatalf("nil-context add failed: %v", GetBaggage(ctx))
+	}
+	stats := GetBaggageStats()
+	if stats.ItemsAdded != 1 || stats.ItemsDropped != 0 || stats.CurrentSize == 0 {
+		t.Fatalf("successful-add stats = %+v", stats)
+	}
+}
+
+func TestWithBaggageExact_ItemLimitAllowsReplacement(t *testing.T) {
+	ctx := context.Background()
+	for i := 0; i < MaxBaggageItems; i++ {
+		var err error
+		ctx, err = WithBaggageExact(ctx, fmt.Sprintf("key%d", i), "value")
+		if err != nil {
+			t.Fatalf("fill member %d: %v", i, err)
+		}
+	}
+
+	ResetBaggageStats()
+	replaced, err := WithBaggageExact(ctx, "key0", "replacement")
+	if err != nil {
+		t.Fatalf("replacement at item limit failed: %v", err)
+	}
+	if got := GetBaggage(replaced)["key0"]; got != "replacement" {
+		t.Fatalf("replacement value = %q", got)
+	}
+	stats := GetBaggageStats()
+	if stats.ItemsAdded != 0 || stats.ItemsDropped != 0 || stats.OverLimit != 0 {
+		t.Fatalf("replacement stats = %+v", stats)
+	}
+
+	ResetBaggageStats()
+	unchanged, err := WithBaggageExact(ctx, "new_key", "value")
+	assertExactReason(t, err, BaggageExactItemLimit)
+	if unchanged != ctx {
+		t.Fatal("item-limit rejection should return the original context")
+	}
+	stats = GetBaggageStats()
+	if stats.ItemsDropped != 1 || stats.OverLimit != 1 {
+		t.Fatalf("item-limit stats = %+v", stats)
+	}
+}
+
+func TestWithBaggageExact_PropertyCountsTowardTotalSize(t *testing.T) {
+	members := make([]baggage.Member, 0, 16)
+	for i := 0; i < 15; i++ {
+		member, err := baggage.NewMemberRaw(
+			fmt.Sprintf("k%d", i),
+			strings.Repeat("x", MaxBaggageValueLength),
+		)
+		if err != nil {
+			t.Fatalf("NewMemberRaw() error = %v", err)
+		}
+		members = append(members, member)
+	}
+	oldMember, err := baggage.NewMemberRaw("conversation_id", "old")
+	if err != nil {
+		t.Fatalf("NewMemberRaw() error = %v", err)
+	}
+	members = append(members, oldMember)
+	bag, err := baggage.New(members...)
+	if err != nil {
+		t.Fatalf("baggage.New() error = %v", err)
+	}
+	if size := serializedBaggageSize(bag); size > MaxBaggageTotalSize {
+		t.Fatalf("test setup baggage size = %d, exceeds cap", size)
+	}
+	ctx := baggage.ContextWithBaggage(context.Background(), bag)
+
+	ResetBaggageStats()
+	unchanged, err := WithBaggageExact(
+		ctx,
+		"conversation_id",
+		strings.Repeat("y", MaxBaggageValueLength),
+		WithMetricLabelEligibility(false),
+	)
+	assertExactReason(t, err, BaggageExactTotalSize)
+	if unchanged != ctx {
+		t.Fatal("total-size rejection should return the original context")
+	}
+	if got := GetBaggage(unchanged)["conversation_id"]; got != "old" {
+		t.Fatalf("old member = %q, want old", got)
+	}
+	stats := GetBaggageStats()
+	if stats.ItemsAdded != 0 || stats.ItemsDropped != 1 || stats.OverLimit != 1 {
+		t.Fatalf("total-size stats = %+v", stats)
+	}
+}
+
+func TestWithoutBaggageMember_PreservesPropertiesAndUpdatesSize(t *testing.T) {
+	ctx, err := WithBaggageExact(
+		context.Background(),
+		"preserved",
+		"value",
+		WithMetricLabelEligibility(false),
+	)
+	if err != nil {
+		t.Fatalf("WithBaggageExact() error = %v", err)
+	}
+	ctx = WithBaggage(ctx, "conversation_id", "remove-me")
+
+	ResetBaggageStats()
+	got := WithoutBaggageMember(ctx, "conversation_id")
+	if _, present := GetBaggage(got)["conversation_id"]; present {
+		t.Fatal("conversation_id was not removed")
+	}
+	member := baggage.FromContext(got).Member("preserved")
+	if member.Value() != "value" || metricLabelEligible(member) {
+		t.Fatalf("preserved member lost value or property: %q, properties=%v", member.Value(), member.Properties())
+	}
+	stats := GetBaggageStats()
+	if stats.ItemsAdded != 0 || stats.ItemsDropped != 0 || stats.OverLimit != 0 {
+		t.Fatalf("removal changed counters: %+v", stats)
+	}
+	if want := uint64(serializedBaggageSize(baggage.FromContext(got))); stats.CurrentSize != want {
+		t.Fatalf("CurrentSize = %d, want %d", stats.CurrentSize, want)
+	}
+}
+
+func TestWithBaggage_CurrentSizeIncludesExistingMemberProperties(t *testing.T) {
+	ctx, err := WithBaggageExact(
+		context.Background(),
+		"conversation_id",
+		"conversation-1",
+		WithMetricLabelEligibility(false),
+	)
+	if err != nil {
+		t.Fatalf("WithBaggageExact() error = %v", err)
+	}
+	ResetBaggageStats()
+	ctx = WithBaggage(ctx, "agent_name", "travel-chat-agent")
+
+	stats := GetBaggageStats()
+	want := uint64(serializedBaggageSize(baggage.FromContext(ctx)))
+	if stats.CurrentSize != want {
+		t.Fatalf("CurrentSize = %d, want property-aware size %d", stats.CurrentSize, want)
+	}
+}
+
+func TestWithBaggage_BatchStopsAtItemLimit(t *testing.T) {
+	ctx := context.Background()
+	for i := 0; i < MaxBaggageItems-1; i++ {
+		var err error
+		ctx, err = WithBaggageExact(ctx, fmt.Sprintf("key%d", i), "value")
+		if err != nil {
+			t.Fatalf("fill member %d: %v", i, err)
+		}
+	}
+
+	ResetBaggageStats()
+	got := WithBaggage(
+		ctx,
+		"last_allowed", "value",
+		"over_limit", "value",
+	)
+	bag := GetBaggage(got)
+	if len(bag) != MaxBaggageItems {
+		t.Fatalf("baggage item count = %d, want %d", len(bag), MaxBaggageItems)
+	}
+	if bag["last_allowed"] != "value" {
+		t.Fatal("last allowed batch member was not added")
+	}
+	if _, present := bag["over_limit"]; present {
+		t.Fatal("batch member above the item limit was added")
+	}
+	stats := GetBaggageStats()
+	if stats.ItemsAdded != 1 || stats.ItemsDropped != 1 || stats.OverLimit != 1 {
+		t.Fatalf("batch item-limit stats = %+v", stats)
+	}
+}
+
+func TestWithBaggage_UsesSerializedTotalSize(t *testing.T) {
+	members := make([]baggage.Member, 0, 15)
+	for i := 0; i < 15; i++ {
+		member, err := baggage.NewMemberRaw(
+			fmt.Sprintf("key%d", i),
+			strings.Repeat("x", MaxBaggageValueLength),
+		)
+		if err != nil {
+			t.Fatalf("NewMemberRaw() error = %v", err)
+		}
+		members = append(members, member)
+	}
+	bag, err := baggage.New(members...)
+	if err != nil {
+		t.Fatalf("baggage.New() error = %v", err)
+	}
+	baseSize := serializedBaggageSize(bag)
+	if baseSize > MaxBaggageTotalSize {
+		t.Fatalf("test setup baggage size = %d, exceeds cap", baseSize)
+	}
+
+	overflow, err := baggage.NewMember(
+		"overflow",
+		strings.Repeat("y", MaxBaggageValueLength),
+	)
+	if err != nil {
+		t.Fatalf("NewMember() error = %v", err)
+	}
+	candidate, err := bag.SetMember(overflow)
+	if err != nil {
+		t.Fatalf("SetMember() error = %v", err)
+	}
+	if size := serializedBaggageSize(candidate); size <= MaxBaggageTotalSize {
+		t.Fatalf("test setup candidate size = %d, want above cap", size)
+	}
+
+	ctx := baggage.ContextWithBaggage(context.Background(), bag)
+	ResetBaggageStats()
+	got := WithBaggage(
+		ctx,
+		"overflow",
+		strings.Repeat("y", MaxBaggageValueLength),
+	)
+	gotBag := baggage.FromContext(got)
+	if gotBag.Member("overflow").Key() != "" {
+		t.Fatal("serialized-size overflow member was added")
+	}
+	if gotBag.Len() != bag.Len() {
+		t.Fatalf("baggage item count = %d, want %d", gotBag.Len(), bag.Len())
+	}
+	for _, member := range members {
+		if gotBag.Member(member.Key()).Value() != member.Value() {
+			t.Fatalf("existing member %q changed", member.Key())
+		}
+	}
+	stats := GetBaggageStats()
+	if stats.ItemsAdded != 0 || stats.ItemsDropped != 1 || stats.OverLimit != 0 {
+		t.Fatalf("serialized-size stats = %+v", stats)
+	}
+	if stats.CurrentSize != uint64(baseSize) {
+		t.Fatalf("CurrentSize = %d, want %d", stats.CurrentSize, baseSize)
+	}
+}
+
+func TestMetricLabelEligibility_IgnoresUnrelatedProperties(t *testing.T) {
+	property, err := baggage.NewKeyValueProperty("vendor", "value")
+	if err != nil {
+		t.Fatalf("NewKeyValueProperty() error = %v", err)
+	}
+	member, err := baggage.NewMemberRaw("custom_id", "custom-value", property)
+	if err != nil {
+		t.Fatalf("NewMemberRaw() error = %v", err)
+	}
+	bag, err := baggage.New(member)
+	if err != nil {
+		t.Fatalf("baggage.New() error = %v", err)
+	}
+	ctx := baggage.ContextWithBaggage(context.Background(), bag)
+
+	if !labelsContainKey(appendBaggageToLabels(ctx, nil), "custom_id") {
+		t.Fatal("unrelated baggage property made member metric-ineligible")
+	}
+}
+
+func TestCopyBaggage_PreservesPropertiesDeadlineAndCounters(t *testing.T) {
+	src, err := WithBaggageExact(
+		context.Background(),
+		"conversation_id",
+		"conversation-1",
+		WithMetricLabelEligibility(false),
+	)
+	if err != nil {
+		t.Fatalf("WithBaggageExact() error = %v", err)
+	}
+	deadline := time.Now().Add(time.Minute)
+	dst, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	ResetBaggageStats()
+	got := CopyBaggage(dst, src)
+	gotDeadline, ok := got.Deadline()
+	if !ok || !gotDeadline.Equal(deadline) {
+		t.Fatalf("destination deadline = %v, %v; want %v, true", gotDeadline, ok, deadline)
+	}
+	member := baggage.FromContext(got).Member("conversation_id")
+	if member.Value() != "conversation-1" || metricLabelEligible(member) {
+		t.Fatalf("copied member lost value or property: %q, properties=%v", member.Value(), member.Properties())
+	}
+	if stats := GetBaggageStats(); stats != (BaggageStats{}) {
+		t.Fatalf("CopyBaggage changed usage stats: %+v", stats)
+	}
+}
+
+func TestBaggageContextHelpers_NilAndEmptyInputs(t *testing.T) {
+	if reason, ok := BaggageExactErrorReasonOf(errors.New("other")); ok || reason != "" {
+		t.Fatalf("non-exact error reason = %q, %v", reason, ok)
+	}
+
+	removed := WithoutBaggageMember(nil, "")
+	if removed == nil {
+		t.Fatal("WithoutBaggageMember(nil) returned nil")
+	}
+	if len(GetBaggage(removed)) != 0 {
+		t.Fatalf("unexpected baggage after nil removal: %v", GetBaggage(removed))
+	}
+
+	copied := CopyBaggage(nil, nil)
+	if copied == nil {
+		t.Fatal("CopyBaggage(nil, nil) returned nil")
+	}
+	dst := context.WithValue(context.Background(), baggageContextTestKey{}, "preserved")
+	if got := CopyBaggage(dst, context.Background()); got != dst {
+		t.Fatal("empty source should return destination unchanged")
+	}
+	src := WithBaggage(context.Background(), "key", "value")
+	if got := GetBaggage(CopyBaggage(nil, src))["key"]; got != "value" {
+		t.Fatalf("nil destination copy value = %q", got)
+	}
+}
+
+func labelsContainKey(labels []string, key string) bool {
+	for i := 0; i < len(labels)-1; i += 2 {
+		if labels[i] == key {
+			return true
+		}
+	}
+	return false
+}
+
+func assertExactReason(t *testing.T, err error, want BaggageExactErrorReason) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected %q error", want)
+	}
+	got, ok := BaggageExactErrorReasonOf(err)
+	if !ok || got != want {
+		t.Fatalf("error reason = %q, %v; want %q, true", got, ok, want)
+	}
+}

--- a/telemetry/context_exact_test.go
+++ b/telemetry/context_exact_test.go
@@ -14,6 +14,12 @@ import (
 
 type baggageContextTestKey struct{}
 
+var (
+	benchmarkBaggageContextSink context.Context
+	benchmarkBaggageCarrierSink propagation.MapCarrier
+	benchmarkBaggageIntSink     int
+)
+
 func TestBaggageExactError_ErrorIsBounded(t *testing.T) {
 	var nilError *BaggageExactError
 	if got := nilError.Error(); got != "exact baggage rejected" {
@@ -459,6 +465,219 @@ func TestBaggageContextHelpers_NilAndEmptyInputs(t *testing.T) {
 	if got := GetBaggage(CopyBaggage(nil, src))["key"]; got != "value" {
 		t.Fatalf("nil destination copy value = %q", got)
 	}
+}
+
+func BenchmarkWithBaggageExact(b *testing.B) {
+	base := WithBaggage(
+		context.Background(),
+		"agent_name", "travel-chat-agent",
+		"phase_number", "2",
+		"ai.purpose", "conversation",
+	)
+
+	b.Run("generic", func(b *testing.B) {
+		b.ReportAllocs()
+		var got context.Context
+		for i := 0; i < b.N; i++ {
+			got = WithBaggage(base, "conversation_id", "conversation-benchmark")
+		}
+		benchmarkBaggageContextSink = got
+	})
+
+	b.Run("exact_default_metric_eligible", func(b *testing.B) {
+		b.ReportAllocs()
+		var got context.Context
+		for i := 0; i < b.N; i++ {
+			var err error
+			got, err = WithBaggageExact(base, "conversation_id", "conversation-benchmark")
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		benchmarkBaggageContextSink = got
+	})
+
+	b.Run("exact_metric_ineligible", func(b *testing.B) {
+		b.ReportAllocs()
+		var got context.Context
+		for i := 0; i < b.N; i++ {
+			var err error
+			got, err = WithBaggageExact(
+				base,
+				"conversation_id",
+				"conversation-benchmark",
+				WithMetricLabelEligibility(false),
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		benchmarkBaggageContextSink = got
+	})
+}
+
+func BenchmarkAppendBaggageMetricEligibility(b *testing.B) {
+	base := WithBaggage(
+		context.Background(),
+		"agent_name", "travel-chat-agent",
+		"phase_number", "2",
+		"ai.purpose", "conversation",
+	)
+	generic := WithBaggage(base, "conversation_id", "conversation-benchmark")
+	exactEligible, err := WithBaggageExact(
+		base,
+		"conversation_id",
+		"conversation-benchmark",
+		WithMetricLabelEligibility(true),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	exactIneligible, err := WithBaggageExact(
+		base,
+		"conversation_id",
+		"conversation-benchmark",
+		WithMetricLabelEligibility(false),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		ctx  context.Context
+	}{
+		{name: "generic", ctx: generic},
+		{name: "exact_metric_eligible", ctx: exactEligible},
+		{name: "exact_metric_ineligible", ctx: exactIneligible},
+	}
+	for _, test := range cases {
+		b.Run(test.name, func(b *testing.B) {
+			b.ReportAllocs()
+			count := 0
+			for i := 0; i < b.N; i++ {
+				labels := appendBaggageToLabels(test.ctx, []string{"explicit", "label"})
+				count = len(labels)
+				returnLabelSlice(labels)
+			}
+			benchmarkBaggageIntSink = count
+		})
+	}
+}
+
+func BenchmarkCopyBaggage(b *testing.B) {
+	src := WithBaggage(
+		context.Background(),
+		"agent_name", "travel-chat-agent",
+		"phase_number", "2",
+		"ai.purpose", "conversation",
+	)
+	var err error
+	src, err = WithBaggageExact(
+		src,
+		"conversation_id",
+		"conversation-benchmark",
+		WithMetricLabelEligibility(false),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	dst := context.WithValue(context.Background(), baggageContextTestKey{}, "preserved")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var got context.Context
+	for i := 0; i < b.N; i++ {
+		got = CopyBaggage(dst, src)
+	}
+	benchmarkBaggageContextSink = got
+}
+
+func BenchmarkW3CBaggagePropagation(b *testing.B) {
+	representative := WithBaggage(
+		context.Background(),
+		"agent_name", "travel-chat-agent",
+		"phase_number", "2",
+		"ai.purpose", "conversation",
+	)
+	var err error
+	representative, err = WithBaggageExact(
+		representative,
+		"conversation_id",
+		"550e8400-e29b-41d4-a716-446655440000",
+		WithMetricLabelEligibility(false),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	contexts := []struct {
+		name string
+		ctx  context.Context
+	}{
+		{name: "representative", ctx: representative},
+		{name: "maximum_allowed", ctx: baggageContextAtSerializedLimit(b)},
+	}
+	propagator := propagation.Baggage{}
+
+	for _, test := range contexts {
+		b.Run(test.name+"/inject", func(b *testing.B) {
+			b.ReportAllocs()
+			var carrier propagation.MapCarrier
+			for i := 0; i < b.N; i++ {
+				carrier = propagation.MapCarrier{}
+				propagator.Inject(test.ctx, carrier)
+			}
+			benchmarkBaggageCarrierSink = carrier
+		})
+
+		carrier := propagation.MapCarrier{}
+		propagator.Inject(test.ctx, carrier)
+		b.Run(test.name+"/extract", func(b *testing.B) {
+			b.ReportAllocs()
+			var got context.Context
+			for i := 0; i < b.N; i++ {
+				got = propagator.Extract(context.Background(), carrier)
+			}
+			benchmarkBaggageContextSink = got
+		})
+	}
+}
+
+func baggageContextAtSerializedLimit(tb testing.TB) context.Context {
+	tb.Helper()
+
+	ctx := context.Background()
+	for i := 0; i < MaxBaggageItems; i++ {
+		bag := baggage.FromContext(ctx)
+		currentSize := serializedBaggageSize(bag)
+		key := fmt.Sprintf("bench_%02d", i)
+		memberOverhead := len(key) + 1
+		if currentSize > 0 {
+			memberOverhead++
+		}
+		valueLength := MaxBaggageTotalSize - currentSize - memberOverhead
+		if valueLength <= 0 {
+			break
+		}
+		if valueLength > MaxBaggageValueLength {
+			valueLength = MaxBaggageValueLength
+		}
+
+		var err error
+		ctx, err = WithBaggageExact(ctx, key, strings.Repeat("x", valueLength))
+		if err != nil {
+			tb.Fatalf("build maximum baggage member %d: %v", i, err)
+		}
+		if serializedBaggageSize(baggage.FromContext(ctx)) == MaxBaggageTotalSize {
+			break
+		}
+	}
+
+	if got := serializedBaggageSize(baggage.FromContext(ctx)); got != MaxBaggageTotalSize {
+		tb.Fatalf("maximum baggage size = %d, want %d", got, MaxBaggageTotalSize)
+	}
+	return ctx
 }
 
 func labelsContainKey(labels []string, key string) bool {

--- a/telemetry/http.go
+++ b/telemetry/http.go
@@ -40,6 +40,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/truvaagents/truva-g3/core"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -173,19 +174,29 @@ func stampTruvaG3HeadersOnSpan(r *http.Request) {
 		return
 	}
 	headerToAttr := []struct {
-		header string
-		attr   string
+		header                 string
+		attr                   string
+		validateConversationID bool
 	}{
-		{"X-TruvaG3-Request-ID", "request_id"},
-		{"X-TruvaG3-Original-Request-ID", "original_request_id"},
-		{"X-TruvaG3-Step-ID", "step_id"},
-		{"X-TruvaG3-Phase-Number", "phase_number"},
-		{"X-TruvaG3-Plan-ID", "plan_id"},
-		{"X-TruvaG3-Agent-Name", "caller_agent_name"},
+		{header: "X-TruvaG3-Request-ID", attr: "request_id"},
+		{header: "X-TruvaG3-Original-Request-ID", attr: "original_request_id"},
+		{
+			header:                 "X-TruvaG3-Conversation-ID",
+			attr:                   "conversation_id",
+			validateConversationID: true,
+		},
+		{header: "X-TruvaG3-Step-ID", attr: "step_id"},
+		{header: "X-TruvaG3-Phase-Number", attr: "phase_number"},
+		{header: "X-TruvaG3-Plan-ID", attr: "plan_id"},
+		{header: "X-TruvaG3-Agent-Name", attr: "caller_agent_name"},
 	}
 	attrs := make([]attribute.KeyValue, 0, len(headerToAttr))
 	for _, m := range headerToAttr {
 		if v := r.Header.Get(m.header); v != "" {
+			if m.validateConversationID &&
+				core.ValidateConversationID(v) != core.ConversationIDValidationNone {
+				continue
+			}
 			attrs = append(attrs, attribute.String(m.attr, v))
 		}
 	}

--- a/telemetry/http_test.go
+++ b/telemetry/http_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"go.opentelemetry.io/otel"
@@ -350,5 +351,58 @@ func TestTracedHTTPClient_MultipleRequests(t *testing.T) {
 
 	if requestCount != 5 {
 		t.Errorf("Expected 5 requests, server received %d", requestCount)
+	}
+}
+
+func TestStampTruvaG3HeadersOnSpan_ValidatesConversationID(t *testing.T) {
+	tests := []struct {
+		name             string
+		conversationID   string
+		wantConversation string
+	}{
+		{
+			name:             "valid",
+			conversationID:   "conversation-server-span",
+			wantConversation: "conversation-server-span",
+		},
+		{
+			name:           "malformed",
+			conversationID: "invalid conversation",
+		},
+		{
+			name:           "over limit",
+			conversationID: strings.Repeat("x", 513),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder, tracer := setupTestTracer(t)
+			ctx, span := tracer.Start(context.Background(), "server-span")
+			request := httptest.NewRequest(http.MethodPost, "/execute", nil).WithContext(ctx)
+			request.Header.Set("X-TruvaG3-Request-ID", "request-preserved")
+			request.Header.Set("X-TruvaG3-Conversation-ID", test.conversationID)
+
+			stampTruvaG3HeadersOnSpan(request)
+			span.End()
+
+			ended := recorder.Ended()
+			if len(ended) != 1 {
+				t.Fatalf("ended spans = %d, want 1", len(ended))
+			}
+			if got, ok := spanAttributeString(ended[0], "request_id"); !ok || got != "request-preserved" {
+				t.Fatalf("existing request_id attribute = %q, %v", got, ok)
+			}
+			got, present := spanAttributeString(ended[0], "conversation_id")
+			if test.wantConversation == "" {
+				if present {
+					t.Fatalf("invalid conversation_id reached span: %q", got)
+				}
+				return
+			}
+			if !present || got != test.wantConversation {
+				t.Fatalf("conversation_id span attribute = %q, %v", got, present)
+			}
+		})
 	}
 }

--- a/telemetry/redis_llm_recorder.go
+++ b/telemetry/redis_llm_recorder.go
@@ -212,6 +212,7 @@ func (r *RedisLLMCallRecorder) RecordLLMCall(ctx context.Context, requestID stri
 		// Extract trace context from baggage (matches orchestration store pattern)
 		traceID := GetTraceContext(ctx).TraceID
 		originalRequestID := requestID
+		conversationID := recorderConversationIDFromContext(ctx)
 		// originatingAgent mirrors the orchestration store's field (see
 		// orchestration/redis_llm_debug_store.go). Sourced from the same
 		// "agent_name" baggage key the orchestrator stamps from o.config.Name.
@@ -245,6 +246,9 @@ func (r *RedisLLMCallRecorder) RecordLLMCall(ctx context.Context, requestID stri
 		pipe.HSet(ctx, metaKey, "trace_id", traceID)
 		pipe.HSet(ctx, metaKey, "request_id", requestID)
 		pipe.HSet(ctx, metaKey, "original_request_id", originalRequestID)
+		if conversationID != "" {
+			pipe.HSetNX(ctx, metaKey, "meta:conversation_id", conversationID)
+		}
 		if interaction.SourceComponent != "" {
 			pipe.HSetNX(ctx, metaKey, "source_component", interaction.SourceComponent)
 		}
@@ -265,6 +269,23 @@ func (r *RedisLLMCallRecorder) RecordLLMCall(ctx context.Context, requestID stri
 	}
 
 	return r.executeWithRetry(ctx, operation)
+}
+
+func recorderConversationIDFromContext(ctx context.Context) string {
+	coreCandidate := core.GetConversationIDCandidate(ctx)
+	if coreCandidate.Present {
+		if coreCandidate.RejectionReason != core.ConversationIDValidationNone ||
+			core.ValidateConversationID(coreCandidate.Value) != core.ConversationIDValidationNone {
+			return ""
+		}
+		return coreCandidate.Value
+	}
+
+	conversationID := GetBaggage(ctx)["conversation_id"]
+	if core.ValidateConversationID(conversationID) != core.ConversationIDValidationNone {
+		return ""
+	}
+	return conversationID
 }
 
 // Close closes the Redis connection.

--- a/telemetry/redis_llm_recorder_test.go
+++ b/telemetry/redis_llm_recorder_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +21,17 @@ func TestRedisLLMCallRecorder_ImplementsLLMCallRecorder(t *testing.T) {
 	// Compile-time check already exists in redis_llm_recorder.go (line 318).
 	// This test makes the assertion explicit and visible in test output.
 	var _ LLMCallRecorder = (*RedisLLMCallRecorder)(nil)
+}
+
+func TestNoOpLLMCallRecorder_RemainsSafe(t *testing.T) {
+	var recorder LLMCallRecorder = &NoOpLLMCallRecorder{}
+	if err := recorder.RecordLLMCall(
+		core.WithConversationID(context.Background(), "conversation-noop"),
+		"request-noop",
+		LLMCallRecord{CallType: "agent_llm_call"},
+	); err != nil {
+		t.Fatalf("RecordLLMCall: %v", err)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -437,5 +449,105 @@ func TestRecordLLMCall_EmptyBaggage_NoOriginatingAgent(t *testing.T) {
 	metaKey := recorderKeyPrefix + "req-no-bag" + recorderMetaSuffix
 	if got := mr.HGet(metaKey, "originating_agent"); got != "" {
 		t.Errorf("originating_agent must be empty when baggage carries no agent_name; got %q", got)
+	}
+}
+
+func TestRecordLLMCall_ConversationIDResolution(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  func() context.Context
+		want string
+	}{
+		{
+			name: "core candidate wins",
+			ctx: func() context.Context {
+				ctx := WithBaggage(
+					context.Background(),
+					"conversation_id",
+					"conversation-baggage",
+				)
+				return core.WithConversationID(ctx, "conversation-core")
+			},
+			want: "conversation-core",
+		},
+		{
+			name: "validated baggage fallback",
+			ctx: func() context.Context {
+				return WithBaggage(
+					context.Background(),
+					"conversation_id",
+					"conversation-baggage",
+				)
+			},
+			want: "conversation-baggage",
+		},
+		{
+			name: "invalid core blocks fallback",
+			ctx: func() context.Context {
+				ctx := WithBaggage(
+					context.Background(),
+					"conversation_id",
+					"conversation-baggage",
+				)
+				return core.WithConversationID(ctx, "invalid conversation")
+			},
+		},
+		{
+			name: "invalid baggage omitted",
+			ctx: func() context.Context {
+				return WithBaggage(
+					context.Background(),
+					"conversation_id",
+					"invalid conversation",
+				)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mr, recorder := setupRedisLLMRecorderTest(t)
+			requestID := "request-" + strings.ReplaceAll(test.name, " ", "-")
+			if err := recorder.RecordLLMCall(
+				test.ctx(),
+				requestID,
+				LLMCallRecord{CallType: "agent_llm_call", Success: true},
+			); err != nil {
+				t.Fatalf("RecordLLMCall: %v", err)
+			}
+			metaKey := recorderKeyPrefix + requestID + recorderMetaSuffix
+			if got := mr.HGet(metaKey, "meta:conversation_id"); got != test.want {
+				t.Fatalf("conversation field = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRecordLLMCall_ConversationFirstValidWriterWins(t *testing.T) {
+	mr, recorder := setupRedisLLMRecorderTest(t)
+	requestID := "request-conversation-first-writer"
+	record := LLMCallRecord{CallType: "agent_llm_call", Success: true}
+
+	if err := recorder.RecordLLMCall(context.Background(), requestID, record); err != nil {
+		t.Fatalf("empty first write: %v", err)
+	}
+	if err := recorder.RecordLLMCall(
+		core.WithConversationID(context.Background(), "conversation-first"),
+		requestID,
+		record,
+	); err != nil {
+		t.Fatalf("valid backfill: %v", err)
+	}
+	if err := recorder.RecordLLMCall(
+		core.WithConversationID(context.Background(), "conversation-different"),
+		requestID,
+		record,
+	); err != nil {
+		t.Fatalf("later write: %v", err)
+	}
+
+	metaKey := recorderKeyPrefix + requestID + recorderMetaSuffix
+	if got := mr.HGet(metaKey, "meta:conversation_id"); got != "conversation-first" {
+		t.Fatalf("conversation field = %q", got)
 	}
 }

--- a/telemetry/span_common.go
+++ b/telemetry/span_common.go
@@ -1,11 +1,12 @@
 // Package telemetry — common span attribute helpers.
 //
 // Distributed traces become navigable when every span carries the small set of
-// identifiers that tie work back to a business request: request_id,
-// original_request_id (HITL resumes), agent_name, user_id. The orchestrator
-// puts these into baggage on every request; this file provides one helper that
-// pulls them off baggage and stamps them onto a span. Call from anywhere a
-// span starts and the span becomes greppable in Jaeger by request_id.
+// identifiers that tie work back to a business request or conversation:
+// request_id, original_request_id (HITL resumes), conversation_id, agent_name,
+// and user_id. The orchestrator puts these into baggage on every request; this
+// file provides one helper that pulls them off baggage and stamps them onto a
+// span. Call from anywhere a span starts and the span becomes greppable in
+// Jaeger by request_id or conversation_id.
 package telemetry
 
 import (
@@ -27,6 +28,7 @@ import (
 var CommonSpanAttrKeys = []string{
 	"request_id",
 	"original_request_id",
+	"conversation_id",
 	"agent_name",
 	"user_id",
 	"session_id",

--- a/telemetry/span_common_test.go
+++ b/telemetry/span_common_test.go
@@ -1,0 +1,99 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func TestCommonSpanHelpersIncludeConversationID(t *testing.T) {
+	t.Run("current span", func(t *testing.T) {
+		recorder, _ := setupTestTracer(t)
+		ctx, err := WithBaggageExact(
+			context.Background(),
+			"conversation_id",
+			"conversation-span",
+			WithMetricLabelEligibility(false),
+		)
+		if err != nil {
+			t.Fatalf("WithBaggageExact() error = %v", err)
+		}
+
+		spanCtx, span := otel.Tracer("common-span-test").Start(ctx, "common-current")
+		SetCommonSpanAttrs(spanCtx)
+		span.End()
+
+		ended := recorder.Ended()
+		if len(ended) != 1 {
+			t.Fatalf("ended spans = %d, want 1", len(ended))
+		}
+		if got, ok := spanAttributeString(ended[0], "conversation_id"); !ok || got != "conversation-span" {
+			t.Fatalf("conversation_id span attribute = %q, %v", got, ok)
+		}
+	})
+
+	t.Run("child span", func(t *testing.T) {
+		recorder, _ := setupTestTracer(t)
+		ctx, err := WithBaggageExact(
+			context.Background(),
+			"conversation_id",
+			"conversation-span",
+			WithMetricLabelEligibility(false),
+		)
+		if err != nil {
+			t.Fatalf("WithBaggageExact() error = %v", err)
+		}
+
+		_, end := StartChildSpan(ctx, "common-child")
+		end()
+
+		ended := recorder.Ended()
+		if len(ended) != 1 {
+			t.Fatalf("ended spans = %d, want 1", len(ended))
+		}
+		if got, ok := spanAttributeString(ended[0], "conversation_id"); !ok || got != "conversation-span" {
+			t.Fatalf("conversation_id span attribute = %q, %v", got, ok)
+		}
+	})
+}
+
+func TestSetCommonAttrsOnIncludesConversationID(t *testing.T) {
+	ctx, err := WithBaggageExact(
+		context.Background(),
+		"conversation_id",
+		"conversation-core-span",
+		WithMetricLabelEligibility(false),
+	)
+	if err != nil {
+		t.Fatalf("WithBaggageExact() error = %v", err)
+	}
+	span := &commonAttributeCapture{}
+
+	SetCommonAttrsOn(ctx, span)
+
+	if got := span.attributes["conversation_id"]; got != "conversation-core-span" {
+		t.Fatalf("conversation_id = %v", got)
+	}
+}
+
+type commonAttributeCapture struct {
+	attributes map[string]interface{}
+}
+
+func (c *commonAttributeCapture) SetAttribute(key string, value interface{}) {
+	if c.attributes == nil {
+		c.attributes = make(map[string]interface{})
+	}
+	c.attributes[key] = value
+}
+
+func spanAttributeString(span sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, attr := range span.Attributes() {
+		if string(attr.Key) == key {
+			return attr.Value.AsString(), true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
## Summary

Adds a canonical multi-turn conversation identity across the framework and exposes that relationship in the Registry Viewer Execution DAG experience.

- Defines and validates `conversation_id` in core and orchestration.
- Propagates conversation identity through request context, W3C baggage, executor headers, telemetry, HITL checkpoints/resume, LLM debug records, and execution-debug persistence.
- Adds bounded, indexed conversation execution lookup for provider-backed and direct Redis stores.
- Adds server-owned conversation grouping, stable immutable-sort pagination, a chronological conversation timeline, related-execution nesting, and a session-scoped Flat fallback in the Registry Viewer.
- Documents the framework contracts, operational limits, tracing/logging behavior, and reference UI behavior.
- Hardens the final implementation with bounded DB 7 enrichment, page-scoped enrichment for immutable DB 8 sorts, overlapping-scan deduplication, consistent newest-window semantics, and atomic Redis conversation-index TTL preservation.

## Why

Chat agents already maintain multi-turn continuity, but execution-debug records were independently keyed by request ID and did not carry a stable canonical conversation identity. The Registry Viewer therefore could not show which executions belonged to the same user conversation, making multi-turn and HITL troubleshooting unnecessarily difficult.

The root cause was a missing cross-module correlation contract: the application session identifier was not resolved into framework-owned metadata, propagated across service boundaries, persisted consistently, or indexed for bounded lookup. This PR adds that contract and a reference visualization without making the Viewer a writer to execution Redis databases.

## User and developer impact

- Operators can see conversation groups directly in Execution DAG, expand individual turns, and open a same-panel chronological timeline.
- Created-time and request-text grouping use server-owned, group-atomic keyset pagination; optional DB 7 enrichment cannot suppress those cursors.
- Combined-duration sorting remains a bounded cursorless view because mutable DB 7 LLM duration contributes to its order.
- HITL resume and delegated execution paths retain the original conversation identity.
- Stateless executions remain standalone and existing request lineage retains its distinct meaning.
- Existing flat execution APIs and the Viewer Flat mode remain available as compatibility and diagnostic fallbacks.

## Test plan

Framework validation:

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./...`
- `goimports`
- `golangci-lint run ./...` — 0 issues
- `gosec ./...` — 0 issues
- `govulncheck ./...` — no called vulnerabilities

Registry Viewer validation:

- Standalone `go test ./...`
- Standalone `go test -race ./...`
- Standalone `go vet ./...`
- Standalone `go build ./...`
- Owner browser verification of grouped cards, timeline navigation, related executions, selected-group collapse behavior, compacted-result visualization, and right-pane header layout
- Live Kind/Redis/API verification covering conversation membership, interleaved conversations, tracing/log correlation, delegation, stateless requests, invalid identity rejection, and HITL checkpoint/resume behavior
- Docusaurus production build passed in the pre-push hook

Known baseline: the standalone Registry Viewer still has pre-existing `main.go` lint/gosec findings outside this PR's changed logic. Its `govulncheck` result also reports the Go 1.26.4 standard-library advisory fixed in Go 1.26.5. The changed Viewer logic has no new lint or gosec findings.

## Checklist

- [x] Framework `go vet`, `go build`, `go test`, `goimports`, `golangci-lint`, `gosec`, and `govulncheck` pass locally
- [x] No new external dependencies
- [x] User-facing behavior and framework contracts are reflected in docs and examples
- [x] Files under `notes/` and `bugs/` are excluded from the PR
