### PR TITLE
chore(release): finalize v0.3.0 module dependencies

### DIFF
--- a/ai/go.mod
+++ b/ai/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.31
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.30
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.56.0
+	github.com/aws/smithy-go v1.27.3
 	github.com/stretchr/testify v1.11.1
 	github.com/truvaagents/truva-g3/core v0.3.0
 	github.com/truvaagents/truva-g3/telemetry v0.3.0
@@ -25,7 +26,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.0 // indirect
-	github.com/aws/smithy-go v1.27.3 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -56,8 +56,3 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// Temporary release bootstrap; remove after core/v0.3.0 and telemetry/v0.3.0 are published.
-replace github.com/truvaagents/truva-g3/core => ../core
-
-replace github.com/truvaagents/truva-g3/telemetry => ../telemetry

--- a/ai/go.sum
+++ b/ai/go.sum
@@ -75,10 +75,10 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/truvaagents/truva-g3/core v0.2.0 h1:EStsfUSsoMRWKyspFvN1Csg7W5H6HWmr8DLJMA1PHlc=
-github.com/truvaagents/truva-g3/core v0.2.0/go.mod h1:htx9LSkj39jVTDhE8e/i5C3+xOrkzCsXYgbdMEcBhEg=
-github.com/truvaagents/truva-g3/telemetry v0.2.0 h1:7nJirE9DFUH1c3Vps7LA1u0v/fYwizmZajfTRP3pwFE=
-github.com/truvaagents/truva-g3/telemetry v0.2.0/go.mod h1:Z7c1KDUeYBqzP2m9k8hPvoAZsZPXOpflRZHX2ewstC4=
+github.com/truvaagents/truva-g3/core v0.3.0 h1:zcEXqYR0tEY0b7NvAPbGovwPWwNG8eU3D4mHmwzOpB8=
+github.com/truvaagents/truva-g3/core v0.3.0/go.mod h1:WvvKpYHzhCmifaDNNJjZPUmNAy5m5CSDuD5PVxY5lKY=
+github.com/truvaagents/truva-g3/telemetry v0.3.0 h1:PthHiIBOl5tlOc0zONkW799A48sTuq2N8AUx96Cm450=
+github.com/truvaagents/truva-g3/telemetry v0.3.0/go.mod h1:i+l8UcEhU3p3yGO/I6QbdzIh4Q8XA3PemkRO6TiFrH8=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,9 @@ require github.com/truvaagents/truva-g3/core v0.3.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	golang.org/x/text v0.37.0 // indirect
 )
 
