### PR TITLE
chore(release): stage v0.3.0 module references

### DIFF
--- a/ai/go.mod
+++ b/ai/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.30
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.56.0
 	github.com/stretchr/testify v1.11.1
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 
@@ -56,3 +56,8 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// Temporary release bootstrap; remove after core/v0.3.0 and telemetry/v0.3.0 are published.
+replace github.com/truvaagents/truva-g3/core => ../core
+
+replace github.com/truvaagents/truva-g3/telemetry => ../telemetry

--- a/examples/agent-example/go.mod
+++ b/examples/agent-example/go.mod
@@ -4,9 +4,9 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 )
 
 // Use local workspace modules for development

--- a/examples/agent-with-async/go.mod
+++ b/examples/agent-with-async/go.mod
@@ -4,10 +4,10 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 )
 
 require (

--- a/examples/agent-with-human-approval/go.mod
+++ b/examples/agent-with-human-approval/go.mod
@@ -5,10 +5,10 @@ go 1.26.4
 require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/agent-with-orchestration/go.mod
+++ b/examples/agent-with-orchestration/go.mod
@@ -4,10 +4,10 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/agent-with-resilience/go.mod
+++ b/examples/agent-with-resilience/go.mod
@@ -4,10 +4,10 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/resilience v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/resilience v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 )
 
 // Use local workspace modules for development

--- a/examples/agent-with-telemetry/go.mod
+++ b/examples/agent-with-telemetry/go.mod
@@ -4,9 +4,9 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/agentic-memory-tool/go.mod
+++ b/examples/agentic-memory-tool/go.mod
@@ -4,10 +4,10 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/memory v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/memory v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/arxiv-tool/go.mod
+++ b/examples/arxiv-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/arxiv-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/clinical-trials-tool/go.mod
+++ b/examples/clinical-trials-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/clinical-trials-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/confluence-tool/go.mod
+++ b/examples/confluence-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/confluence-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/country-info-tool/go.mod
+++ b/examples/country-info-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/country-info-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/currency-global-tool/go.mod
+++ b/examples/currency-global-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/currency-global-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/currency-tool/go.mod
+++ b/examples/currency-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/currency-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 )

--- a/examples/demographics-tool/go.mod
+++ b/examples/demographics-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/demographics-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/devops-chat-agent/go.mod
+++ b/examples/devops-chat-agent/go.mod
@@ -5,11 +5,11 @@ go 1.26.4
 require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/memory v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/memory v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/devops-observability-tool/go.mod
+++ b/examples/devops-observability-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/devops-observability-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/devops-tool/go.mod
+++ b/examples/devops-tool/go.mod
@@ -4,8 +4,8 @@ go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/economic-data-tool/go.mod
+++ b/examples/economic-data-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/economic-data-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/event-driven-agent/go.mod
+++ b/examples/event-driven-agent/go.mod
@@ -4,11 +4,11 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/memory v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/memory v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 )

--- a/examples/fiscal-data-tool/go.mod
+++ b/examples/fiscal-data-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/fiscal-data-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/flight-tool/go.mod
+++ b/examples/flight-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/flight-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/geocoding-tool/go.mod
+++ b/examples/geocoding-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/geocoding-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 )

--- a/examples/github-pr-review-agent/go.mod
+++ b/examples/github-pr-review-agent/go.mod
@@ -5,11 +5,11 @@ go 1.26.4
 require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/memory v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/memory v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 )

--- a/examples/github-tool/go.mod
+++ b/examples/github-tool/go.mod
@@ -4,8 +4,8 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/grocery-tool/go.mod
+++ b/examples/grocery-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/grocery-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/hotel-tool/go.mod
+++ b/examples/hotel-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/hotel-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/jira-tool/go.mod
+++ b/examples/jira-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/jira-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/my-async-agent/go.mod
+++ b/examples/my-async-agent/go.mod
@@ -3,10 +3,10 @@ module github.com/truvaagents/truva-g3/examples/my-async-agent
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 )
 
 // Use local workspace modules for development

