### PR TITLE
chore(release): resolve telemetry core v0.3.0

### DIFF
--- a/telemetry/go.mod
+++ b/telemetry/go.mod
@@ -19,14 +19,12 @@ require (
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
@@ -39,6 +37,3 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
-
-// Temporary release bootstrap; remove after core/v0.3.0 is published.
-replace github.com/truvaagents/truva-g3/core => ../core

--- a/telemetry/go.sum
+++ b/telemetry/go.sum
@@ -37,8 +37,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/truvaagents/truva-g3/core v0.2.0 h1:EStsfUSsoMRWKyspFvN1Csg7W5H6HWmr8DLJMA1PHlc=
-github.com/truvaagents/truva-g3/core v0.2.0/go.mod h1:htx9LSkj39jVTDhE8e/i5C3+xOrkzCsXYgbdMEcBhEg=
+github.com/truvaagents/truva-g3/core v0.3.0 h1:zcEXqYR0tEY0b7NvAPbGovwPWwNG8eU3D4mHmwzOpB8=
+github.com/truvaagents/truva-g3/core v0.3.0/go.mod h1:WvvKpYHzhCmifaDNNJjZPUmNAy5m5CSDuD5PVxY5lKY=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
## What changed

- Removed telemetry's temporary local replacement for the core module.
- Refreshed telemetry's module checksums against the published `core/v0.3.0` tag.

## Why

TruvaG3 is a multi-module Go repository. Telemetry must resolve its published
core dependency independently before `telemetry/v0.3.0` can be tagged. This PR
is the second layer of the ordered v0.3.0 release.

## Impact

No runtime code changes. Standalone telemetry consumers will resolve the
immutable `core/v0.3.0` module rather than workspace source.

## Validation

Run with `GOWORK=off` and Go 1.26.5:

- `go mod tidy`
- `go build ./...`
- `go test -race ./...`
- `go vet ./...`
- `goimports -l .`
- `golangci-lint run ./...`
- `gosec ./...`
- `govulncheck ./...`

All passed; `go list -m -json` confirms telemetry resolves
`github.com/truvaagents/truva-g3/core v0.3.0` from the published module cache.

After this PR merges, publish only `telemetry/v0.3.0`. The remaining module tags
must wait for the final bootstrap-replacement cleanup layer.