@@ -18,6 +16,3 @@ require (
 // unresolvable core requirement, so external consumers cannot build it. It is
 // superseded by v0.2.0.
 retract v0.1.0
-
-// Temporary release bootstrap; remove after core/v0.3.0 is published.
-replace github.com/truvaagents/truva-g3/core => ./core

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/truvaagents/truva-g3/core v0.2.0 h1:EStsfUSsoMRWKyspFvN1Csg7W5H6HWmr8DLJMA1PHlc=
-github.com/truvaagents/truva-g3/core v0.2.0/go.mod h1:htx9LSkj39jVTDhE8e/i5C3+xOrkzCsXYgbdMEcBhEg=
+github.com/truvaagents/truva-g3/core v0.3.0 h1:zcEXqYR0tEY0b7NvAPbGovwPWwNG8eU3D4mHmwzOpB8=
+github.com/truvaagents/truva-g3/core v0.3.0/go.mod h1:WvvKpYHzhCmifaDNNJjZPUmNAy5m5CSDuD5PVxY5lKY=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=

--- a/memory/go.mod
+++ b/memory/go.mod
@@ -43,8 +43,3 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// Temporary release bootstrap; remove after core/v0.3.0 and telemetry/v0.3.0 are published.
-replace github.com/truvaagents/truva-g3/core => ../core
-
-replace github.com/truvaagents/truva-g3/telemetry => ../telemetry

--- a/memory/go.sum
+++ b/memory/go.sum
@@ -45,10 +45,10 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/truvaagents/truva-g3/core v0.2.0 h1:EStsfUSsoMRWKyspFvN1Csg7W5H6HWmr8DLJMA1PHlc=
-github.com/truvaagents/truva-g3/core v0.2.0/go.mod h1:htx9LSkj39jVTDhE8e/i5C3+xOrkzCsXYgbdMEcBhEg=
-github.com/truvaagents/truva-g3/telemetry v0.2.0 h1:7nJirE9DFUH1c3Vps7LA1u0v/fYwizmZajfTRP3pwFE=
-github.com/truvaagents/truva-g3/telemetry v0.2.0/go.mod h1:Z7c1KDUeYBqzP2m9k8hPvoAZsZPXOpflRZHX2ewstC4=
+github.com/truvaagents/truva-g3/core v0.3.0 h1:zcEXqYR0tEY0b7NvAPbGovwPWwNG8eU3D4mHmwzOpB8=
+github.com/truvaagents/truva-g3/core v0.3.0/go.mod h1:WvvKpYHzhCmifaDNNJjZPUmNAy5m5CSDuD5PVxY5lKY=
+github.com/truvaagents/truva-g3/telemetry v0.3.0 h1:PthHiIBOl5tlOc0zONkW799A48sTuq2N8AUx96Cm450=
+github.com/truvaagents/truva-g3/telemetry v0.3.0/go.mod h1:i+l8UcEhU3p3yGO/I6QbdzIh4Q8XA3PemkRO6TiFrH8=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/orchestration/go.mod
+++ b/orchestration/go.mod
@@ -43,8 +43,3 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
-
-// Temporary release bootstrap; remove after core/v0.3.0 and telemetry/v0.3.0 are published.
-replace github.com/truvaagents/truva-g3/core => ../core
-
-replace github.com/truvaagents/truva-g3/telemetry => ../telemetry

--- a/orchestration/go.sum
+++ b/orchestration/go.sum
@@ -45,10 +45,10 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/truvaagents/truva-g3/core v0.2.0 h1:EStsfUSsoMRWKyspFvN1Csg7W5H6HWmr8DLJMA1PHlc=
-github.com/truvaagents/truva-g3/core v0.2.0/go.mod h1:htx9LSkj39jVTDhE8e/i5C3+xOrkzCsXYgbdMEcBhEg=
-github.com/truvaagents/truva-g3/telemetry v0.2.0 h1:7nJirE9DFUH1c3Vps7LA1u0v/fYwizmZajfTRP3pwFE=
-github.com/truvaagents/truva-g3/telemetry v0.2.0/go.mod h1:Z7c1KDUeYBqzP2m9k8hPvoAZsZPXOpflRZHX2ewstC4=
+github.com/truvaagents/truva-g3/core v0.3.0 h1:zcEXqYR0tEY0b7NvAPbGovwPWwNG8eU3D4mHmwzOpB8=
+github.com/truvaagents/truva-g3/core v0.3.0/go.mod h1:WvvKpYHzhCmifaDNNJjZPUmNAy5m5CSDuD5PVxY5lKY=
+github.com/truvaagents/truva-g3/telemetry v0.3.0 h1:PthHiIBOl5tlOc0zONkW799A48sTuq2N8AUx96Cm450=
+github.com/truvaagents/truva-g3/telemetry v0.3.0/go.mod h1:i+l8UcEhU3p3yGO/I6QbdzIh4Q8XA3PemkRO6TiFrH8=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/resilience/go.mod
+++ b/resilience/go.mod
@@ -12,7 +12,6 @@ require (
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -20,7 +19,6 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0 // indirect
@@ -38,8 +36,3 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
-
-// Temporary release bootstrap; remove after core/v0.3.0 and telemetry/v0.3.0 are published.
-replace github.com/truvaagents/truva-g3/core => ../core
-
-replace github.com/truvaagents/truva-g3/telemetry => ../telemetry

--- a/resilience/go.sum
+++ b/resilience/go.sum
@@ -37,10 +37,10 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/truvaagents/truva-g3/core v0.2.0 h1:EStsfUSsoMRWKyspFvN1Csg7W5H6HWmr8DLJMA1PHlc=
-github.com/truvaagents/truva-g3/core v0.2.0/go.mod h1:htx9LSkj39jVTDhE8e/i5C3+xOrkzCsXYgbdMEcBhEg=
-github.com/truvaagents/truva-g3/telemetry v0.2.0 h1:7nJirE9DFUH1c3Vps7LA1u0v/fYwizmZajfTRP3pwFE=
-github.com/truvaagents/truva-g3/telemetry v0.2.0/go.mod h1:Z7c1KDUeYBqzP2m9k8hPvoAZsZPXOpflRZHX2ewstC4=
+github.com/truvaagents/truva-g3/core v0.3.0 h1:zcEXqYR0tEY0b7NvAPbGovwPWwNG8eU3D4mHmwzOpB8=
+github.com/truvaagents/truva-g3/core v0.3.0/go.mod h1:WvvKpYHzhCmifaDNNJjZPUmNAy5m5CSDuD5PVxY5lKY=
+github.com/truvaagents/truva-g3/telemetry v0.3.0 h1:PthHiIBOl5tlOc0zONkW799A48sTuq2N8AUx96Cm450=
+github.com/truvaagents/truva-g3/telemetry v0.3.0/go.mod h1:i+l8UcEhU3p3yGO/I6QbdzIh4Q8XA3PemkRO6TiFrH8=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
## What changed

- Removed the remaining temporary local replacements from the root, AI, memory,
  orchestration, and resilience modules.
- Refreshed their checksums against the published `core/v0.3.0` and
  `telemetry/v0.3.0` tags.
- Let `go mod tidy` correctly classify `github.com/aws/smithy-go` as a direct AI
  module dependency.

## Why

This is the final dependency layer of the ordered multi-module v0.3.0 release.
The remaining modules can now be published without workspace-relative
replacements and can be consumed independently.

## Impact

No runtime code changes. Published framework modules will resolve immutable
v0.3.0 dependencies using normal Go module semantics.

## Validation

Every framework module was validated standalone with `GOWORK=off` and Go
1.26.5:

- `go mod tidy` for every changed module
- `go build ./...`
- `go test -race ./...`
- `go vet ./...`
- framework-scoped `goimports -l`
- `golangci-lint run ./...`
- `gosec ./...`
- `govulncheck ./...`

All passed. Module resolution checks confirm `core@v0.3.0` and
`telemetry@v0.3.0` are downloaded without local replacements, and no internal
v0.2.0 checksums remain in the changed modules.

After this PR merges, the AI, memory, orchestration, resilience, and root v0.3.0
tags can be published from its merge commit.