--- a/examples/my-streaming-agent/go.mod
+++ b/examples/my-streaming-agent/go.mod
@@ -3,10 +3,10 @@ module github.com/truvaagents/truva-g3/examples/my-streaming-agent
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 )
 
 // Use local workspace modules for development

--- a/examples/my-tool/go.mod
+++ b/examples/my-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/my-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 )
 
 // Use local workspace modules for development

--- a/examples/news-tool/go.mod
+++ b/examples/news-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/news-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 )

--- a/examples/openclaw-tool/go.mod
+++ b/examples/openclaw-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/openclaw-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/openfda-tool/go.mod
+++ b/examples/openfda-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/openfda-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/places-tool/go.mod
+++ b/examples/places-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/places-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/playwright-tool/go.mod
+++ b/examples/playwright-tool/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/prometheus-query-tool/go.mod
+++ b/examples/prometheus-query-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/prometheus-query-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/pubmed-tool/go.mod
+++ b/examples/pubmed-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/pubmed-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 	golang.org/x/time v0.9.0
 )

--- a/examples/qa-agent/go.mod
+++ b/examples/qa-agent/go.mod
@@ -4,11 +4,11 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/memory v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/memory v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/registry-viewer-app/go.mod
+++ b/examples/registry-viewer-app/go.mod
@@ -4,9 +4,9 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/memory v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/memory v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
 	golang.org/x/sync v0.20.0
 )
 
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/qdrant/go-client v1.18.3 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
-	github.com/truvaagents/truva-g3/telemetry v0.2.0 // indirect
+	github.com/truvaagents/truva-g3/telemetry v0.3.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect

--- a/examples/scheduled-executor/go.mod
+++ b/examples/scheduled-executor/go.mod
@@ -4,9 +4,9 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/scheduler-tool/go.mod
+++ b/examples/scheduler-tool/go.mod
@@ -4,10 +4,10 @@ go 1.26.4
 
 require (
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/memory v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/memory v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 )
 
 require (

--- a/examples/semantic-scholar-tool/go.mod
+++ b/examples/semantic-scholar-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/semantic-scholar-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/slack-tool/go.mod
+++ b/examples/slack-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/slack-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/stock-market-tool/go.mod
+++ b/examples/stock-market-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/stock-market-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/system-utilities-tool/go.mod
+++ b/examples/system-utilities-tool/go.mod
@@ -4,8 +4,8 @@ go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/tool-example/go.mod
+++ b/examples/tool-example/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/tool-example
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/travel-advisory-tool/go.mod
+++ b/examples/travel-advisory-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/travel-advisory-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/travel-chat-agent/go.mod
+++ b/examples/travel-chat-agent/go.mod
@@ -5,11 +5,11 @@ go 1.26.4
 require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/ai v0.2.0
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/memory v0.2.0
-	github.com/truvaagents/truva-g3/orchestration v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/ai v0.3.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/memory v0.3.0
+	github.com/truvaagents/truva-g3/orchestration v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/weather-tool-v2/go.mod
+++ b/examples/weather-tool-v2/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/weather-tool-v2
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 )

--- a/examples/web-search-tool/go.mod
+++ b/examples/web-search-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/web-search-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/examples/world-health-tool/go.mod
+++ b/examples/world-health-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/world-health-tool
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/truvaagents/truva-g3
 
 go 1.26.4
 
-require github.com/truvaagents/truva-g3/core v0.2.0
+require github.com/truvaagents/truva-g3/core v0.3.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -18,3 +18,6 @@ require (
 // unresolvable core requirement, so external consumers cannot build it. It is
 // superseded by v0.2.0.
 retract v0.1.0
+
+// Temporary release bootstrap; remove after core/v0.3.0 is published.
+replace github.com/truvaagents/truva-g3/core => ./core

--- a/memory/go.mod
+++ b/memory/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/qdrant/go-client v1.18.3
 	github.com/stretchr/testify v1.11.1
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
@@ -43,3 +43,8 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// Temporary release bootstrap; remove after core/v0.3.0 and telemetry/v0.3.0 are published.
+replace github.com/truvaagents/truva-g3/core => ../core
+
+replace github.com/truvaagents/truva-g3/telemetry => ../telemetry

--- a/orchestration/go.mod
+++ b/orchestration/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
@@ -43,3 +43,8 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+// Temporary release bootstrap; remove after core/v0.3.0 and telemetry/v0.3.0 are published.
+replace github.com/truvaagents/truva-g3/core => ../core
+
+replace github.com/truvaagents/truva-g3/telemetry => ../telemetry

--- a/resilience/go.mod
+++ b/resilience/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/resilience
 go 1.26.4
 
 require (
-	github.com/truvaagents/truva-g3/core v0.2.0
-	github.com/truvaagents/truva-g3/telemetry v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/telemetry v0.3.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/metric v1.44.0
 )
@@ -38,3 +38,8 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+// Temporary release bootstrap; remove after core/v0.3.0 and telemetry/v0.3.0 are published.
+replace github.com/truvaagents/truva-g3/core => ../core
+
+replace github.com/truvaagents/truva-g3/telemetry => ../telemetry

--- a/telemetry/go.mod
+++ b/telemetry/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/go-redis/redis/v8 v8.11.5
-	github.com/truvaagents/truva-g3/core v0.2.0
+	github.com/truvaagents/truva-g3/core v0.3.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0
@@ -39,3 +39,6 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+// Temporary release bootstrap; remove after core/v0.3.0 is published.
+replace github.com/truvaagents/truva-g3/core => ../core


### PR DESCRIPTION
## Summary

Prepare the first dependency layer of the TruvaG3 `v0.3.0` multi-module release.

- Update all 57 framework and example module references from `v0.2.0` to `v0.3.0`.
- Add explicitly labeled temporary local replacements to the six framework modules that consume unpublished internal `v0.3.0` dependencies.
- Keep `go.sum` files unchanged until the corresponding dependency tags genuinely exist.

## Why

The conversation-correlation release adds new `core` APIs that are consumed by `telemetry` and `orchestration`. Tagging all modules directly from current `main` would leave their `go.mod` files resolving `core` and `telemetry` `v0.2.0`, which do not contain the new symbols and would break standalone consumers.

This follows the proven `v0.2.0` dependency-order publication process: stage version requirements first, publish `core`, publish `telemetry` against the real core tag, then remove the remaining temporary replacements and publish the dependent modules and root tag.

## Release sequence

After this PR merges:

1. Create and verify signed `core/v0.3.0` at the merge commit.
2. Remove only `telemetry`'s temporary core replacement, run standalone tidy/gates, merge, and tag `telemetry/v0.3.0`.
3. Remove the remaining temporary replacements, run standalone tidy/gates for root/AI/orchestration/memory/resilience, merge, and tag their module tags plus root `v0.3.0`.
4. Create the GitHub `v0.3.0` release.

Do not create `telemetry/v0.3.0` or dependent-module tags from this PR.

## Validation

- Standalone `go build ./...` and `go test -race ./...` for all seven framework modules
- Standalone `go vet ./...` for all seven framework modules
- `golangci-lint run ./...` for all seven framework modules — 0 issues
- `gosec ./...` for all seven framework modules — 0 issues
- `govulncheck ./...` for all seven framework modules with the patched Go 1.26.5 release toolchain — no called vulnerabilities
- `go mod tidy && go build ./...` for every example module
- `git diff --check`
- Verified zero remaining internal `v0.2.0` requirements across repository `go.mod` files

## Checklist

- [x] First-layer changes are limited to module references and temporary bootstrap replacements
- [x] No `go.sum` files changed before dependency tags exist
- [x] All framework and example validation passed
- [x] No tags are created by this PR
