### PR TITLE
docs(www): polish TruvaG3 introduction

### DIFF
--- a/www/blogs/truvag3-introduction.html
+++ b/www/blogs/truvag3-introduction.html
@@ -199,10 +199,73 @@
     font-size: 0.85rem;
     text-align: center;
     margin-top: 0.4rem;
+    line-height: 1.5;
   }
   figcaption strong {
     color: var(--accent);
     font-weight: 600;
+  }
+  figure img {
+    width: 100%; height: auto; display: block; margin: 0 auto;
+    border: 1px solid var(--rule); border-radius: 10px;
+    background: #0b1220; cursor: zoom-in;
+  }
+  figure > svg { cursor: zoom-in; }
+  figure:has(> img),
+  figure:has(> svg) { position: relative; }
+  figure:has(> img)::after,
+  figure:has(> svg)::after {
+    content: ""; position: absolute; top: 10px; right: 10px;
+    width: 30px; height: 30px; border-radius: 8px; border: 1px solid var(--rule);
+    background-color: rgba(18, 24, 38, 0.82);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23cfe1ff' stroke-width='2' stroke-linecap='round'%3E%3Ccircle cx='10.5' cy='10.5' r='6.5'/%3E%3Cline x1='15.2' y1='15.2' x2='21' y2='21'/%3E%3C/svg%3E");
+    background-repeat: no-repeat; background-position: center; background-size: 16px 16px;
+    opacity: 0; transform: scale(0.92);
+    transition: opacity 0.15s ease, transform 0.15s ease; pointer-events: none;
+  }
+  figure:has(> img):hover::after,
+  figure:has(> img):focus-within::after,
+  figure:has(> svg):hover::after,
+  figure:has(> svg):focus-within::after { opacity: 1; transform: scale(1); }
+  figure [data-lightbox-trigger]:focus-visible {
+    outline: 3px solid var(--accent);
+    outline-offset: 3px;
+  }
+  @media (max-width: 720px) {
+    figure:has(> svg) {
+      overflow-x: auto;
+      overscroll-behavior-inline: contain;
+      -webkit-overflow-scrolling: touch;
+    }
+    figure > svg {
+      min-width: 720px;
+    }
+  }
+  .img-lightbox {
+    position: fixed; inset: 0; z-index: 1000; display: none;
+    align-items: center; justify-content: center; padding: 28px; box-sizing: border-box;
+    background: rgba(6, 10, 18, 0.93); cursor: zoom-out;
+  }
+  .img-lightbox.open { display: flex; }
+  .img-lightbox .lb-viewport {
+    max-width: 96vw; max-height: 90vh; overflow: auto;
+    border-radius: 10px; cursor: default;
+  }
+  .img-lightbox img {
+    display: block; width: auto; height: auto;
+    border: 1px solid var(--rule); border-radius: 10px; background: #0b1220;
+    box-shadow: 0 24px 70px rgba(0, 0, 0, 0.65); cursor: zoom-out;
+  }
+  .img-lightbox img.lb-raster { max-width: 96vw; max-height: 90vh; }
+  .img-lightbox img.lb-svg { width: 1000px; max-width: none; max-height: none; }
+  .img-lightbox .lb-close {
+    position: fixed; top: 14px; right: 20px; width: 38px; height: 38px;
+    border: 1px solid var(--rule); border-radius: 8px; background: #121826;
+    color: #cfe1ff; font-size: 22px; line-height: 1; cursor: pointer;
+  }
+  .img-lightbox .lb-hint {
+    position: fixed; bottom: 16px; left: 0; right: 0; text-align: center;
+    color: #6b7a99; font-size: 12px; pointer-events: none;
   }
   /* Amber-toned text for inline emphasis — matches --brand-g3 mid-tone
    * (#FFA040) used across the brand mark and homepage accents. */
@@ -333,8 +396,18 @@
 <header class="article-header">
   <h1>TruvaG3: An Introduction to the Microagents Framework</h1>
   <p class="dek">A guided tour of <a href="https://github.com/truvaagents/truva-g3">TruvaG3</a> — why it exists, how the architecture works in practice, what the framework ships with, and how to decide whether it fits your situation. Written for engineers and architects who already operate Kubernetes platforms.</p>
-  <p class="meta">Neelabh Tripathi · May 16, 2026 · Updated July 23, 2026</p>
+  <p class="meta">Neelabh Tripathi · May 16, 2026 · Updated July 29, 2026</p>
 </header>
+
+<aside class="callout">
+  <strong>In brief.</strong>
+  <ul>
+    <li><strong>What it is:</strong> a modular Go framework for independently deployable AI agents and tools that discover capabilities at runtime.</li>
+    <li><strong>What is different:</strong> coordination stays inside each agent, peers call one another directly over HTTP, and no central agent control plane is required.</li>
+    <li><strong>Best fit:</strong> teams already operating Go services on Kubernetes that want self-hosting, runtime discovery, and OpenTelemetry-native operations.</li>
+    <li><strong>Probably not the best fit:</strong> a small prototype with a fixed tool list, or a team that does not want to operate Kubernetes and the supporting services.</li>
+  </ul>
+</aside>
 
 <details class="toc">
   <summary>Contents</summary>
@@ -387,7 +460,7 @@
 
 <p><strong>TruvaG3 is a Go framework that takes a different position on both counts.</strong> The architecture is the microagents reference described in <a href="microagents-architecture.html">a separate article</a> — capabilities registered into a shared registry at runtime, peers addressed by logical name, orchestration inside each agent, decentralized coordination between participants. The runtime is ordinary Kubernetes: Deployments, Services, ConfigMaps, Secrets, ingress, service mesh, autoscaling, OpenTelemetry. The framework adds the agent-specific pieces — discovery, an LLM client, an orchestrator, resilience and memory primitives — and does not require anything else.</p>
 
-<p>This article walks through both halves. It is meant to be read in one sitting; sections can be skipped without losing the thread.</p>
+<p>This article walks through both halves. Read it end to end, or use the contents to jump directly to the areas relevant to you; sections can be skipped without losing the thread.</p>
 </section>
 
 <section>
@@ -499,7 +572,7 @@
 <svg viewBox="0 0 760 340" xmlns="http://www.w3.org/2000/svg"
      style="width:100%;height:auto;display:block;margin:0 auto;background:#ffffff;border-radius:6px;border:1px solid #2a3550;"
      role="img"
-     aria-label="Between participants. A Capability Registry box at the top is connected by thin dashed gray lines down to four participants below — Agent A and Agent C on the outside (each containing a small inner AIOrchestrator showing plan, act, observe, and a loop), and Tool B and Tool D between them (passive endpoints with no orchestrator). A thick blue arrow labelled 'user query' enters Agent A from outside the diagram on the left, indicating that Agent A is the entry point for the request. From there, thick blue arrows show direct peer-to-peer HTTP calls between participants: Agent A to Tool B, Agent C to Tool D, and Agent A curving downward to Agent C beneath the others. There is no central process between the participants; each one runs its own loop and reaches its peers directly.">
+     aria-label="Between participants. A Capability Registry box at the top is connected by thin dashed gray lines down to four participants below — Agent A and Agent C on the outside (each containing a small inner AIOrchestrator showing plan, act, observe, and a loop), and Tool B and Tool D between them (passive endpoints with no orchestrator). A thick blue arrow labeled 'user query' enters Agent A from outside the diagram on the left, indicating that Agent A is the entry point for the request. From there, thick blue arrows show direct peer-to-peer HTTP calls between participants: Agent A to Tool B, Agent C to Tool D, and Agent A curving downward to Agent C beneath the others. There is no central process between the participants; each one runs its own loop and reaches its peers directly.">
   <defs>
     <marker id="bp-arr-blue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M0,0 L10,5 L0,10 z" fill="#0b6cff"/>
@@ -572,7 +645,7 @@
 
 <p>The result: tools and agents look the same to the LLM. A capability is a capability. Adding a new participant is purely additive — no central manifest changes, no caller code changes, no redeploys elsewhere. Within one refresh cycle of the registry, the new participant is visible to every existing caller.</p>
 
-<p>One architectural property is worth surfacing here, because it underpins everything that follows: <strong>the wire protocol between agents and tools is plain HTTP/REST</strong>. Each participant exposes its capability descriptions, JSON schemas, health, and OpenAPI document over HTTP. Calls between peers are HTTP. The shared registry — Redis or Valkey by default; pluggable — sits behind the discovery interface, but everything visible to an agent, a tool, or a piece of platform tooling on the network is an HTTP/REST surface. The architecture introduces no new wire protocol for agent-tool communication — it composes well-understood distributed-systems primitives (service discovery, REST endpoints, structured contracts) into a model that fits multi-agent systems. The pattern is credible at scale not because it is new, but because every component of it has been operated in production microservice systems for years. The next subsection covers what that choice means operationally.</p>
+<p>One architectural property underpins everything that follows: <strong>the wire protocol between agents and tools is plain HTTP/REST</strong>. The shared registry — Redis or Valkey by default; pluggable — sits behind the discovery interface, while participants expose contracts and call peers over familiar HTTP surfaces. The architecture composes established distributed-systems primitives rather than introducing a new agent-specific wire protocol. The next subsection covers what that choice means operationally.</p>
 
 <h3 id="operational-reason">The operational reason</h3>
 
@@ -605,7 +678,7 @@
 
 <p>This is a structural property, not a compatibility claim. Because the protocol is the one your platform team already operates, every piece of infrastructure that already works on your REST services works on TruvaG3 components in the same way: API gateways (Kong, Ambassador, Nginx), service meshes (Istio, Linkerd), ingress controllers, network policies, identity providers, mTLS, OAuth and JWT validation, RBAC, audit logging, rate limiters, web application firewalls, monitoring, API governance tools, OpenAPI consumers (Swagger UI, Postman, code generators). Nothing has to be re-built or re-secured for agent workloads. Security and authentication and authorization patterns the team has already standardized on apply by default, because the thing being secured is just an HTTP service.</p>
 
-<p>The combined claim is straightforward. TruvaG3 is architecturally different from most agent frameworks, because it inherits the microagents pattern. It is also operationally familiar, because the platform layer is the same Kubernetes platform the team is already running — and because the wire protocol is the same HTTP/REST contract every other service in the cluster already follows. Most frameworks pick one or the other; TruvaG3 is shaped around the assumption that both matter.</p>
+<p>That combination is the point: the microagents architecture without a parallel operating model. TruvaG3 assumes architectural flexibility and operational familiarity both matter.</p>
 </section>
 
 <section>
@@ -624,7 +697,7 @@
   <li>An optional full JSON Schema for deployments that want stricter validation.</li>
 </ul>
 
-<p>Registrations are kept alive by heartbeats. Each participant refreshes its entry every 15 seconds against a 30-second TTL. If a participant crashes or loses network connectivity, its entry expires within one TTL window. Liveness is the registration — there is no separate health-check system to keep in sync.</p>
+<p>Registrations are leases kept alive by heartbeats. If a participant crashes or loses network connectivity, its entry expires automatically; <a href="#runtime-discovery">the runtime-discovery section</a> covers the timing and failure trade-off.</p>
 
 <p>Three roles run on top of the registry:</p>
 
@@ -670,592 +743,949 @@ type Discovery interface {
 <p>The framework is intentionally modular. The <code>core</code> module is the only required dependency; everything else is opt-in. Six modules ship in the box:</p>
 
 <ul>
-  <li><a href="https://github.com/truvaagents/truva-g3/blob/main/core/README.md"><strong><code>core</code></strong></a> — defines the framework's interfaces (<code>Component</code>, <code>Registry</code>, <code>Discovery</code>, <code>AIClient</code>, <code>Telemetry</code>), base implementations for tools and agents, configuration loading, the pluggable service registry, and the auto-generated HTTP surface (capability endpoints, <code>/health</code>, <code>/openapi.json</code>). Every component depends on it.</li>
-  <li><a href="https://github.com/truvaagents/truva-g3/blob/main/ai/README.md"><strong><code>ai</code></strong></a> — provider-neutral LLM clients with environment-based detection among registered providers, request-aware enterprise profiles, dynamic routing and credentials, model aliases, heterogeneous chain failover, request policy, and embeddings. Add it when an agent needs to call an LLM.</li>
-  <li><a href="https://github.com/truvaagents/truva-g3/blob/main/orchestration/README.md"><strong><code>orchestration</code></strong></a> — the per-agent reasoning loop: dynamic LLM-driven planning, DAG execution with parallelism, iterative multi-phase plans, streaming, human-in-the-loop approvals, async tasks, and scheduled execution. Add it when an agent coordinates multi-step work.</li>
-  <li><a href="https://github.com/truvaagents/truva-g3/blob/main/memory/README.md"><strong><code>memory</code></strong></a> — shared agent memory (episodic events, knowledge store, semantic recall) and per-user memory (extraction, reconciliation, forget). Add it when agents need state across requests.</li>
-  <li><a href="https://github.com/truvaagents/truva-g3/blob/main/resilience/README.md"><strong><code>resilience</code></strong></a> — circuit breakers, retry with exponential backoff and jitter, panic recovery. Add it for robust fault isolation between components.</li>
+  <li><a href="https://github.com/truvaagents/truva-g3/blob/main/core/README.md"><strong><code>core</code></strong></a> — the framework's interfaces, the base implementations for tools and agents, configuration loading, the pluggable service registry, and the auto-generated HTTP surface. Every component depends on it.</li>
+  <li><a href="https://github.com/truvaagents/truva-g3/blob/main/ai/README.md"><strong><code>ai</code></strong></a> — provider-neutral LLM clients, enterprise routing, failover chains, and embeddings. Add it when an agent needs to call an LLM.</li>
+  <li><a href="https://github.com/truvaagents/truva-g3/blob/main/orchestration/README.md"><strong><code>orchestration</code></strong></a> — the per-agent reasoning loop: planning, DAG execution, streaming, approvals, async and scheduled work. Add it when an agent coordinates multi-step work.</li>
+  <li><a href="https://github.com/truvaagents/truva-g3/blob/main/memory/README.md"><strong><code>memory</code></strong></a> — shared agent memory and per-user memory. Add it when agents need state across requests.</li>
+  <li><a href="https://github.com/truvaagents/truva-g3/blob/main/resilience/README.md"><strong><code>resilience</code></strong></a> — circuit breakers, retry with exponential backoff, panic recovery. Add it for fault isolation between components.</li>
   <li><a href="https://github.com/truvaagents/truva-g3/blob/main/telemetry/README.md"><strong><code>telemetry</code></strong></a> — OpenTelemetry-native metrics, traces, and structured logging. Cross-cutting; the other modules wire it in through dependency injection.</li>
 </ul>
 
-<p>The walk below is a tour through what each of these modules provides, not a manual — each subsection has a link to the corresponding section of the <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/overview/FRAMEWORK_FEATURES_GUIDE.md">Framework Features Guide</a> for the details that matter at implementation time.</p>
+<figure id="fig-module-stack">
+<svg viewBox="0 0 760 330" xmlns="http://www.w3.org/2000/svg"
+     style="width:100%;height:auto;display:block;margin:0 auto;background:#ffffff;border-radius:6px;border:1px solid #2a3550;"
+     role="img"
+     aria-label="The six modules that ship with TruvaG3, drawn as a stack. A wide amber-bordered box across the bottom is the core module, labeled REQUIRED: it holds the framework interfaces, the base tool and agent implementations, configuration loading, the pluggable service registry, and the auto-generated HTTP surface, and every component depends on it. Above it sit four separate white boxes, each labeled OPT-IN, connected down to core by short dashed lines: ai (provider-neutral LLM clients, chains and embeddings; add it when an agent calls an LLM), orchestration (plan, execute, synthesize, plus async, scheduling and approvals; add it when an agent coordinates multi-step work), memory (shared and per-user state, episodic events, knowledge and recall; add it when agents need state across requests), and resilience (circuit breakers, retry, panic recovery; add it for fault isolation). A gray band across the top is the telemetry module, marked CROSS-CUTTING, carrying metrics, traces and structured logging, which the other modules wire in through dependency injection rather than sitting in the dependency stack.">
+  <style>
+    .ms-core { fill:#fff8e6; stroke:#d9b35a; stroke-width:2; }
+    .ms-opt  { fill:#ffffff; stroke:#d0d7de; stroke-width:1.2; }
+    .ms-cross{ fill:#f6f8fa; stroke:#d0d7de; stroke-width:1.2; }
+    .ms-name { font:600 13.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#1a1a1a; }
+    .ms-mono { font:600 13px ui-monospace, SFMono-Regular, Menlo, monospace; fill:#1a1a1a; }
+    .ms-sub  { font:10.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#6e7781; }
+    .ms-when { font:italic 10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#7a5a16; }
+    .ms-tag  { font:700 8.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0.7px; fill:#8c96a3; }
+    .ms-tagc { font:700 8.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0.7px; fill:#a9862f; }
+    .ms-tie  { stroke:#d0d7de; stroke-width:1; stroke-dasharray:3,3; fill:none; }
+  </style>
+
+  <!-- cross-cutting telemetry band -->
+  <rect x="30" y="26" width="700" height="48" rx="6" class="ms-cross"/>
+  <text x="46" y="47" class="ms-mono">telemetry</text>
+  <text x="132" y="47" class="ms-sub">— OpenTelemetry-native metrics, traces, structured logging</text>
+  <text x="46" y="64" class="ms-sub">wired into the other modules through dependency injection, not stacked on top of them</text>
+  <text x="714" y="47" text-anchor="end" class="ms-tag">CROSS-CUTTING</text>
+
+  <!-- four opt-in modules -->
+  <rect x="30"  y="104" width="164" height="112" rx="6" class="ms-opt"/>
+  <text x="44"  y="124" class="ms-tag">OPT-IN</text>
+  <text x="44"  y="146" class="ms-mono">ai</text>
+  <text x="44"  y="165" class="ms-sub">provider-neutral LLM</text>
+  <text x="44"  y="179" class="ms-sub">clients, failover chains,</text>
+  <text x="44"  y="193" class="ms-sub">embeddings</text>
+  <text x="44"  y="209" class="ms-when">add it: calling an LLM</text>
+
+  <rect x="206" y="104" width="164" height="112" rx="6" class="ms-opt"/>
+  <text x="220" y="124" class="ms-tag">OPT-IN</text>
+  <text x="220" y="146" class="ms-mono">orchestration</text>
+  <text x="220" y="165" class="ms-sub">plan → execute →</text>
+  <text x="220" y="179" class="ms-sub">synthesize; async,</text>
+  <text x="220" y="193" class="ms-sub">scheduling, approvals</text>
+  <text x="220" y="209" class="ms-when">add it: multi-step work</text>
+
+  <rect x="382" y="104" width="164" height="112" rx="6" class="ms-opt"/>
+  <text x="396" y="124" class="ms-tag">OPT-IN</text>
+  <text x="396" y="146" class="ms-mono">memory</text>
+  <text x="396" y="165" class="ms-sub">shared and per-user</text>
+  <text x="396" y="179" class="ms-sub">state; episodic events,</text>
+  <text x="396" y="193" class="ms-sub">knowledge, recall</text>
+  <text x="396" y="209" class="ms-when">add it: state across requests</text>
+
+  <rect x="558" y="104" width="164" height="112" rx="6" class="ms-opt"/>
+  <text x="572" y="124" class="ms-tag">OPT-IN</text>
+  <text x="572" y="146" class="ms-mono">resilience</text>
+  <text x="572" y="165" class="ms-sub">circuit breakers, retry</text>
+  <text x="572" y="179" class="ms-sub">with backoff, panic</text>
+  <text x="572" y="193" class="ms-sub">recovery</text>
+  <text x="572" y="209" class="ms-when">add it: fault isolation</text>
+
+  <!-- ties down to core -->
+  <line x1="112" y1="216" x2="112" y2="240" class="ms-tie"/>
+  <line x1="288" y1="216" x2="288" y2="240" class="ms-tie"/>
+  <line x1="464" y1="216" x2="464" y2="240" class="ms-tie"/>
+  <line x1="640" y1="216" x2="640" y2="240" class="ms-tie"/>
+
+  <!-- core -->
+  <rect x="30" y="240" width="700" height="66" rx="6" class="ms-core"/>
+  <text x="46" y="264" class="ms-mono">core</text>
+  <text x="98" y="264" class="ms-sub">— interfaces, base tool and agent, configuration loading, pluggable service registry,</text>
+  <text x="46" y="282" class="ms-sub">auto-generated HTTP surface (capability endpoints, health, OpenAPI)</text>
+  <text x="46" y="299" class="ms-when">every component depends on it</text>
+  <text x="714" y="264" text-anchor="end" class="ms-tagc">REQUIRED</text>
+</svg>
+<figcaption><strong>Figure 3.</strong> <strong>One required module, four opt-in ones, and telemetry across the top.</strong> Only <code>core</code> is a hard dependency. The four modules above it are additive — an agent that never calls an LLM never imports <code>ai</code>, a tool-only deployment never imports <code>memory</code> — so what you operate is what you actually use. <code>telemetry</code> sits apart because it is not a layer in the stack: the other modules take it by injection.</figcaption>
+</figure>
+
+<p>What follows is a tour of what each module changes about building and running an agent. It is not a reference, and it does not try to be. Every subsection ends with a link to the corresponding reference guide, where the option names, configuration keys, metric names, and interface signatures live.</p>
 
 <h3 id="component-runtime">1. Component runtime</h3>
 
-<p>Behind every TruvaG3 component — tool or agent — is a small runtime that handles the work of being a service: starting an HTTP server, wiring panic-recovery and logging middleware, registering capabilities with the discovery layer, propagating loggers and telemetry into handlers, refreshing heartbeats, and providing a bounded HTTP shutdown the application can invoke on a termination signal. The developer writes the business logic — the API client, the domain handlers — and the framework supplies everything else.</p>
+<p>Behind every TruvaG3 component — tool or agent — is a small runtime that handles the work of being a service: starting an HTTP server, wiring panic-recovery and logging middleware, registering capabilities with the discovery layer, propagating loggers and telemetry into handlers, refreshing heartbeats, and shutting down cleanly on a termination signal. The developer writes the business logic. The framework supplies the rest.</p>
 
-<p><strong>Functional-options API, predictable defaults.</strong> A component starts life with <code>core.NewFramework(component, opts...)</code>. Every operational property is set through a <code>With...</code> option — explicit when you need to override, invisible when defaults are fine. The options that come up in practice:</p>
+<p>A component starts with <code>core.NewFramework(component, opts...)</code>, and every operational property is a functional option — a name, a port, a namespace label, a registry connection, CORS for browser-facing components, middleware, OpenAPI generation. Most have a matching <code>TRUVAG3_*</code> environment variable, so one binary runs in many environments without recompiling, and precedence is predictable: explicit code wins, then environment, then framework defaults. Panic recovery and request logging are wired for you; distributed tracing and anything application-specific — auth, rate limiting, audit — go in through the middleware option.</p>
 
-<ul>
-  <li><strong><code>WithName</code></strong> — the logical name the framework registers in discovery and uses in logs, metrics, and traces.</li>
-  <li><strong><code>WithPort</code></strong> — the HTTP port to listen on. Standard Kubernetes deployments leave this at the container port (e.g., 8080).</li>
-  <li><strong><code>WithNamespace</code></strong> — a logical grouping label (e.g., <code>"production"</code>, <code>"staging"</code>) that is attached to the component's registry metadata and emitted in logs and traces. It is not a Kubernetes namespace, and it does not key-partition the registry — the Redis registry key namespace is currently hardcoded to <code>truvag3</code>.</li>
-  <li><strong><code>WithRedisURL</code></strong> / <strong><code>WithDiscovery</code></strong> — turn on the registry connection. Pluggable backends sit behind these.</li>
-  <li><strong><code>WithCORS</code></strong> / <strong><code>WithCORSDefaults</code></strong> — opt in to CORS for browser-facing components. Off by default, since most internal services do not need it.</li>
-  <li><strong><code>WithMiddleware</code></strong> — wire arbitrary HTTP middleware into the handler chain. Panic recovery, request/response logging, and (when enabled) CORS are wired automatically by the framework. Distributed tracing is NOT auto-wired — application code adds it through this option, typically with <code>telemetry.TracingMiddleware</code> or <code>TracingMiddlewareWithConfig</code>. This is also the hook for application-specific middleware (auth, rate-limiting, audit).</li>
-  <li><strong><code>WithOpenAPI</code></strong> — opt in to the auto-generated OpenAPI document at <code>/openapi.json</code>. Off by default for security; see <a href="#capability-contracts">§3</a> for what the document contains and <a href="#security">§12</a> for when to enable it.</li>
-  <li><strong><code>WithDevelopmentMode</code></strong> — pretty (human-readable) logs, <code>debug</code> log level, text log format. Off in production deployments. (Validation relaxation for AI/discovery is separate, via <code>WithMockAI</code> / <code>WithMockDiscovery</code>.)</li>
-</ul>
+<p>Every component gets the same endpoints mounted for free. <code>GET /health</code> is a Kubernetes-ready liveness probe. <code>GET /api/capabilities</code> is the component's catalog. Each registered capability gets its own POST endpoint, and one that declares an input summary also gets an auto-generated JSON Schema — no HTTP handler to write in either case. <code>GET /openapi.json</code> serves the full document once you turn it on. <a href="#capability-contracts">Section 3</a> covers what those contracts contain.</p>
 
-<p>Most operational options have a corresponding environment variable (<code>TRUVAG3_*</code>) so the same binary can run in many environments without recompilation. Options that take function values — middleware, custom loggers — are code-only. The precedence order is documented and predictable: explicit code overrides take priority, environment variables come next, framework defaults are the fallback.</p>
+<p>Dependencies arrive by injection rather than through globals, and what a component receives depends on what it is. Tools get a registry handle that can register but not look anything up, plus a logger, telemetry, and an optional AI client. Agents get full discovery and memory as well. Tools deliberately have no memory field: caching a tool's own responses is a tool-local concern with tool-specific eviction rules, and the framework does not pretend otherwise. Tests substitute the in-memory implementations that ship alongside.</p>
 
-<p><strong>Standard endpoints, no boilerplate.</strong> The framework auto-mounts a small set of endpoints on every component. Hit any running tool or agent and these are always there:</p>
+<p>Long-running background work — a memory sweeper, a metric reporter, a scheduled-task worker — registers as a runnable, which the framework starts before the HTTP server, hands a cancellation context, and stops during shutdown.</p>
 
-<ul>
-  <li><strong><code>GET /health</code></strong> — liveness probe. The default tool handler returns <code>{"id":..., "name":..., "status":"healthy", "type":"tool"}</code> — e.g. <code>weather-tool-v2</code> returns <code>{"id":"weather-tool-v2","name":"weather-tool-v2","status":"healthy","type":"tool"}</code>. The default agent handler returns a smaller shape: <code>{"status":"healthy", "agent":..., "id":...}</code> (no <code>type</code>; the name field is keyed <code>agent</code>). Bundled chat agents typically override <code>/health</code> with a richer handler that includes orchestrator status. The path is configurable; the default <code>/health</code> works with Kubernetes liveness and readiness probes without any extra configuration.</li>
-  <li><strong><code>GET /api/capabilities</code></strong> — the component's capability catalog. See <a href="#capability-contracts">§3</a>.</li>
-  <li><strong><code>POST /api/capabilities/{name}</code></strong> — the auto-generated endpoint per capability. Components do not have to write HTTP handlers; the framework binds the capability handler function to this path automatically when the capability is registered without an explicit endpoint.</li>
-  <li><strong><code>GET /api/capabilities/{name}/schema</code></strong> — auto-generated JSON Schema per capability. Mounted only when the capability declares an <code>InputSummary</code> (Phase 2 of the schema model — see <a href="#capability-contracts">§3</a>).</li>
-  <li><strong><code>GET /openapi.json</code></strong> — full OpenAPI document (when enabled).</li>
-</ul>
-
-<p>Agents that need to expose the live registry snapshot register a <code>GET /discover</code> capability themselves — the bundled chat agents do this. It is a convention, not a framework-mounted endpoint. See <a href="#runtime-discovery">§2</a> for the discovery story.</p>
-
-<p><strong>Lifecycle.</strong> The framework manages the component's lifespan in this order:</p>
-
-<ol>
-  <li><strong>Setup</strong> — configuration loading, dependency injection (registry, telemetry, memory store for agents), middleware chain wiring.</li>
-  <li><strong>Initialize</strong> — the component registers itself with the discovery registry and starts its heartbeat goroutine. Tools also re-register with the resolved address when the HTTP server actually binds; agents log the address but rely on the Initialize-time registration.</li>
-  <li><strong>Background runnables start</strong> — anything registered via <code>RegisterRunnable</code> (memory sweepers, scheduled-executor workers, custom periodic jobs) starts in parallel goroutines that receive the same context.</li>
-  <li><strong>HTTP server starts</strong> — the component begins serving requests on a blocking <code>ListenAndServe</code> call.</li>
-  <li><strong>Shutdown</strong> — <code>BaseAgent.Stop</code> and <code>BaseTool.Shutdown</code> call <code>http.Server.Shutdown</code> (bounded by <code>HTTP.ShutdownTimeout</code>, code default 10s), deregister from discovery, and stop background runnables cleanly. Two important caveats for the current code: (a) <code>Framework.Run(ctx)</code> does not itself watch <code>ctx</code> to invoke shutdown — applications wire <code>SIGTERM</code>/<code>SIGINT</code> in <code>main</code> and the bundled examples typically end the process with <code>os.Exit</code> after cancellation, so framework-managed graceful shutdown only happens when application code explicitly calls <code>Stop</code>/<code>Shutdown</code>; (b) <code>TRUVAG3_HTTP_SHUTDOWN_TIMEOUT</code> is declared on the struct as a tag but is not currently loaded by <code>LoadFromEnv()</code> — change the value via code (<code>Config.HTTP.ShutdownTimeout</code>) for now.</li>
-</ol>
-
-<p>The 10-second code default for the shutdown timeout sits comfortably inside Kubernetes' default <code>terminationGracePeriodSeconds</code> of 30s, leaving headroom to drain in-flight requests before the kubelet sends <code>SIGKILL</code>.</p>
-
-<p><strong>Dependency injection by default.</strong> The framework wires dependencies into the component struct so handlers reach them without globals. The injected set differs by component type: <strong>tools</strong> get a <code>Registry</code> (registration only, no discovery), <code>Logger</code>, <code>Telemetry</code>, and an optional <code>AIClient</code> — tools deliberately have no <code>Memory</code> field, since response caching is a tool-local concern with tool-specific TTL/eviction semantics. <strong>Agents</strong> get a full <code>Discovery</code> (registration + lookup), <code>Logger</code>, <code>Telemetry</code>, <code>Memory</code>, and an optional <code>AIClient</code>. Tests substitute mocks for any of these through the standard interfaces; the in-memory implementations (<code>core.NewMockDiscovery</code>, <code>core.NewMemoryStore</code>) ship with the framework specifically for tests.</p>
-
-<p><strong>Background runnables.</strong> Long-running work that needs its own goroutine — a memory eviction sweeper, a metric reporter, a periodic refresh job — registers through <code>RegisterRunnable</code>. The framework starts it before the HTTP server, supplies a cancellation context, and stops it during graceful shutdown. The bundled scheduled-executor is built on this pattern; so are custom jobs application teams write for their own deployments.</p>
-
-<p><strong>Working examples in the cluster.</strong> Every tool and agent in the bundled examples uses this runtime — from compact single-capability tools to the full chat agents. The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/weather-tool-v2">weather-tool-v2</a> and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/country-info-tool">country-info-tool</a> examples show what a focused tool looks like in practice. The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/my-tool">my-tool</a> directory is a coding-agent scaffold (with <code>PROMPT.md</code>) for bootstrapping a new tool from scratch, not a runnable example. The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent">travel-chat-agent</a> shows what the same runtime looks like when an agent uses the full feature set — discovery, AI client, memory hooks, HITL, streaming.</p>
+<p><strong>Working examples.</strong> <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/weather-tool-v2">weather-tool-v2</a> and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/country-info-tool">country-info-tool</a> show what a focused tool looks like; <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent">travel-chat-agent</a> shows the same runtime carrying the full feature set. <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/my-tool">my-tool</a> is a coding-agent scaffold for starting a new tool from scratch.</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/core/README.md">core/README.md</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/building/TOOL_DEVELOPMENT_GUIDE.md">Tool Development Guide</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/building/AGENT_DEVELOPMENT_GUIDE.md">Agent Development Guide</a>.</p>
 
 <h3 id="runtime-discovery">2. Runtime discovery</h3>
 
-<p>Discovery is the primitive that makes the whole microagents architecture possible: agents find tools and other agents <em>by what they can do</em>, not by hardcoded addresses. A capability registered by one component becomes visible to every other component on the next read. Add a new tool, and every existing agent sees it within seconds — no agent code change, no redeploy. Remove a tool, and it disappears within seconds too.</p>
+<p>Discovery is the primitive that makes the rest of the architecture possible: agents find tools and other agents <em>by what they can do</em>, not by address. Deploy a new tool and every existing agent can use it within seconds — no agent code change, no redeploy. Remove it and it disappears just as fast.</p>
 
-<p>A single registry holds tools and agents on equal footing — any number of either — each publishing one or more capabilities that any other component can look up by name. All of it sits behind one Go interface called <code>core.Discovery</code>. Capability lookups are key-value reads, so the registry scales with the number of distinct capability names in the deployment, not with the wiring complexity between components.</p>
+<p>One registry holds tools and agents on equal footing, each publishing capabilities that anything else can look up by name, all behind a single Go interface. Redis — or Valkey, which speaks the same protocol — is the default backend, because most platforms already run one for sessions, caching, or queuing. An in-memory implementation ships for tests, and another store can be plugged in behind the same interface. Switching backends is a deployment change, not an application change.</p>
 
-<p><strong>Pluggable backend.</strong> Redis (or Valkey, which speaks the same protocol) is the default registry — they are key-value stores most platforms already operate for sessions, caching, or queuing. The framework ships two implementations of <code>core.Discovery</code>: the Redis backend for production and an in-memory mock for tests. Other systems (etcd, Consul, a custom backend) can be plugged in by satisfying the <code>core.Discovery</code> contract — the adapter is yours to write. Switching backends is a deployment configuration change, not an application code change.</p>
+<p>The workhorse lookup answers "give me every component that can do this," and it is the call the orchestrator makes once the LLM has chosen a capability. Two others answer "give me this specific component, whatever it does" and "give me everything matching this filter."</p>
 
-<p><strong>Three lookup methods, each for a different question.</strong></p>
+<p><strong>Liveness is the registration.</strong> Every entry carries a 30-second TTL, and each component refreshes its own every 15 seconds with jitter. A component that crashes or loses the network simply stops refreshing, and its entry expires within one window. There is no separate health-check system to keep in sync and no orphaned entries to clean up.</p>
 
-<ul>
-  <li><strong><code>FindByCapability(ctx, "geocode_location")</code></strong> — "give me every component that can do this." The workhorse. The orchestrator uses this when the LLM has chosen a capability and the framework needs the address that currently serves it. Most calls in a running system go through this path.</li>
-  <li><strong><code>FindService(ctx, "weather-tool-v2")</code></strong> — "give me this specific component, regardless of what it does." Useful for health checks, admin operations, or any case where the caller already knows the participant by name.</li>
-  <li><strong><code>Discover(ctx, filter)</code></strong> — "give me everything that matches these criteria." The filter combines component type (tool vs agent), name, capability list, and metadata — useful for cross-cutting queries like "list all agents that expose a streaming capability." The Redis key namespace used by a Discovery client is set when the client is constructed (default <code>truvag3</code> through the auto-wired path; override by injecting a client built with <code>NewRedisDiscoveryWithNamespace</code>) and applies to every query made through it.</li>
-</ul>
+<figure id="fig-ttl-lease">
+<svg viewBox="0 0 760 260" xmlns="http://www.w3.org/2000/svg"
+     style="width:100%;height:auto;display:block;margin:0 auto;background:#ffffff;border-radius:6px;border:1px solid #2a3550;"
+     role="img"
+     aria-label="A sixty-second timeline comparing two registered components. The healthy component in the upper lane emits a heartbeat every fifteen seconds — at zero, fifteen, thirty, forty-five and sixty seconds — and its registry entry stays live for the whole window, drawn as an unbroken green bar. The lower lane shows a component that heartbeats at zero and fifteen seconds and then crashes at twenty-two seconds. Its entry does not disappear at the moment of the crash: it stays listed through a shaded amber region until forty-five seconds, which is its last heartbeat at fifteen seconds plus the thirty-second TTL, and then expires. After that point the lane is gray and the component is gone from the registry. A bracket marks the amber region as the worst-case staleness window: at most one TTL, roughly thirty seconds, with no separate health-check system involved.">
+  <style>
+    .tl-axis  { stroke:#d0d7de; stroke-width:1; }
+    .tl-tickt { font:10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#8c96a3; }
+    .tl-lane  { font:600 11.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#1a1a1a; }
+    .tl-sub   { font:10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#6e7781; }
+    .tl-live  { fill:#e8f6ee; stroke:#3fa96b; stroke-width:1.2; }
+    .tl-stale { fill:#fdf3e0; stroke:#d9b35a; stroke-width:1.2; stroke-dasharray:4,3; }
+    .tl-gone  { fill:#f2f3f5; stroke:#d0d7de; stroke-width:1; }
+    .tl-hb    { fill:#3fa96b; }
+    .tl-hbt   { font:italic 9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#3fa96b; }
+    .tl-crash { stroke:#c0392b; stroke-width:1.6; }
+    .tl-crasht{ font:600 10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#c0392b; }
+    .tl-brk   { stroke:#d9b35a; stroke-width:1.2; fill:none; }
+    .tl-brkt  { font:italic 10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#7a5a16; }
+  </style>
 
-<p><strong>TTL-backed leases, not separate health checks.</strong> Every registration carries a 30-second TTL. Each component refreshes its entry every 15 seconds (half the TTL, with jitter to spread load). If a component crashes, loses network, or simply stops responding, its entry expires within one TTL window — no separate liveness probe required, no orphan entries to clean up. The gauge <code>discovery.last_health_check_timestamp</code> exposes the Unix timestamp of each component's last heartbeat per registry, so a stale value is the canonical signal that something is wrong.</p>
+  <!-- axis: t=0 at x=110, t=60s at x=730  (10.333 px per second) -->
+  <line x1="110" y1="214" x2="730" y2="214" class="tl-axis"/>
+  <line x1="110" y1="210" x2="110" y2="218" class="tl-axis"/>
+  <line x1="265" y1="210" x2="265" y2="218" class="tl-axis"/>
+  <line x1="420" y1="210" x2="420" y2="218" class="tl-axis"/>
+  <line x1="575" y1="210" x2="575" y2="218" class="tl-axis"/>
+  <line x1="730" y1="210" x2="730" y2="218" class="tl-axis"/>
+  <text x="110" y="232" text-anchor="middle" class="tl-tickt">0s</text>
+  <text x="265" y="232" text-anchor="middle" class="tl-tickt">15s</text>
+  <text x="420" y="232" text-anchor="middle" class="tl-tickt">30s</text>
+  <text x="575" y="232" text-anchor="middle" class="tl-tickt">45s</text>
+  <text x="730" y="232" text-anchor="middle" class="tl-tickt">60s</text>
 
-<p><strong>Kubernetes Service DNS by default — replicas just work.</strong> In a Kubernetes deployment, the framework registers the Kubernetes Service DNS name (for example, <code>weather-tool-v2-service.truvag3-examples.svc.cluster.local</code>), not individual pod IPs. A discovered call therefore goes through the cluster's own Service, which load-balances across all healthy pods that match the selector. The practical consequence:</p>
+  <!-- lane A: healthy -->
+  <text x="20" y="62" class="tl-lane">Healthy</text>
+  <text x="20" y="76" class="tl-sub">component</text>
+  <rect x="110" y="48" width="620" height="30" rx="4" class="tl-live"/>
+  <text x="420" y="67" text-anchor="middle" class="tl-sub">registry entry live — refreshed before it can expire</text>
+  <circle cx="110" cy="38" r="4" class="tl-hb"/>
+  <circle cx="265" cy="38" r="4" class="tl-hb"/>
+  <circle cx="420" cy="38" r="4" class="tl-hb"/>
+  <circle cx="575" cy="38" r="4" class="tl-hb"/>
+  <circle cx="730" cy="38" r="4" class="tl-hb"/>
+  <text x="110" y="26" class="tl-hbt">heartbeat every 15s (half the TTL, with jitter)</text>
 
-<ul>
-  <li>Horizontal Pod Autoscaler can scale a tool from 1 to 50 replicas without changing a single registry entry.</li>
-  <li>Rolling updates, pod restarts, and node failures are handled by Kubernetes; discovery does not even notice.</li>
-  <li>Outside Kubernetes (bare-metal, Docker Compose), the framework falls back to pod-scoped addresses — same registry shape, different default for what gets registered.</li>
-</ul>
+  <!-- lane B: crashes -->
+  <text x="20" y="140" class="tl-lane">Crashes</text>
+  <text x="20" y="154" class="tl-sub">at t = 22s</text>
+  <circle cx="110" cy="116" r="4" class="tl-hb"/>
+  <circle cx="265" cy="116" r="4" class="tl-hb"/>
+  <rect x="110" y="126" width="207" height="30" rx="4" class="tl-live"/>
+  <rect x="317" y="126" width="258" height="30" rx="4" class="tl-stale"/>
+  <rect x="575" y="126" width="155" height="30" rx="4" class="tl-gone"/>
+  <text x="213" y="145" text-anchor="middle" class="tl-sub">live</text>
+  <text x="446" y="145" text-anchor="middle" class="tl-sub">still listed, not answering</text>
+  <text x="652" y="145" text-anchor="middle" class="tl-sub">gone from registry</text>
 
-<p><strong>Service mesh compatibility.</strong> Because the framework advertises the Service DNS name and nothing else, transparent service meshes like Istio and Linkerd work without any special configuration. The mesh handles mTLS, traffic policy, retries, circuit breaking, and mesh telemetry at the network layer; the framework handles capability discovery at the application layer. The two are orthogonal — neither needs to know the other exists.</p>
+  <line x1="317" y1="104" x2="317" y2="126" class="tl-crash"/>
+  <text x="322" y="112" class="tl-crasht">crash — heartbeats stop</text>
 
-<p><strong>Live metrics, end-to-end.</strong> The framework emits these under the OTEL meter <code>truvag3-telemetry</code>; the names below are the canonical OTEL names (Prometheus exporters typically render them as <code>truvag3_discovery_registrations_total</code> and so on — the exact suffix depends on your exporter configuration).</p>
+  <!-- TTL bracket -->
+  <path d="M 265 176 L 265 186 L 575 186 L 575 176" class="tl-brk"/>
+  <text x="420" y="200" text-anchor="middle" class="tl-brkt">last heartbeat + 30s TTL — entry expires here, at most one window late</text>
+</svg>
+<figcaption><strong>Figure 4.</strong> <strong>Liveness <em>is</em> the registration.</strong> Nothing polls these components and nothing has to be told they died. A crash simply stops the refresh, and the entry falls out of the registry within one TTL — the amber region is the whole worst case. That is also the honest cost of the design: for up to thirty seconds a dead component is still listed, which is why callers treat a failed dispatch as normal (<a href="#reliability">§7</a>) rather than as something discovery should have prevented.</figcaption>
+</figure>
 
-<ul>
-  <li><code>discovery.registrations</code> / <code>discovery.unregistrations</code> — components joining and leaving the registry. A spike in registrations on a deployment is expected; a spike at any other time is investigation-worthy.</li>
-  <li><code>discovery.lookups</code> + <code>discovery.lookup.duration_ms</code> — read traffic against the registry, with latency. Tells you whether the registry itself is healthy under load.</li>
-  <li><code>discovery.services.found</code> — gauge tracking how many results each lookup returned. A drop to zero means a capability is currently unavailable; a sudden jump may indicate duplicate registrations.</li>
-  <li><code>discovery.health_checks</code> + <code>discovery.health_check.duration_ms</code> — heartbeat traffic and how long the registry takes to acknowledge each refresh.</li>
-</ul>
+<p><strong>Replicas just work.</strong> In Kubernetes the framework registers the Service DNS name, not pod IPs, so a discovered call goes through the cluster's own Service and load-balances across healthy pods. The Horizontal Pod Autoscaler can take a tool from one replica to fifty without touching a registry entry, and rolling updates, restarts, and node failures never reach the discovery layer at all. Outside Kubernetes the framework falls back to pod-scoped addresses — same registry shape, different default.</p>
 
-<p>All of these metrics are emitted in the OTLP standard, so they flow into any OpenTelemetry-compatible backend your team already operates — Prometheus + Grafana, Datadog, Honeycomb, New Relic, Grafana Cloud, or any equivalent. No framework-specific monitoring tooling needs to be introduced for agent workloads.</p>
+<p>Because the framework advertises nothing but a Service DNS name, transparent service meshes such as Istio and Linkerd work without special configuration. The mesh handles mTLS, traffic policy, and retries; the framework handles capability discovery at the application layer. The two are orthogonal — neither needs to know the other exists.</p>
 
-<p><strong>Inspect the live registry.</strong> The bundled chat agents register a <code>GET /discover</code> capability that returns the full registry snapshot from that component's point of view (agents and tools, each with their capabilities and addresses) — see <code>travel-chat-agent</code>, <code>devops-chat-agent</code>, and <code>research-agent</code>. The Registry Viewer web app reads the same data and renders it as a browsable dashboard. Both are useful during development and incident response — they answer the basic question "what does my system currently look like?" without reading any logs. Tools and other agents can register the same capability when they want to expose it; the underlying lookup is just a call into <code>core.Discovery</code>.</p>
+<p>Registration, lookup, heartbeat, and result-count metrics all export over OTLP, so the registry's own health shows up in the backend you already run. The bundled chat agents additionally expose a <code>GET /discover</code> capability returning the live registry snapshot, and the Registry Viewer renders the same data as a browsable dashboard — the fastest answer to "what does my system currently look like?"</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/operations/AUTO_DISCOVERY_GUIDE.md">Auto-Discovery Guide</a>.</p>
 
 <h3 id="capability-contracts">3. Self-describing capability contracts</h3>
 
-<p>How does an agent know what JSON to send a tool? In most frameworks, the agent's source code holds a hand-written wrapper for each tool — signature, field names, types — which has to stay in sync with the tool's actual API. When the tool changes, the wrapper drifts. When wrappers drift, the agent stops working in subtle ways that are hard to debug. TruvaG3 takes a different approach: the contract is part of the registration, not part of the caller. Every capability publishes everything an LLM needs to generate a valid payload, everything the framework needs to validate it before sending, and everything a developer needs to inspect it from a browser — all from the same source of truth.</p>
+<p>How does an agent know what JSON to send to a tool? In most frameworks the agent's source holds a hand-written wrapper per tool — signature, field names, types — that has to stay in sync with the tool's real API. When the tool changes, the wrapper drifts, and the agent starts failing in ways that are hard to debug. TruvaG3 moves the contract to the other end: it is part of the registration, not part of the caller.</p>
 
-<p><strong>Three layers, each more precise than the last.</strong> A registered capability carries:</p>
+<p>A registered capability carries three layers, each more precise than the last. A <strong>natural-language description</strong> tells the LLM what the capability does and whether it is relevant at all. <strong>Structured field hints</strong> — name, type, example value, and a short description for every input and output field — tell it the field is called <code>location</code>, not <code>city</code>, and give it concrete guidance for constructing the payload. An optional <strong>JSON Schema</strong>, generated automatically from those hints, lets the orchestrator validate a payload before sending it and catch the remaining edge cases. The first layer ships by default; the second is the baseline for any production tool; the third is opt-in for cases where validation has to be exact.</p>
 
-<ol>
-  <li><strong>Natural-language description</strong> — what the capability does, what inputs it expects, what outputs it returns. The LLM reads this when deciding whether the capability is relevant to a request at all. Research on JSON-schema-aware LLM generation suggests good descriptions land roughly 85-90% accuracy on payload generation by themselves.</li>
-  <li><strong>Structured field hints</strong> — for each input and output field: name, type (string, number, boolean, object, array), example value, and short description. Precise enough that the LLM knows the input field is called <code>location</code> and not <code>city</code>, that <code>amount</code> should be a number, and that the response will contain <code>currency.code</code>. Field hints typically lift payload accuracy to ~95%.</li>
-  <li><strong>JSON Schema (optional)</strong> — for deployments that need strict validation, the framework auto-generates a JSON Schema draft-07 document from the field hints, served at <code>/api/capabilities/{name}/schema</code>. The orchestrator can fetch this schema and validate the LLM-generated payload before sending the request, catching the remaining edge cases — wrong types, missing required fields, values outside the allowed set.</li>
-</ol>
+<figure id="fig-contract-layers">
+<svg viewBox="0 0 760 300" xmlns="http://www.w3.org/2000/svg"
+     style="width:100%;height:auto;display:block;margin:0 auto;background:#ffffff;border-radius:6px;border:1px solid #2a3550;"
+     role="img"
+     aria-label="The three layers of a capability contract, drawn as a stack that builds upward. Layer one at the bottom is the natural-language description — what the capability does and when it is relevant — which ships by default for every registered capability. Layer two is the recommended production baseline: structured field hints giving the name, type, example value, and description for every input and output field. Layer three is an optional JSON Schema generated from those same hints and validated before the request is sent, for cases where validation has to be exact. A stepped line on the right rises from described, to guided, to validated. A note underneath records that all three come from one registration, so there is no second copy to drift.">
+  <style>
+    .cl-box1 { fill:#ffffff; stroke:#d0d7de; stroke-width:1.2; }
+    .cl-box2 { fill:#fbfdff; stroke:#9ec5ff; stroke-width:1.4; }
+    .cl-box3 { fill:#fff8e6; stroke:#d9b35a; stroke-width:1.4; }
+    .cl-num  { font:700 10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0.6px; fill:#8c96a3; }
+    .cl-name { font:600 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#1a1a1a; }
+    .cl-sub  { font:10.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#6e7781; }
+    .cl-when { font:italic 10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#7a5a16; }
+    .cl-acc  { font:600 15px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#1a1a1a; }
+    .cl-accs { font:9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#8c96a3; }
+    .cl-step { stroke:#3fa96b; stroke-width:1.8; fill:none; }
+    .cl-hdr  { font:700 9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0.7px; fill:#8c96a3; }
+    .cl-tie  { stroke:#d0d7de; stroke-width:1; stroke-dasharray:3,3; }
+  </style>
 
-<p>The layers stack. Phase 1 ships by default for every registered capability. Phase 2 is the recommended baseline for any production tool. Phase 3 is opt-in for the small set of cases where validation has to be perfect.</p>
+  <text x="30"  y="26" class="cl-hdr">WHAT A REGISTRATION CARRIES</text>
+  <text x="560" y="26" class="cl-hdr">CONTRACT STRENGTH</text>
 
-<p><strong>Everything is reachable over HTTP.</strong> The same self-describing data that the framework uses internally is reachable by anyone on the network through standard REST endpoints — auto-generated, no extra code:</p>
+  <!-- layer 3 (top) -->
+  <rect x="30" y="40" width="480" height="66" rx="6" class="cl-box3"/>
+  <text x="46" y="60" class="cl-num">LAYER 3 · OPT-IN</text>
+  <text x="46" y="79" class="cl-name">JSON Schema, auto-generated from the hints</text>
+  <text x="46" y="96" class="cl-sub">orchestrator validates the payload before the request is sent</text>
+  <text x="498" y="60" text-anchor="end" class="cl-when">strict deployments</text>
 
-<ul>
-  <li><code>GET /api/capabilities</code> — the component's full capability catalog, including descriptions, input and output field hints, endpoint paths, and input/output content types.</li>
-  <li><code>POST /api/capabilities/{name}</code> — the capability endpoint itself (the handler that runs the work). The framework decodes the JSON request body and invokes the registered handler.</li>
-  <li><code>GET /api/capabilities/{name}/schema</code> — the auto-generated JSON Schema (draft-07) for that capability's input. Mounted only when the capability declares an <code>InputSummary</code>. Useful for code generators, validators, and contract tests.</li>
-  <li><code>GET /openapi.json</code> — a complete OpenAPI document covering every capability the component exposes, with both Input and Output schemas registered as named components. Drops straight into Swagger UI, Postman, code generators, and API gateways that consume OpenAPI.</li>
-</ul>
+  <!-- layer 2 -->
+  <rect x="30" y="118" width="480" height="66" rx="6" class="cl-box2"/>
+  <text x="46" y="138" class="cl-num">LAYER 2 · RECOMMENDED</text>
+  <text x="46" y="157" class="cl-name">Structured field hints</text>
+  <text x="46" y="174" class="cl-sub">name, type, example value, description — for every input and output field</text>
+  <text x="498" y="138" text-anchor="end" class="cl-when">production baseline</text>
 
-<p>The practical consequence: the people, scripts, and platforms that already integrate with REST services in your organization can integrate with TruvaG3 tools the same way. There is no separate API documentation site that has to be kept in sync with the code, no client SDK with hardcoded signatures, no version-pinned schema file checked into a wiki — the registration <em>is</em> the documentation.</p>
+  <!-- layer 1 -->
+  <rect x="30" y="196" width="480" height="66" rx="6" class="cl-box1"/>
+  <text x="46" y="216" class="cl-num">LAYER 1 · DEFAULT</text>
+  <text x="46" y="235" class="cl-name">Natural-language description</text>
+  <text x="46" y="252" class="cl-sub">what it does, and whether it is relevant to this request at all</text>
+  <text x="498" y="216" text-anchor="end" class="cl-when">always on</text>
 
-<p><strong>Output schemas catch a class of LLM mistakes.</strong> Most planning systems only describe inputs; output structure is left implicit. TruvaG3 also publishes an <code>OutputSummary</code> for every capability. When a multi-step plan references upstream output — <code>{{step-1.response.data.products}}</code> — the orchestrator validates that <code>products</code> is actually a declared field in step 1's output. If the LLM hallucinated a field that does not exist, the validation rejects the plan before any step runs and asks for a corrected plan. Field-level hallucination becomes a recoverable retry instead of a confusing runtime error.</p>
+  <!-- accuracy ladder -->
+  <line x1="510" y1="229" x2="560" y2="229" class="cl-tie"/>
+  <line x1="510" y1="151" x2="560" y2="151" class="cl-tie"/>
+  <line x1="510" y1="73"  x2="560" y2="73"  class="cl-tie"/>
+  <path d="M 566 229 L 640 229 L 640 151 L 690 151 L 690 73 L 730 73" class="cl-step"/>
+  <text x="576" y="222" class="cl-acc">described</text>
+  <text x="576" y="245" class="cl-accs">relevance is explicit</text>
+  <text x="650" y="144" class="cl-acc">guided</text>
+  <text x="650" y="167" class="cl-accs">fields are explicit</text>
+  <text x="640" y="66" class="cl-acc">validated</text>
+  <text x="640" y="89" class="cl-accs">bad payloads never leave</text>
+</svg>
+<figcaption><strong>Figure 5.</strong> <strong>Three layers, one source.</strong> The layers stack rather than compete: schemas are generated from the same field hints the LLM reads, and the hints sit beside the same description. Because all of it comes from the registration, there is no wrapper in the caller to drift out of sync — which is the failure this design exists to remove.</figcaption>
+</figure>
 
-<p><strong>Schema cache for high-traffic deployments.</strong> When strict validation is enabled, the orchestrator caches fetched schemas in Redis (the default backend) with a 24-hour TTL — shared across all agent replicas, so even with horizontal scaling each schema fetch happens at most once per TTL window. The cache exposes hit-rate statistics through standard metrics; configurable TTL and key prefix for multi-tenant deployments.</p>
+<p>All of it is reachable over plain HTTP — the catalog, the per-capability endpoints, the generated schemas, and a complete OpenAPI document that drops straight into Swagger UI, Postman, code generators, and API gateways. Nothing here comes from a documentation pipeline that can fall behind the code, and there is no client SDK with hardcoded signatures to version. <strong>The registration <em>is</em> the documentation.</strong></p>
 
-<p><strong>Working examples in the cluster.</strong> Every bundled tool ships with all three layers wired. The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/weather-tool-v2">weather-tool-v2</a> example, for instance, publishes <code>get_current_weather</code> with a natural-language description, field hints declaring <code>lat</code> and <code>lon</code> as required numbers with realistic example values, an auto-generated JSON Schema reachable at <code>/api/capabilities/get_current_weather/schema</code>, and the capability appearing in the tool's <code>/openapi.json</code> with separate Input and Output schema components.</p>
+<p><strong>Output schemas catch a class of LLM mistake most planners miss.</strong> Systems that describe only inputs leave output structure implicit. TruvaG3 publishes output hints too, so when a multi-step plan references upstream data — <code>{{step-1.response.data.products}}</code> — the orchestrator can check that <code>products</code> is a field step 1 actually returns. A hallucinated field is rejected before any step runs and the planner is asked for a corrected plan. Field-level hallucination becomes a recoverable retry instead of a confusing runtime error.</p>
+
+<p><strong>Working example.</strong> <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/weather-tool-v2">weather-tool-v2</a> ships all three layers: a description, field hints declaring <code>lat</code> and <code>lon</code> as required numbers with realistic examples, a generated schema, and separate input and output components in its OpenAPI document.</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/building/TOOL_SCHEMA_DISCOVERY_GUIDE.md">Tool Schema Discovery Guide</a>.</p>
 
 <h3 id="observability">4. Observability</h3>
 
-<p>The depth of telemetry is one of the framework's most distinctive properties. Every meaningful operation across every layer of the stack emits a span and one or more metrics — not just at the agent boundary, but <em>inside</em> the orchestrator, the AI client, the discovery layer, the memory subsystem, the pipeline hooks, and the prompt builder. A single user request that crosses three services typically produces 40+ spans across roughly 28 distinct operation types, with rich attributes on each.</p>
+<p>The depth of telemetry is one of the framework's more distinctive properties. Instrumentation does not stop at the agent boundary — it runs <em>inside</em> the orchestrator, the AI client, the discovery layer, the memory subsystem, the pipeline hooks, and the prompt builder. A single user request crossing three services typically produces more than 40 spans across roughly 28 distinct operation types.</p>
 
-<p><strong>Distributed traces.</strong> W3C TraceContext propagation reassembles a request that spans several agents and tools into one trace in any OTLP-compatible backend (Jaeger, Tempo, Honeycomb, Datadog, etc.). Each span carries operation-specific attributes:</p>
+<p>W3C TraceContext propagation reassembles a request spanning several agents and tools into one trace in any OTLP-compatible backend. The spans carry what you want when something is wrong and little else: for AI calls, the provider, semantic model, token counts, finish reason, and retry attempt; for the orchestrator, plan and phase identity and, per step, which capability ran, how many attempts it took, and whether it succeeded; for memory, which recall paths fired and what they found. The framework deliberately does not estimate cost in dollars — authoritative spend comes from your provider's billing export and negotiated pricing, not from a multiplication the framework guesses at.</p>
 
-<ul>
-  <li><strong>AI calls</strong> — provider, semantic model, prompt and completion token counts, total tokens, finish reason, streaming flag, retry attempt, max retries, chain entry index, attempt status, request-policy adjustments, and sanitized route identity when an application supplies one. The framework deliberately does not infer cost in USD; authoritative spend comes from the provider's billing export and negotiated pricing.</li>
-  <li><strong>Orchestrator phases and steps</strong> — plan ID, phase number, total phases, steps per phase, terminal flag, termination reason; per step: agent name, capability invoked, attempt count, success status, duration.</li>
-  <li><strong>Synthesis</strong> — model, provider, prompt/completion/total tokens, step count, success and failure counts, finish reason, streaming flag.</li>
-  <li><strong>Pipeline hooks</strong> — hook name and stage (before-planning, after-planning, after-execution, after-synthesis), duration, short-circuit outcome.</li>
-  <li><strong>Memory operations</strong> — recall path (identity, query, stable namespace, summary, universal), candidate count, neighbors found, facts recalled, search duration.</li>
-  <li><strong>Prompt building</strong> — builder type, prompt size, request size, capability info size, type-rule count, custom-persona flag.</li>
-</ul>
+<figure id="fig-jaeger-waterfall">
+<img src="https://assets.truvag3.dev/blogs/observability/tokyo-weather-jaeger-trace-top.png" alt="A Jaeger trace waterfall for one chat request to travel-chat-agent. The trace header reports 52 spans at depth 8. The waterfall shows nested spans for the orchestrator phases and steps, with each ai.chain.generate_response span decomposing into a provider attempt span and an HTTP attempt span beneath it, so retries and provider failover appear as their own rows rather than being hidden inside the parent call.">
+<figcaption><strong>Figure 6.</strong> <strong>Ordinary Jaeger, no adapter.</strong> Fifty-two spans at depth eight for a single chat request, reassembled across services by W3C TraceContext. Nothing in this view is TruvaG3-specific tooling — it is the same trace UI the platform team already runs, which is the whole point: each model call decomposes into its provider attempt and its HTTP attempt, so a retry or a failover is a row you can see rather than latency you have to infer. Captured in the <a href="truvag3-observability-deep-dive.html">observability deep dive</a>.</figcaption>
+</figure>
 
-<p><strong>Metrics.</strong> 240+ base metric families exported via OTLP/HTTP to any OpenTelemetry-compatible backend, with cardinality-protected labels. Coverage spans every framework layer:</p>
+<p>Alongside the traces, more than 240 base metric families export over OTLP with cardinality-protected labels, covering orchestration, AI calls, discovery, memory, approvals, and HTTP at both client and server. JSON logs carry trace IDs from request context, so logs and traces correlate in Loki and Jaeger with no extra wiring.</p>
 
-<ul>
-  <li><strong>Orchestration</strong> — plans generated, plan success rate, average phases per request, plan-generation duration, continuation re-plan rate, parse-error counts.</li>
-  <li><strong>AI</strong> — successful provider responses and reported token usage, successful-request duration, bounded retry-exhaustion counts, chain failover and exhaustion events, and embedding outcomes.</li>
-  <li><strong>Discovery</strong> — lookups, registrations, deregistrations, health-check duration, services found per lookup.</li>
-  <li><strong>Memory</strong> — cache hits and misses, eviction rate, ops rate, conversation-history compaction duration, episodic events recorded.</li>
-  <li><strong>HITL</strong> — checkpoints created, decisions per outcome (approved, rejected, edited, expired).</li>
-  <li><strong>HTTP</strong> — request and response sizes, durations, status codes — at both client and server.</li>
-</ul>
+<p>The bundled local deployment provisions seven Grafana dashboards under a <em>TruvaG3</em> folder — Platform Overview, Agent Telemetry, LLM &amp; AI Analytics, Orchestration &amp; Execution, Memory &amp; Knowledge, Logs &amp; Traces, and Resource Usage. They work on a fresh install because the metrics they query are the ones the framework emits by default. Two more tools help during development: the Registry Viewer, a web app that inspects the live registry, captured LLM payloads, approval checkpoints, execution DAGs, and shared memory — the same viewer used for the screenshots in the architecture article — and Swagger UI over each component's OpenAPI document.</p>
 
-<p><strong>Structured logging.</strong> JSON logs carry trace IDs from request context, so logs and traces correlate in Loki and Jaeger without any extra wiring.</p>
+<figure id="fig-registry-dag">
+<img src="https://assets.truvag3.dev/blogs/observability/tokyo-weather-registry-dag-visualization.png" alt="The Registry Viewer's Execution DAG for a single travel-chat-agent request. A vertical node graph runs from the agent node through Memory Prepare, User Memory Enrichment, Tier Select, Planning, a geocoding-tool step, then Resolution, Error Analysis and streaming Synthesis nodes, into Complete and finally User Memory Extraction. A legend identifies the node types: Agent/LLM, Plan, Before, After, Error, Step OK, Step Fail, Response, Auto-wire, LLM Resolved and Semantic Retry. The header reads: travel-chat-agent, 2 steps, total 20.84 seconds, Success, 15 LLM calls.">
+<figcaption><strong>Figure 7.</strong> <strong>The same request in the Registry Viewer.</strong> Where Jaeger shows timing, this shows reasoning: two tool calls at the user's level, and underneath them fifteen model calls, a memory-enrichment hook, a tier-selection pass, an error-analysis branch that recovered a failed step, and a post-hoc extraction step. This one <em>is</em> framework tooling — a development and incident-response aid, not something to expose in production (<a href="#security">§12</a>).</figcaption>
+</figure>
 
-<p><strong>Pre-built Grafana dashboards.</strong> The bundled local deployment provisions seven dashboards under a <em>TruvaG3</em> folder: Platform Overview, Agent Telemetry, LLM &amp; AI Analytics, Orchestration &amp; Execution, Memory &amp; Knowledge, Logs &amp; Traces, and Resource Usage. (An additional Service Detail dashboard ships as a standalone JSON for manual import.) Turn-key visibility from a fresh install — the dashboards work because the metrics they query are the standard ones the framework emits by default.</p>
-
-<p>For developers, two additional tools help during build and debug:</p>
-
-<ul>
-  <li><strong>Registry Viewer</strong> — a web app that inspects the live service registry, captured LLM payloads, HITL checkpoints, execution DAGs, and shared memory. It is the same viewer used to capture the screenshots in the architecture article.</li>
-  <li><strong>Swagger UI</strong> — consumes the per-component <code>/openapi.json</code> document and provides interactive API exploration.</li>
-</ul>
-
-<p>This depth is unusual. Most agent frameworks expose logs and a few LLM-call traces; orchestrator-internal state, memory operations, discovery behavior, pipeline-hook execution, and chain-failover paths are typically not instrumented. Because TruvaG3 components are ordinary HTTP services emitting OTLP, all of this data lands in the observability stack the platform team already operates — Prometheus + Jaeger + Grafana + Loki by default, or any commercial equivalent.</p>
+<p>This depth is unusual. Most agent frameworks expose logs and a handful of LLM-call traces; orchestrator-internal state, memory operations, discovery behavior, hook execution, and provider failover paths typically are not instrumented at all. And because TruvaG3 components are ordinary HTTP services emitting OTLP, all of it lands in the observability stack your platform team already operates.</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/telemetry/README.md">telemetry/README.md</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/observability/DISTRIBUTED_TRACING_GUIDE.md">Distributed Tracing Guide</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/observability/LOGGING_IMPLEMENTATION_GUIDE.md">Logging Implementation Guide</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/operations/DEV_TOOLS_GUIDE.md">Developer Tools Guide</a>.</p>
 
 <h3 id="ai-provider-layer">5. Vendor-agnostic AI provider layer</h3>
 
-<p>The <code>ai</code> module presents two provider-neutral contracts: the compact <code>core.AIClient</code> interface used by existing agents, and the presence-aware <code>core.AIRequestClient</code> interface used when an application needs explicit parameter intent, request policy, preparation reports, or enterprise routing. Applications can let <code>ai.NewClient()</code> auto-detect a registered provider from the environment, explicitly select one, construct a request-aware client, or assemble independently configured entries with <code>ai.NewChain</code>. Built-in provider packages are opt-in: importing a package runs its registration hook, and auto-detection considers only registered factories. The agent and orchestration layers remain independent of each provider's HTTP schema or SDK types.</p>
+<p>Agent and orchestration code never sees a provider's HTTP schema or SDK types. The <code>ai</code> module presents provider-neutral contracts — a compact client for the common case, and a request-aware one for applications that need explicit routing, credentials, or policy — and everything above them is written against the contract, not the vendor.</p>
 
-<p><strong>Support is organized by integration surface rather than a single provider count.</strong> This distinction matters in enterprise deployments: a direct API key, an Azure deployment, a Google publisher model, and an AWS inference profile are not interchangeable configuration shapes.</p>
+<p>Support is organized by <em>integration surface</em> rather than a headline provider count, because in enterprise deployments a direct API key, an Azure deployment, a Google publisher model, and an AWS inference profile are not interchangeable configuration shapes:</p>
 
-<ul>
-  <li><strong>Direct HTTP providers:</strong> <code>openai</code>, <code>anthropic</code>, and <code>gemini</code>. OpenAI and Anthropic support both legacy and request-aware construction; Gemini currently uses the legacy client contract.</li>
-  <li><strong>Native SDK provider:</strong> <code>bedrock</code>, compiled with the <code>bedrock</code> build tag. It uses AWS SDK configuration and the Converse API, supports generate, stream, Titan Text Embeddings, request policy, and optional per-request selection of a Converse-supported <code>modelId</code>, such as a foundation model, inference profile, provisioned model, or custom model deployment.</li>
-  <li><strong>First-class hosted request-aware profiles:</strong> <code>azureopenai.v1</code>, <code>azureopenai.classic</code>, and <code>anthropic.vertex</code>. The first two cover Azure OpenAI v1 and the classic deployment-scoped Chat Completions surface; the third covers Anthropic Claude publisher models on Google Vertex AI. All three support generate and stream through the same normalized request contract.</li>
-  <li><strong>Registered OpenAI-compatible aliases:</strong> <code>openai.groq</code>, <code>openai.deepseek</code>, <code>openai.xai</code>, <code>openai.mistral</code>, <code>openai.qwen</code>, <code>openai.together</code>, and <code>openai.ollama</code>.</li>
-  <li><strong>Hosted compatibility recipe:</strong> Google Cloud's OpenAI-compatible Vertex AI endpoint reuses the <code>openai</code> request-aware adapter with an application-owned endpoint resolver and Google access-token source. It remains under the <code>openai</code> provider identity because its wire contract is OpenAI Chat Completions.</li>
-</ul>
+<table>
+  <thead>
+    <tr><th>Integration surface</th><th>What it covers</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><strong>Direct HTTP</strong></td><td>OpenAI, Anthropic, Gemini</td></tr>
+    <tr><td><strong>Native SDK</strong></td><td>AWS Bedrock, behind a build tag, using the Converse API</td></tr>
+    <tr><td><strong>Hosted enterprise profiles</strong></td><td>Azure OpenAI (v1 and classic), Claude on Google Vertex AI</td></tr>
+    <tr><td><strong>OpenAI-compatible aliases</strong></td><td>Groq, DeepSeek, xAI, Mistral, Qwen, Together, Ollama</td></tr>
+  </tbody>
+</table>
 
-<p>The Azure and Vertex profiles are explicit by design: they are not auto-detected, do not accept a generic static base URL, and require application-supplied routing and explicit credentials. Azure accepts either a static API key or a dynamic credential source; Vertex requires a Google bearer-token source. That keeps tenant, region, Azure deployment, Google publisher model, and short-lived token lifecycle decisions in application code rather than hiding them behind environment-variable conventions. Bedrock can participate in auto-detection only when its build tag is present and the process exposes one of the AWS credential signals checked by its factory. Those signals identify a candidate; client construction loads AWS SDK configuration, and an invocation can still fail if its credentials, region, or selected model are unusable.</p>
+<p>The simple path stays simple: import the provider packages you intend to use, call <code>ai.NewClient()</code>, and the framework detects a configured provider from the environment. The enterprise profiles are deliberately <em>not</em> auto-detected — Azure and Vertex require application-supplied routing and explicit credentials, which keeps tenant, region, deployment, and short-lived token decisions in your code rather than buried in environment-variable conventions.</p>
 
-<p><strong>Environment-based detection remains the simple path.</strong> After the application imports the provider packages it intends to use, <code>ai.NewClient()</code> checks registered factories for configured credentials or local-service signals, orders the available aliases by priority, and constructs the highest-priority candidate. Common signals include <code>OPENAI_API_KEY</code>, <code>ANTHROPIC_API_KEY</code>, <code>GEMINI_API_KEY</code>, alias-specific API keys, and an explicitly configured local Ollama URL. Explicit selection and explicit chains remain available when deployment order must be deterministic. Two metrics expose detection (canonical OTEL names; Prometheus exporters add <code>_total</code> and replace dots with underscores):</p>
+<p><strong>Semantic model roles instead of hardcoded model IDs.</strong> Application code asks for a role — <code>default</code>, <code>fast</code>, <code>smart</code>, <code>premium</code>, <code>code</code>, or <code>vision</code> — and each provider's catalog resolves it. Today <code>default</code> maps to GPT-4.1-mini on OpenAI, Claude Sonnet 4.5 on Anthropic, and Gemini 2.5 Flash on Google, while <code>smart</code> maps to o3, Claude Sonnet 4.5, and Gemini 2.5 Pro. Environment variables override any mapping. The role stays stable for policy decisions even when the wire destination resolves to a deployment-specific Azure or Vertex identifier.</p>
 
-<ul>
-  <li><code>ai.provider.detection</code> — counter for provider-detection activity, including the no-provider outcome.</li>
-  <li><code>ai.provider.selected</code> — counter labeled by the selected base provider and alias, so dashboards can show provider mix across environments at a glance.</li>
-</ul>
+<p><strong>Failover chains, including heterogeneous ones.</strong> A chain can be built from provider aliases, or assembled from independently configured clients — Azure OpenAI first, Claude on Vertex second, direct Anthropic third. Failover triggers on provider-specific failures: authentication, rate limits, upstream server errors, network failures, quota. A malformed request aborts the chain instead of replaying a bad payload against three vendors in turn. Streaming fails over only <em>before</em> the caller sees output; once a chunk is on the wire, the chain never restarts the answer somewhere else. Failure metadata is sanitized before it reaches logs, traces, or metric labels — raw provider and credential errors go to the caller, not into your telemetry.</p>
 
-<p><strong>Catalog-backed semantic model roles.</strong> Instead of hardcoding a direct model ID everywhere, application code can request one of up to six roles. The direct HTTP providers, registered OpenAI-compatible aliases, Azure profiles, and Vertex profile resolve only the roles their corresponding model catalog defines. Bedrock does not resolve these roles; it uses its own direct default or an application-supplied model or inference-profile ID. Environment overrides are available when a deployment needs to pin a specific catalog mapping:</p>
+<figure id="fig-failover-chain">
+<svg viewBox="0 0 760 446" xmlns="http://www.w3.org/2000/svg"
+     style="width:100%;height:auto;display:block;margin:0 auto;background:#ffffff;border-radius:6px;border:1px solid #2a3550;"
+     role="img"
+     aria-label="How a failover chain behaves. Along the top, a request enters a chain of three entries — OpenAI, Anthropic and Gemini — each holding its own API key, with amber failover arrows between them. The first entry to succeed returns, and later entries are never called; a note adds that entries need not share an integration surface, so a hosted Azure or Vertex profile can sit in the same chain. In the middle, two panels show how a failure is classified. Failures that move to the next entry are 401 and 403, because every entry carries its own credentials; 429, because rate limits are counted per provider; 5xx, network errors and 408 or 504 timeouts, because that provider is unwell; a 400 produced by a CDN or proxy and marked transient; billing or hard-quota errors marked retryable; and an entry whose route cannot be resolved. Failures that stop the chain and return immediately are an ordinary 400 bad request, a content-policy rejection, malformed input, and caller cancellation or an expired context deadline — because the same payload would fail identically everywhere and replaying it only buys the same error three times. Across the bottom, streaming is shown as a one-way door: before the first chunk reaches the caller callback, failover is still permitted, but once any output is visible the chain is locked to the active entry and never restarts the answer somewhere else. A closing note records that a callback returning an error is the caller stopping, not a provider failing, and so does not trigger failover.">
+  <style>
+    .fo-req  { fill:#ffffff; stroke:#d0d7de; stroke-width:1.2; }
+    .fo-ent  { fill:#fff8e6; stroke:#d9b35a; stroke-width:1.3; }
+    .fo-num  { font:700 9px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0.6px; fill:#a9862f; }
+    .fo-t    { font:600 12.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#1a1a1a; }
+    .fo-s    { font:9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#6e7781; }
+    .fo-k    { font:9px ui-monospace, SFMono-Regular, Menlo, monospace; fill:#6e7781; }
+    .fo-hdr  { font:700 9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0.7px; fill:#8c96a3; }
+    .fo-arr  { stroke:#d9b35a; stroke-width:1.6; fill:none; }
+    .fo-arrb { stroke:#0b6cff; stroke-width:1.6; fill:none; }
+    .fo-arrg { stroke:#3fa96b; stroke-width:1.5; fill:none; }
+    .fo-lbl  { font:600 9px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#a9862f; }
+    .fo-ok   { font:italic 10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#256b45; }
+    .fo-panG { fill:#f4faf6; stroke:#b9dfc9; stroke-width:1.2; }
+    .fo-panR { fill:#fdf4f2; stroke:#e8c4bd; stroke-width:1.2; }
+    .fo-ptG  { font:700 10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0.5px; fill:#256b45; }
+    .fo-ptR  { font:700 10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0.5px; fill:#a33125; }
+    .fo-li   { font:10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#3d4551; }
+    .fo-why  { font:italic 9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#8c96a3; }
+    .fo-band1{ fill:#f4faf6; stroke:#b9dfc9; stroke-width:1.2; }
+    .fo-band2{ fill:#fdf8ec; stroke:#e3cf9c; stroke-width:1.2; }
+    .fo-door { stroke:#c0392b; stroke-width:2; }
+    .fo-doort{ font:600 10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#a33125; }
+  </style>
+  <defs>
+    <marker id="fo-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#d9b35a"/>
+    </marker>
+    <marker id="fo-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#0b6cff"/>
+    </marker>
+    <marker id="fo-g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#3fa96b"/>
+    </marker>
+  </defs>
 
-<ul>
-  <li><strong><code>default</code></strong> — the framework catalog's workhorse choice (currently OpenAI → gpt-4.1-mini, Anthropic → Claude Sonnet 4.5, Gemini → Gemini 2.5 Flash)</li>
-  <li><strong><code>fast</code></strong> — the catalog's speed- or cost-oriented choice</li>
-  <li><strong><code>smart</code></strong> — the catalog's higher-reasoning choice (currently OpenAI → o3, Anthropic → Claude Sonnet 4.5, Gemini → Gemini 2.5 Pro)</li>
-  <li><strong><code>premium</code></strong> — the catalog's highest-capability tier, where defined</li>
-  <li><strong><code>code</code></strong> — the catalog's code-oriented choice</li>
-  <li><strong><code>vision</code></strong> — an image-capable catalog choice, where defined. The current portable <code>core.AIRequest</code> envelope is text-only; this alias does not by itself add image input to a request.</li>
-</ul>
+  <!-- ===== the chain ===== -->
+  <text x="24" y="22" class="fo-hdr">ONE CHAIN, THREE ENTRIES — EACH WITH ITS OWN CREDENTIALS</text>
 
-<p>Alias overrides use <code>TRUVAG3_{PROVIDER}_MODEL_{ALIAS}</code>-style environment variables. Hosted routing happens after semantic alias resolution: an Azure resolver maps the resolved OpenAI semantic model to an Azure deployment, while a Vertex resolver maps the resolved Anthropic semantic model to a publisher-model ID. The semantic model stays stable for policy and capability decisions even when the wire destination is deployment-specific.</p>
+  <rect x="24"  y="44" width="84"  height="60" rx="6" class="fo-req"/>
+  <text x="66"  y="80" text-anchor="middle" class="fo-t">Request</text>
 
-<p><strong>Enterprise integrations extend built-in providers instead of forking them.</strong> For HTTP providers that support the request-aware hooks, <code>ai.NewRequestClient</code> accepts an <code>EndpointResolver</code> for per-request destinations, a <code>CredentialSource</code> for rotating API keys or bearer tokens, and an application-owned <code>http.Client</code> for corporate CAs, mTLS, proxies, and connection policy. A credential source may also implement <code>CredentialRejectionObserver</code> so the provider can report a 401 or 403 and the application can invalidate cached credentials. Request preparation resolves the semantic model and route, applies declarative rules and trusted middleware under the selected compatibility mode, and produces a secret-free report and fingerprint before credentials are attached for transport. These HTTP hooks cover Azure OpenAI, Google-hosted OpenAI compatibility, Claude on Vertex AI, and compatible private enterprise gateways. Bedrock participates in the same normalized request, policy, reporting, fingerprinting, and chain contracts through an SDK-native adapter; its AWS SDK configuration continues to own credentials and HTTP transport.</p>
+  <rect x="136" y="44" width="176" height="60" rx="6" class="fo-ent"/>
+  <text x="150" y="62" class="fo-num">ENTRY 1</text>
+  <text x="150" y="81" class="fo-t">OpenAI</text>
+  <text x="150" y="96" class="fo-k">OPENAI_API_KEY</text>
 
-<p><strong>Chain clients support both convenient and heterogeneous failover.</strong> <code>ai.NewChainClient</code> constructs an ordered chain from provider aliases. <code>ai.NewChain</code> can combine provider entries with independently configured or injected clients — for example, Azure OpenAI first, Claude on Vertex AI second, and a direct Anthropic client third. Failover is allowed for provider-specific failures such as authentication, rate limits, upstream server errors, network failures, local route-viability failures, and billing or hard-quota conditions marked <code>IsRetryable</code>. A malformed request or another non-transient, non-provider-retryable client error aborts the chain. Streaming fails over only before the callback observes output; once a chunk is visible, the chain never restarts the answer on a different provider.</p>
+  <rect x="340" y="44" width="176" height="60" rx="6" class="fo-ent"/>
+  <text x="354" y="62" class="fo-num">ENTRY 2</text>
+  <text x="354" y="81" class="fo-t">Anthropic</text>
+  <text x="354" y="96" class="fo-k">ANTHROPIC_API_KEY</text>
 
-<p>The chain is instrumented at every level:</p>
+  <rect x="544" y="44" width="176" height="60" rx="6" class="fo-ent"/>
+  <text x="558" y="62" class="fo-num">ENTRY 3</text>
+  <text x="558" y="81" class="fo-t">Gemini</text>
+  <text x="558" y="96" class="fo-k">GEMINI_API_KEY</text>
 
-<ul>
-  <li><code>ai.chain.attempt</code> — every generate attempt, with a bounded outcome label and, for failures, a bounded reason label.</li>
-  <li><code>ai.chain.failover</code> — successful generate requests that recovered on a later entry. A rising rate is the signal that an earlier entry is failing while a fallback still succeeds.</li>
-  <li><code>ai.chain.exhausted</code> — generate requests for which every chain entry was tried and failed.</li>
-  <li><code>ai.chain.stream.success</code> — successful stream requests; <code>ai.chain.stream.partial</code> — streams that emitted output and then failed; <code>ai.chain.stream.failure</code> — entry attempts that failed before output; <code>ai.chain.stream.exhausted</code> — stream requests for which every entry failed before output.</li>
-  <li><code>failover_reason=route</code> — bounded signal for endpoint resolution or local invocation-viability failures; <code>failover_reason=provider_retryable</code> — bounded operator-action signal for billing, hard quota, or provider account state, including terminal exhaustion.</li>
-</ul>
+  <line x1="110" y1="74" x2="132" y2="74" class="fo-arrb" marker-end="url(#fo-b)"/>
+  <line x1="314" y1="74" x2="336" y2="74" class="fo-arr" marker-end="url(#fo-a)"/>
+  <text x="325" y="66" text-anchor="middle" class="fo-lbl">✗</text>
+  <line x1="518" y1="74" x2="540" y2="74" class="fo-arr" marker-end="url(#fo-a)"/>
+  <text x="529" y="66" text-anchor="middle" class="fo-lbl">✗</text>
 
-<p>The trace view of a failover is a parent <code>ai.chain.generate</code> or <code>ai.chain.stream</code> span containing one or more <code>ai.chain.provider_attempt</code> or <code>ai.chain.stream_attempt</code> spans. Attempt spans carry the stable non-secret entry name, provider index, attempt status, retry marker, duration, and sanitized bounded failure metadata. Parent spans record the successful entry or the final exhaustion classification. Raw provider, route, credential, and SDK error messages are returned to the caller but are not copied into logs, traces, or metric labels.</p>
+  <line x1="224" y1="106" x2="224" y2="124" class="fo-arrg" marker-end="url(#fo-g)"/>
+  <line x1="428" y1="106" x2="428" y2="124" class="fo-arrg" marker-end="url(#fo-g)"/>
+  <line x1="632" y1="106" x2="632" y2="124" class="fo-arrg" marker-end="url(#fo-g)"/>
+  <text x="428" y="140" text-anchor="middle" class="fo-ok">the first entry that succeeds returns — the ones after it are never called</text>
+  <text x="428" y="156" text-anchor="middle" class="fo-why">entries need not share a surface: a hosted Azure or Vertex profile can sit in the same chain</text>
 
-<p><strong>Common AI metrics, with scope made explicit.</strong></p>
+  <!-- ===== classification ===== -->
+  <text x="24" y="184" class="fo-hdr">WHAT MADE IT MOVE ON — OR STOP</text>
 
-<ul>
-  <li><code>ai.request.total</code> and <code>ai.request.duration_ms</code> — successful built-in provider responses and their duration; <code>ai.request.failures</code> — exhausted HTTP retry sequences. Chain-level failures use the separate metrics above.</li>
-  <li><code>ai.tokens.used</code> — token throughput when a provider returns usage, labeled by provider and token type (<code>input</code> or <code>output</code>).</li>
-  <li><code>ai.embedding.duration_ms</code> and <code>ai.embedding.success</code> — successful-call latency and count from the OpenAI-compatible embedding client; <code>ai.embedding.errors</code> — its bounded error count. When that endpoint returns nonzero usage, the <code>ai.embedding.completed</code> span event carries prompt and total token counts. Bedrock's Titan helper instead exposes an <code>ai.get_embeddings</code> span.</li>
-</ul>
+  <rect x="24"  y="194" width="352" height="128" rx="7" class="fo-panG"/>
+  <text x="40"  y="214" class="fo-ptG">→ TRY THE NEXT ENTRY</text>
+  <text x="40"  y="234" class="fo-li">401 · 403 — every entry carries its own credentials</text>
+  <text x="40"  y="250" class="fo-li">429 — rate limits are counted per provider</text>
+  <text x="40"  y="266" class="fo-li">5xx · network · 408 · 504 — that provider is unwell</text>
+  <text x="40"  y="282" class="fo-li">400 from a CDN or proxy, marked transient</text>
+  <text x="40"  y="298" class="fo-li">billing or hard quota, marked retryable</text>
+  <text x="40"  y="314" class="fo-li">this entry's route cannot be resolved</text>
 
-<p><strong>Custom providers have three integration levels.</strong> Configure a built-in provider when only keys, models, timeouts, or a static URL differ. Extend a request-aware built-in provider when credentials, routes, HTTP transport, policy, or independently configured failover entries differ. Implement a new provider only when identity, model semantics, wire format, SDK request types, response decoding, or error translation differ. New implementations register a <code>ProviderFactory</code>, normally add <code>ValidatedProviderFactory</code> for error-capable construction, and add <code>RequestProviderFactory</code> when they support the normalized request path. OpenAI-compatible services can reuse the public <code>openaiwire.Codec</code>, while SDK-native adapters can expose their own policy draft. The provider registry remains the source used by explicit construction and auto-detection.</p>
+  <rect x="392" y="194" width="328" height="128" rx="7" class="fo-panR"/>
+  <text x="408" y="214" class="fo-ptR">✗ STOP AND RETURN THE ERROR</text>
+  <text x="408" y="234" class="fo-li">400 bad request — the payload is the problem</text>
+  <text x="408" y="250" class="fo-li">content policy — the content is the problem</text>
+  <text x="408" y="266" class="fo-li">malformed input — your code is the problem</text>
+  <text x="408" y="282" class="fo-li">caller canceled, or the deadline passed</text>
+  <text x="408" y="306" class="fo-why">replaying a bad request just buys the same</text>
+  <text x="408" y="318" class="fo-why">error three times, at three vendors' prices</text>
 
-<p><strong>Working examples in the cluster.</strong> Both the <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/agent-with-orchestration">agent-with-orchestration</a> and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent">travel-chat-agent</a> examples construct <code>ai.NewChainClient</code> in auto-detect mode; their source comments also show how to supply <code>WithProviderChain</code> for explicit ordering.</p>
+  <!-- ===== streaming one-way door ===== -->
+  <text x="24" y="350" class="fo-hdr">STREAMING — A ONE-WAY DOOR AT THE FIRST VISIBLE CHUNK</text>
+
+  <rect x="40"  y="372" width="340" height="36" rx="6" class="fo-band1"/>
+  <text x="210" y="395" text-anchor="middle" class="fo-li">failover still allowed</text>
+  <rect x="380" y="372" width="340" height="36" rx="6" class="fo-band2"/>
+  <text x="550" y="395" text-anchor="middle" class="fo-li">locked to this entry — the answer never restarts elsewhere</text>
+  <line x1="380" y1="366" x2="380" y2="414" class="fo-door"/>
+  <text x="380" y="362" text-anchor="middle" class="fo-doort">first chunk reaches the callback</text>
+
+  <text x="40" y="434" class="fo-why">a callback that returns an error is the caller stopping, not a provider failing — it does not trigger failover</text>
+</svg>
+<figcaption><strong>Figure 8.</strong> <strong>Move on, or give up — decided by what the failure was.</strong> The interesting case is authentication. Traditionally a 401 means stop trying, but every entry in a chain holds its own key, so an expired <code>OPENAI_API_KEY</code> says nothing about whether Anthropic or Gemini will answer. The chain moves on. A 400 is the opposite: the payload is wrong and will be wrong everywhere, so replaying it three times only multiplies the bill. Streaming adds the one constraint the rest of the design bends around — once a user has seen a token, the answer cannot be quietly rewritten by a different vendor.</figcaption>
+</figure>
+
+<p>Extending is layered: configure a built-in provider when only keys or models differ, extend a request-aware one when credentials, routes, or HTTP transport differ — the path Azure, Vertex, and private gateways take, with hooks for per-request endpoints, rotating credentials, and an application-owned HTTP client for corporate CAs and proxies — and implement a new provider only when the wire format itself is different.</p>
+
+<p><strong>Working examples.</strong> <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/agent-with-orchestration">agent-with-orchestration</a> and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent">travel-chat-agent</a> both construct a chain client in auto-detect mode, with commented alternatives for explicit ordering.</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/ai/README.md">ai/README.md</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/building/AI_PROVIDERS_SETUP_GUIDE.md">AI Providers Setup Guide</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/building/CUSTOM_AI_PROVIDER_GUIDE.md">Custom AI Providers and Enterprise Integration Guide</a>.</p>
 
 <h3 id="orchestration">6. Orchestration</h3>
 
-<p>The orchestrator is what turns a list of capabilities and a natural-language request into an answer. It is the per-agent reasoning loop, and it is built around dynamic LLM-driven planning — the part of the framework that most directly uses the microagents architecture. No hand-written routing graphs, no pre-wired tool list in source code: the plan is generated against whatever is in the registry at the moment the request arrives.</p>
+<p>The orchestrator turns a list of capabilities and a natural-language request into an answer. It is the part of the framework that most directly uses the microagents architecture: no hand-written routing graphs, no pre-wired tool list in source, just a plan generated against whatever is in the registry the moment the request arrives.</p>
 
-<p><strong>The plan-execute-synthesize loop.</strong> A request enters the orchestrator. The orchestrator hands the live capability catalog to the LLM and asks for a plan. The LLM returns a directed acyclic graph (DAG) of steps — each step names a capability and lists the steps it depends on. The executor then runs the DAG: independent steps in parallel, dependent steps in topological order. When all steps finish, a synthesis call composes the response. Every operation along this path is instrumented, with one span per layer:</p>
+<p>The loop is plan, execute, synthesize. A request arrives; the orchestrator hands the live capability catalog to the LLM and asks for a plan; the LLM returns a DAG of steps, each naming a capability and its dependencies; the executor runs independent steps in parallel and dependent ones in topological order; a synthesis call composes the response. Every layer emits its own span, so a trace shows the plan, each phase, each step, and the synthesis separately rather than as one opaque block.</p>
 
-<ul>
-  <li><strong><code>orchestrator.process_request_streaming</code></strong> — the top-level span. Attributes: <code>iterative_planning</code>, <code>phase_count</code>.</li>
-  <li><strong><code>orchestrator.phase.N</code></strong> — one per planning phase. Attributes: <code>phase_number</code>, <code>plan_id</code>, <code>plan_source</code>, <code>steps_in_phase</code>.</li>
-  <li><strong><code>orchestrator.step.step-N</code></strong> — one per step. Attributes: <code>step.agent_name</code>, <code>step.capability</code>, <code>step.attempts</code>, <code>step.duration_ms</code>, <code>step.success</code>, <code>step.namespace</code>.</li>
-  <li><strong><code>orchestrator.synthesis</code></strong> — the final composition call. 14 attributes: model, provider, prompt and completion tokens, total tokens, prompt and response length, finish reason, streaming flag, step count, success and failure step counts, chunks sent, duration.</li>
-</ul>
+<figure id="fig-plan-expanded">
+<img src="https://assets.truvag3.dev/blogs/observability/tokyo-weather-registry-dag-llm-plan-expanded.png" alt="The Registry Viewer showing one LLM call from the orchestration phase with its prompt and response expanded. The prompt lists the capability catalog available at that moment; the response is the JSON plan the model returned, naming each step, the capability it calls, and the steps it depends on.">
+<figcaption><strong>Figure 9.</strong> <strong>The plan, as the model actually wrote it.</strong> The prompt is the live capability catalog; the response is the DAG that drove every step of the request. This is the artifact that makes dynamic planning debuggable rather than mysterious — when an agent does something unexpected, the plan is the first and usually the only place to look. Captured in the <a href="truvag3-observability-deep-dive.html">observability deep dive</a>.</figcaption>
+</figure>
 
-<p><strong>Iterative multi-phase planning.</strong> When the LLM cannot plan the full response upfront — because the destinations come from a search, or the coordinates come from geocoding, or the next step depends on what the previous step returned — the orchestrator returns to planning after a phase completes and feeds fresh results back as planning context. Plans are capped at 5 phases by default (<code>MaxPhases</code>) with a 200-step total budget (<code>MaxTotalSteps</code>) and a 180-second per-phase timeout (<code>PhaseTimeout</code>), tunable through environment variables. The Switzerland trip example in the architecture article shows this in practice: phase 1 calls one web search, phase 2 fans out three parallel geocoding calls, phase 3 fans out six parallel weather and hotel calls — 10 tool invocations in three phases, 6-way parallelism at peak, 29 seconds wall time. The metric <code>orchestration.phases_per_request</code> exposes the actual phase count distribution so a production team can see whether their workload is mostly single-phase, multi-phase, or both.</p>
+<p><strong>When one plan is not enough, the orchestrator re-plans.</strong> Some requests cannot be planned upfront — the destinations come from a search, the coordinates come from geocoding, the next step depends on what the last one returned. After a phase completes, the orchestrator can return to planning with the fresh results as context. The Switzerland trip in the <a href="microagents-architecture.html">architecture article</a> is this in practice: phase one runs a single web search, phase two fans out three parallel geocoding calls, phase three fans out six parallel weather and hotel calls — ten tool invocations across three phases, six-way parallelism at peak, 29 seconds wall time. Phase count, total steps, and per-phase timeout are bounded by default and tunable per deployment.</p>
 
-<p><strong>Plan validation, before any step runs.</strong> The LLM occasionally produces plans that are structurally invalid — references to dependencies that do not exist, references to steps in earlier phases that were never created, references to plan macros that are not registered. The orchestrator catches each of these classes before execution starts and emits a counter per rejection class:</p>
+<p><strong>Plans are validated before any step runs.</strong> LLMs occasionally produce structurally invalid plans: a dependency on a step that does not exist, a cross-phase reference to a step never created, an unregistered macro. Each class is caught before execution and counted separately, so a rising rejection rate tells you the planning prompt has drifted or a model swap went badly — visible on a dashboard without reading a log line.</p>
 
-<ul>
-  <li><code>orchestration.plan.rejected_missing_dependency</code></li>
-  <li><code>orchestration.plan.rejected_cross_phase_missing_step</code></li>
-  <li><code>orchestration.plan.rejected_unknown_macro</code></li>
-</ul>
+<p><strong>Large catalogs get a two-step selection.</strong> Past about twenty registered capabilities, sending every schema on every planning call wastes tokens and eventually overflows the context window. The orchestrator instead sends lightweight summaries, asks the planner which tools it wants, and fetches full schemas only for those.</p>
 
-<p>A rising rejection count is the canonical signal that the planning prompt has drifted, the LLM provider has been swapped to a less capable model, or a new tool's schema has confused the planner — visible without reading a single log line.</p>
+<p><strong>Failed steps get more than a blind retry.</strong> Transient transport errors are handled by exponential backoff. Input-level failures — wrong field name, missing value, ambiguous parameter — go further: the orchestrator hands the LLM the error, the original payload, and the capability's input schema, and asks for corrected parameters before the next attempt.</p>
 
-<p><strong>Tiered capability selection (large-catalog mode).</strong> Once a deployment grows past 20 registered capabilities (the default <code>TRUVAG3_TIERED_MIN_TOOLS</code> threshold), sending all schemas to every planning call wastes tokens and can exceed the context window. Instead, the orchestrator sends lightweight tool summaries to the planner first, asks for the tool selection, then fetches full schemas only for the chosen tools. The selection step is capped at 2000 tokens by default (<code>TRUVAG3_TIERED_SELECTION_MAX_TOKENS</code>). This is enabled by default and configurable per deployment.</p>
+<p>Two smaller things happen along the way: oversized tool responses are trimmed before entering the next prompt, preserving JSON shape and key names; and when the planner needs something it cannot infer, such as a date or an account ID, it returns a structured clarification request rather than inventing a value.</p>
 
-<p><strong>Per-step retry, with semantic re-resolution.</strong> Each step gets an initial attempt plus two retries by default (overridable via <code>TRUVAG3_STEP_RETRY_MAX_ATTEMPTS</code>). Generic retry with exponential backoff handles transient transport errors. For input-level failures — wrong field name, missing required value, ambiguous parameter — the orchestrator goes further: it can ask the LLM to read the error, the original payload, and the capability's input schema, then propose corrected parameters before the next attempt. The counters <code>orchestration.error_analysis.retry</code> and <code>orchestration.error_analysis.no_retry</code> track whether the LLM judged the error recoverable; <code>orchestration.error_analyzer.llm_latency_ms</code> tracks how long the analysis itself took.</p>
-
-<p><strong>Result trimming for large step outputs.</strong> Tool responses sometimes weigh in at tens of kilobytes — a clinical record, a full Confluence page, a deep telemetry payload. Pushing these raw into the next planning prompt would waste tokens and confuse the LLM. The orchestrator trims them before they enter the next prompt: structural trimming first (preserves JSON shape, key names, representative samples), with an optional LLM-summarization (distill) pass for very large outputs. Tracked by <code>orchestration.result_trim.triggered</code> and <code>orchestration.result_distill.triggered</code>; the original byte size is recorded in <code>orchestration.result.original_size_bytes</code>, which makes it easy to identify which tools are producing oversized responses.</p>
-
-<p><strong>Streaming and clarification.</strong> The orchestrator can emit progress events while work is running — phase started, step completed, synthesis token chunks — suitable for chat UIs and long-running operations. When the planner needs information it cannot infer (a date, a destination, an account ID), it surfaces a structured <code>Clarification</code> request rather than hallucinating a value. Simple chat UIs forward the natural-language response; richer UIs can render structured prompts from the clarification field.</p>
-
-<p><strong>Working examples in the cluster.</strong> The bundled <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent">travel-chat-agent</a>, <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/devops-chat-agent">devops-chat-agent</a>, and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/agent-with-orchestration">agent-with-orchestration</a> all wire the dynamic orchestrator. The Jaeger traces they emit (40+ spans per request across multiple services) are what the architecture article's captured executions are based on.</p>
+<p><strong>Working examples.</strong> <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent">travel-chat-agent</a>, <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/devops-chat-agent">devops-chat-agent</a>, and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/agent-with-orchestration">agent-with-orchestration</a> all wire the dynamic orchestrator; the traces they emit are the source of the captured executions in the architecture article.</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/orchestration/README.md">orchestration/README.md</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/orchestration/LLM_PLANNING_PROMPT_GUIDE.md">LLM Planning Prompt Guide</a>.</p>
 
 <h3 id="reliability">7. Reliability and error recovery</h3>
 
-<p>Failure is a normal part of running distributed systems. Networks degrade, external APIs rate-limit, downstream services go through deployments, and LLMs sometimes pass slightly wrong arguments. A framework that ignores this turns every transient problem into a user-facing error. TruvaG3 builds error handling into the request path as a layered, instrumented system — so most failures are absorbed and recovered from before they ever reach the user. The orchestrator-internal recovery layers (semantic re-resolution, LLM error analysis, result trimming) are covered in <a href="#orchestration">§6 above</a>; this section is about the foundation underneath them: how tools report errors and the resilience primitives the framework provides.</p>
+<p>Failure is normal in distributed systems. Networks degrade, external APIs rate-limit, downstream services go through deployments, and LLMs sometimes pass slightly wrong arguments. A framework that ignores this turns every transient problem into a user-facing error. The orchestrator-internal recovery layers are covered in <a href="#orchestration">§6</a>; this is the foundation underneath them.</p>
 
-<p><strong>Structured tool errors, not opaque strings.</strong> Every tool that returns an error returns a typed <code>ToolError</code> with a <code>Category</code> field. There are five categories, and each one tells the orchestrator something specific about what to do next:</p>
+<p><strong>Tools return typed errors, not opaque strings.</strong> Every error carries one of five categories, and each tells the orchestrator what to do next. <code>INPUT_ERROR</code> means the request was malformed, which is exactly the case the LLM error analyzer can fix. <code>RATE_LIMIT</code> and <code>SERVICE_ERROR</code> are retryable with backoff. <code>NOT_FOUND</code> surfaces to synthesis so the answer can say the resource is missing. <code>AUTH_ERROR</code> is not retryable at all — there is no point retrying the same bad token — so it escalates to an operator. Because the category is explicit, the orchestrator's response is deterministic rather than guessed from the wording of an error message.</p>
 
-<ul>
-  <li><strong><code>INPUT_ERROR</code></strong> — the request was malformed (wrong field name, wrong type, value out of range). The orchestrator can route this to the LLM error analyzer, which will read the error and propose corrected parameters before the next attempt.</li>
-  <li><strong><code>NOT_FOUND</code></strong> — the requested resource does not exist. Usually non-retryable; the orchestrator surfaces it to the synthesis step so the response can tell the user the resource is missing.</li>
-  <li><strong><code>RATE_LIMIT</code></strong> — the upstream API quota was exceeded. Retryable with backoff; the framework waits and tries again.</li>
-  <li><strong><code>AUTH_ERROR</code></strong> — credentials are invalid or missing. Non-retryable on its own (no point in retrying the same bad token); escalates to operator attention.</li>
-  <li><strong><code>SERVICE_ERROR</code></strong> — the upstream service is temporarily unhealthy (5xx, network error). Retryable with backoff.</li>
-</ul>
+<figure id="fig-error-routing">
+<svg viewBox="0 0 760 356" xmlns="http://www.w3.org/2000/svg"
+     style="width:100%;height:auto;display:block;margin:0 auto;background:#ffffff;border-radius:6px;border:1px solid #2a3550;"
+     role="img"
+     aria-label="How the five tool error categories route to four different framework responses. INPUT_ERROR, meaning a malformed request, routes to the LLM error analyzer, which reads the error, the original payload and the input schema and proposes corrected parameters for the next attempt. RATE_LIMIT and SERVICE_ERROR both route to retry with exponential backoff and plus or minus ten percent jitter. NOT_FOUND routes to synthesis, so the answer can tell the user the resource is missing. AUTH_ERROR routes to operator escalation with no retry, because retrying the same bad token cannot help. A band across the bottom notes what sits underneath every call regardless of category: a circuit breaker moving between closed, open and half-open states, and panic recovery that converts a crash inside a handler into a structured SERVICE_ERROR response instead of taking down the process.">
+  <style>
+    .er-cat  { fill:#ffffff; stroke:#d0d7de; stroke-width:1.2; }
+    .er-catt { font:600 11.5px ui-monospace, SFMono-Regular, Menlo, monospace; fill:#1a1a1a; }
+    .er-cats { font:9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#8c96a3; }
+    .er-act  { fill:#fbfdff; stroke:#9ec5ff; stroke-width:1.3; }
+    .er-actt { font:600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#1a1a1a; }
+    .er-acts { font:10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#6e7781; }
+    .er-arr  { stroke:#0b6cff; stroke-width:1.4; fill:none; }
+    .er-arrn { stroke:#c0392b; stroke-width:1.4; fill:none; }
+    .er-hdr  { font:700 9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0.7px; fill:#8c96a3; }
+    .er-base { fill:#f6f8fa; stroke:#d0d7de; stroke-width:1.2; }
+    .er-baset{ font:600 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#1a1a1a; }
+    .er-bases{ font:10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#6e7781; }
+    .er-rt   { font:italic 9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#3fa96b; }
+    .er-nrt  { font:italic 9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#c0392b; }
+  </style>
+  <defs>
+    <marker id="er-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#0b6cff"/>
+    </marker>
+    <marker id="er-n" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#c0392b"/>
+    </marker>
+  </defs>
 
-<p>Because the category is explicit, the orchestrator's response is deterministic rather than guessed from the error message text. A tool that returns <code>RATE_LIMIT</code> gets retried with backoff; a tool that returns <code>AUTH_ERROR</code> does not.</p>
+  <text x="30"  y="26" class="er-hdr">THE TOOL SAYS WHAT WENT WRONG</text>
+  <text x="400" y="26" class="er-hdr">THE ORCHESTRATOR KNOWS WHAT TO DO</text>
 
-<p><strong>Step retry with exponential backoff and jitter.</strong> Each step in a plan gets an initial attempt plus two retries by default (<code>TRUVAG3_STEP_RETRY_MAX_ATTEMPTS</code>, total 3). The wait between attempts grows exponentially — 100ms initial, doubling each attempt, capped at 5 seconds — with ±10% jitter added so that a fleet of agents retrying against the same backend does not synchronize into a thundering-herd retry storm. These defaults come from the resilience module's <code>DefaultRetryConfig</code>; every value is configurable per call.</p>
+  <rect x="30" y="40"  width="200" height="34" rx="5" class="er-cat"/>
+  <text x="44" y="62" class="er-catt">INPUT_ERROR</text>
+  <text x="216" y="62" text-anchor="end" class="er-rt">retryable</text>
 
-<p><strong>Circuit breakers for failure isolation.</strong> A single misbehaving tool can affect every agent that calls it. TruvaG3 ships a circuit breaker primitive (<code>resilience.CircuitBreaker</code>) that any agent can wrap around outbound calls. Three states:</p>
+  <rect x="30" y="88"  width="200" height="34" rx="5" class="er-cat"/>
+  <text x="44" y="110" class="er-catt">RATE_LIMIT</text>
+  <text x="216" y="110" text-anchor="end" class="er-rt">retryable</text>
 
-<ul>
-  <li><strong>Closed</strong> — normal operation; calls flow through.</li>
-  <li><strong>Open</strong> — too many failures in the recent window; calls fail fast without touching the upstream service, giving it time to recover.</li>
-  <li><strong>Half-open</strong> — after a recovery timeout, a limited number of calls is allowed through to test whether the downstream is healthy again. Success closes the breaker; failure reopens it.</li>
-</ul>
+  <rect x="30" y="136" width="200" height="34" rx="5" class="er-cat"/>
+  <text x="44" y="158" class="er-catt">SERVICE_ERROR</text>
+  <text x="216" y="158" text-anchor="end" class="er-rt">retryable</text>
 
-<p>Thresholds are configurable: error rate (default 0.5, meaning open if more than half of recent requests fail), volume threshold (minimum request count before evaluation), and recovery timeout. The breaker's state, transitions, and outcomes are all instrumented:</p>
+  <rect x="30" y="184" width="200" height="34" rx="5" class="er-cat"/>
+  <text x="44" y="206" class="er-catt">NOT_FOUND</text>
+  <text x="216" y="206" text-anchor="end" class="er-nrt">terminal</text>
 
-<ul>
-  <li><code>agent.circuit_breaker.success</code> / <code>agent.circuit_breaker.failure</code> — outcomes of attempted calls.</li>
-  <li><code>agent.circuit_breaker.rejected</code> — calls fast-failed by an open breaker. Tells you how much load the breaker absorbed.</li>
-  <li><code>circuit_breaker.state_change</code> — counter of state transitions, labeled <code>from</code> and <code>to</code>; filtering by <code>to=open</code> tells you how often a downstream tripped the breaker.</li>
-  <li><code>circuit_breaker.current_state</code> — gauge of the current state (closed / open / half-open), per breaker.</li>
-  <li><code>circuit_breaker.duration_ms</code> — histogram of call durations recorded through the breaker.</li>
-</ul>
+  <rect x="30" y="232" width="200" height="34" rx="5" class="er-cat"/>
+  <text x="44" y="254" class="er-catt">AUTH_ERROR</text>
+  <text x="216" y="254" text-anchor="end" class="er-nrt">terminal</text>
 
-<p>An operator looking at a Grafana panel for circuit breakers can see immediately which downstream services are degraded — without reading any application logs.</p>
+  <rect x="400" y="38"  width="330" height="52" rx="6" class="er-act"/>
+  <text x="416" y="59" class="er-actt">LLM error analyzer</text>
+  <text x="416" y="77" class="er-acts">reads error + payload + schema, proposes new params</text>
 
-<p><strong>Panic recovery, so a single bad request does not crash the process.</strong> Go's <code>panic</code> mechanism is occasionally triggered by unexpected conditions — a nil dereference inside a third-party library, a malformed response, a corrupt payload. The framework wraps execution paths with <code>recover()</code>, so a panic during one request is caught, logged with full stack trace, and converted into a structured error returned to the caller. The agent process keeps serving other requests. Without this, one buggy code path could take down an entire pod and trigger a cascade of restarts.</p>
+  <rect x="400" y="102" width="330" height="52" rx="6" class="er-act"/>
+  <text x="416" y="123" class="er-actt">Retry with backoff</text>
+  <text x="416" y="141" class="er-acts">100 ms doubling to a 5 s cap, ±10% jitter</text>
 
-<p><strong>How the pieces fit together.</strong> A typical failure scenario, end to end:</p>
+  <rect x="400" y="180" width="330" height="46" rx="6" class="er-act"/>
+  <text x="416" y="200" class="er-actt">Surface to synthesis</text>
+  <text x="416" y="217" class="er-acts">the answer tells the user the resource is missing</text>
 
-<ol>
-  <li>An agent makes an outbound call through a circuit breaker. The breaker is closed; the call goes through.</li>
-  <li>The downstream tool returns <code>RATE_LIMIT</code> with a retry-after hint.</li>
-  <li>The orchestrator's step-retry layer sees the retryable category, waits with exponential backoff plus jitter, and retries.</li>
-  <li>The second attempt succeeds. The breaker records the success, the request completes.</li>
-</ol>
+  <rect x="400" y="238" width="330" height="46" rx="6" class="er-act"/>
+  <text x="416" y="258" class="er-actt">Escalate, no retry</text>
+  <text x="416" y="275" class="er-acts">the same bad token will fail the same way</text>
 
-<p>If the rate-limit persisted across all retries, the request would fail with a clean structured error rather than a hang. If many agents were hitting the same rate-limited tool, the breaker would eventually open and shed load. If a code path inside the tool panicked instead, the panic would be caught and converted into a <code>SERVICE_ERROR</code> response. At no point does an unexpected failure crash the calling agent.</p>
+  <path d="M 232 57 L 396 62"  class="er-arr"  marker-end="url(#er-a)"/>
+  <path d="M 232 105 L 396 124" class="er-arr"  marker-end="url(#er-a)"/>
+  <path d="M 232 153 L 396 134" class="er-arr"  marker-end="url(#er-a)"/>
+  <path d="M 232 201 L 396 203" class="er-arrn" marker-end="url(#er-n)"/>
+  <path d="M 232 249 L 396 261" class="er-arrn" marker-end="url(#er-n)"/>
 
-<p><strong>Working example in the cluster.</strong> The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/agent-with-resilience">agent-with-resilience</a> example wires all of this end to end: per-tool circuit breakers, <code>resilience.RetryWithCircuitBreaker</code> for combined retry + breaker protection, <code>cb.ExecuteWithTimeout</code> for explicit timeout control, and a status endpoint that exposes circuit-breaker state per downstream tool. It is the right starting point for any agent that needs hardened fault isolation.</p>
+  <rect x="30" y="292" width="700" height="52" rx="5" class="er-base"/>
+  <text x="44" y="310" class="er-baset">Underneath every call, whatever the category:</text>
+  <text x="44" y="325" class="er-bases">circuit breaker (closed → open → half-open) sheds load from a downstream that is already failing</text>
+  <text x="44" y="338" class="er-bases">panic recovery turns a crash inside a handler into a structured response instead of a dead pod</text>
+</svg>
+<figcaption><strong>Figure 10.</strong> <strong>The category is the routing decision.</strong> Nothing here parses an error message. Because the tool states the category, the orchestrator's response is fixed in advance — which is why a rate limit costs a retry and a bad credential pages an operator, rather than both costing three identical retries against a service that was never going to answer.</figcaption>
+</figure>
+
+<p><strong>Retries back off and jitter.</strong> Each step gets an initial attempt plus two retries by default, the wait doubling from 100 ms up to a five-second cap, with ±10% jitter so a fleet of agents retrying against the same backend does not synchronize into a thundering herd.</p>
+
+<p><strong>Circuit breakers isolate a misbehaving downstream.</strong> Any agent can wrap outbound calls in a breaker. Closed, calls flow through. Open, they fail fast without touching a service that is already struggling. Half-open, a limited number are let through to test recovery — success closes the breaker, failure reopens it. State, transitions, and outcomes are instrumented, so a Grafana panel shows immediately which downstream services are degraded.</p>
+
+<p><strong>A recovered request panic does not take out the pod.</strong> A dependency can panic while processing an unexpected value — for example, through a nil dereference inside a third-party library. The framework wraps request execution paths with recovery, so that panic is caught, logged with its stack trace, and converted into a structured error returned to the caller. The process keeps serving everything else.</p>
+
+<p><strong>How the pieces fit together.</strong> A typical failure, end to end: an agent makes an outbound call through a closed breaker; the downstream tool returns <code>RATE_LIMIT</code>; the step-retry layer sees a retryable category, waits with backoff and jitter, and tries again; the second attempt succeeds and the breaker records it. Had the rate limit persisted across every retry, the request would have failed with a clean structured error rather than hanging. Had many agents been hitting the same limited tool, the breaker would have opened and shed load. Had the tool panicked inside a protected request path, the panic would have become a <code>SERVICE_ERROR</code> response instead of crashing the process.</p>
+
+<p><strong>Working example.</strong> <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/agent-with-resilience">agent-with-resilience</a> wires all of it — per-tool breakers, combined retry-plus-breaker execution, explicit timeout control, and a status endpoint exposing breaker state per downstream tool.</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/resilience/README.md">resilience/README.md</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/orchestration/ERROR_HANDLING_GUIDE.md">Error Handling Guide</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/orchestration/INTELLIGENT_ERROR_HANDLING.md">Intelligent Error Handling</a>.</p>
 
 <h3 id="async-and-scheduling">8. Async tasks and scheduling</h3>
 
-<p>Not every agent workflow fits inside a single synchronous HTTP request. A research-style agent that calls a dozen tools across three planning phases can take a minute or more — long enough that holding a TCP connection open is fragile and the user has no useful progress signal. A nightly batch that runs at 2 AM is not even waiting for a user request. TruvaG3 ships two complementary mechanisms for these cases: <strong>async tasks</strong> for long-running synchronous-shaped work and <strong>scheduled execution</strong> for time-based work.</p>
+<p>Agent work is not millisecond work. A single model call can take 5–60 seconds, a rate-limited external API 10–120 seconds, document processing several minutes, and a step gated on human approval longer still — so a research workflow that chains a dozen of them may run for minutes or hours. Held open that long, a synchronous HTTP request can collect timeouts at every hop, tie up request resources, give the user no progress signal, resist cancellation once it has gone off course, and turn an impatient client retry into duplicate work. A nightly batch at 2 AM, meanwhile, is not waiting for anyone at all. The framework covers both cases as separate subsystems.</p>
 
-<p><strong>Async tasks — the standard HTTP-202-and-polling pattern.</strong> The client sends a request, the API returns immediately with a task ID and <code>202 Accepted</code>, and the work continues in the background. The client then polls a status endpoint until the task is complete. The bundled <code>agent-with-async</code> example wires the framework's <code>orchestration.NewTaskAPIHandler</code> at <code>/api/v1/tasks</code>:</p>
+<p><strong>Async tasks</strong> follow the standard 202-and-poll pattern: the client posts a request, the API validates it, creates a task, enqueues it and returns a task ID with a status URL in about ten milliseconds. A worker pool blocks waiting for work rather than polling for it, and reports structured progress as it goes — current step, total steps, percentage — into a task store the API reads when the client asks. So a polling client sees "step 2 of 3, 60%" rather than an opaque spinner, and can cancel a task at any point rather than waiting out a mistake. Task duration and the wait before a worker picks a task up are both instrumented, and a climbing wait time is the canonical "add workers" signal. The same binary runs all of it in one process for development, or splits into API pods and worker pods that scale on different signals — request rate and queue depth — in production.</p>
 
-<ol>
-  <li><code>POST /api/v1/tasks</code> with the request body → returns <code>{"task_id": "...", "status": "queued", "status_url": "/api/v1/tasks/&lt;id&gt;"}</code>.</li>
-  <li><code>GET /api/v1/tasks/&lt;id&gt;</code> → returns <code>{"status": "running", ...}</code> while work is in flight.</li>
-  <li><code>GET /api/v1/tasks/&lt;id&gt;</code> after completion → returns the full response payload.</li>
-</ol>
+<p><strong>Scheduled execution</strong> lets any agent or external system create a schedule against any target agent, using exactly one of three primitives: a relative <code>delay</code> ("check this order in 15 minutes"), an absolute <code>run_at</code> ("send a reminder at 6 PM on launch day"), or a <code>cron_expr</code> for recurring work ("the compliance check every weekday at 9"). Three independently deployable roles make it work — a scheduler tool that owns the schedule API and is discoverable like any other tool, a horizontally scalable executor that polls for due work and atomically claims it so two workers never fire the same schedule twice, and any target agent that opts in with one line and then receives scheduled requests through the same orchestration pipeline as its chat traffic.</p>
 
-<p>Step-completion callbacks during execution write progress updates into the task store, so the polling client gets meaningful state. The duration of each task and the wait time before it is picked up by a worker are both instrumented (canonical OTEL names): <code>executor.task.duration_ms</code>, <code>executor.task.wait_ms</code>, <code>executor.tasks.submitted</code>, <code>executor.tasks.completed</code>. A wait-time histogram that starts climbing is the canonical signal that you need more workers.</p>
+<figure id="fig-async-scheduling">
+<svg viewBox="0 0 760 496" xmlns="http://www.w3.org/2000/svg"
+     style="width:100%;height:auto;display:block;margin:0 auto;background:#ffffff;border-radius:6px;border:1px solid #2a3550;"
+     role="img"
+     aria-label="Two ways work reaches an agent without a caller waiting, drawn as two separate subsystems. The upper lane is the async task path, introduced by the fact that agent work runs for minutes to hours rather than milliseconds: one LLM call takes 5 to 60 seconds, a rate-limited external API 10 to 120 seconds, document processing 1 to 30 minutes, and a step gated on human approval longer still. A client posts to the task API, which validates, creates a task with a UUID, enqueues it to a Redis list and returns HTTP 202 with a task ID in about ten milliseconds. A worker pool blocks on BRPOP waiting for work, then runs the orchestration and reports structured progress into a separate task store held as a Redis string, which the API reads when the client polls. The task moves from queued to running, carrying step and percentage progress, to completed or canceled. The lower lane is the scheduled path, for work with no caller at all: a leader-elected scheduler tool creates a schedule from exactly one of three primitives — a relative delay, an absolute run_at timestamp, or a cron expression — into a schedule store, and a horizontally scaling executor pool consumes work that is due and dispatches it over HTTP to any target agent that opted in. Beneath the lower lane only, two delivery semantics are offered for that executor-to-agent hop: at-most-once using BRPOP, the default, where the task is removed on consume so an executor crashing mid-dispatch loses it, suited to best-effort or duplicate-sensitive schedules; and at-least-once using Redis Streams, where the task stays pending until acknowledged and a reaper reclaims work from crashed replicas, requiring an idempotent handler and suited to financial actions and compliance jobs.">
+  <style>
+    .as-ext  { fill:#ffffff; stroke:#d0d7de; stroke-width:1.2; }
+    .as-fw   { fill:#fff8e6; stroke:#d9b35a; stroke-width:1.3; }
+    .as-store{ fill:#f6f8fa; stroke:#d0d7de; stroke-width:1.2; }
+    .as-t    { font:600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#1a1a1a; }
+    .as-s    { font:9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#6e7781; }
+    .as-m    { font:9.5px ui-monospace, SFMono-Regular, Menlo, monospace; fill:#6e7781; }
+    .as-hdr  { font:700 9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0.7px; fill:#8c96a3; }
+    .as-why  { font:10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#8c96a3; }
+    .as-note { font:italic 10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#7a5a16; }
+    .as-arr  { stroke:#0b6cff; stroke-width:1.5; fill:none; }
+    .as-arrd { stroke:#0b6cff; stroke-width:1.3; fill:none; stroke-dasharray:4,3; }
+    .as-arrg { stroke:#b8bcc2; stroke-width:1.4; fill:none; }
+    .as-arrgd{ stroke:#b8bcc2; stroke-width:1.2; fill:none; stroke-dasharray:3,3; }
+    .as-lbl  { font:9px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#0b6cff; }
+    .as-lblg { font:9px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#8c96a3; }
+    .as-pan  { fill:#ffffff; stroke:#d0d7de; stroke-width:1.2; }
+    .as-pt   { font:600 11.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#1a1a1a; }
+    .as-ps   { font:10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#6e7781; }
+    .as-good { font:italic 10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#256b45; }
+  </style>
+  <defs>
+    <marker id="as-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#0b6cff"/>
+    </marker>
+    <marker id="as-g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#b8bcc2"/>
+    </marker>
+  </defs>
 
-<p><strong>Scheduled execution — three primitives that cover everything.</strong> A scheduler-tool capability lets any agent or external system create a schedule against any target agent. The three primitives are mutually exclusive (exactly one per schedule):</p>
+  <!-- ================= lane 1: async ================= -->
+  <text x="30" y="22" class="as-hdr">1 · ASYNC TASK — AGENT WORK RUNS FOR MINUTES TO HOURS, NOT MILLISECONDS</text>
+  <text x="30" y="40" class="as-why">one LLM call 5–60s · a rate-limited API 10–120s · document processing 1–30 min · a step waiting on a human, longer still</text>
 
-<ul>
-  <li><strong><code>delay</code></strong> — relative one-shot. Go-duration string like <code>"30s"</code>, <code>"10m"</code>, <code>"2h"</code>. Useful for follow-ups: <em>"check this order status in 15 minutes"</em>.</li>
-  <li><strong><code>run_at</code></strong> — absolute time. RFC3339 timestamp like <code>"2026-06-01T18:00:00Z"</code>. Useful for one-off events: <em>"send a reminder at 6 PM on launch day"</em>.</li>
-  <li><strong><code>cron_expr</code></strong> — recurring. Standard five-field cron syntax (<code>*/5 * * * *</code>, <code>0 9 * * 1-5</code>, etc.) parsed by the well-established <code>robfig/cron/v3</code> library. Useful for periodic work: <em>"run the daily compliance check every morning at 9 AM."</em></li>
-</ul>
+  <rect x="30"  y="54" width="96"  height="64" rx="6" class="as-ext"/>
+  <text x="78"  y="82" text-anchor="middle" class="as-t">Client</text>
+  <text x="78"  y="100" text-anchor="middle" class="as-s">any caller</text>
 
-<p>The architecture has three roles, each independently deployable:</p>
+  <rect x="176" y="54" width="136" height="64" rx="6" class="as-fw"/>
+  <text x="244" y="78" text-anchor="middle" class="as-t">Task API</text>
+  <text x="244" y="95" text-anchor="middle" class="as-s">validate · create UUID</text>
+  <text x="244" y="109" text-anchor="middle" class="as-s">enqueue · return</text>
 
-<ol>
-  <li><strong>Scheduler-tool</strong> — the create/update/delete API for schedules. It is just another TruvaG3 tool, discoverable like everything else.</li>
-  <li><strong>Scheduled-executor</strong> — a worker that polls the schedule store for due work, atomically claims it (so two workers cannot fire the same schedule twice), and dispatches the task to the target agent. Scales horizontally — add replicas to handle more schedules.</li>
-  <li><strong>Target agent</strong> — any agent that registers a <code>scheduled</code> handler. One-line wiring opts in; the agent then receives scheduled requests through the same orchestration pipeline that handles synchronous chat requests.</li>
-</ol>
+  <rect x="362" y="54" width="118" height="64" rx="6" class="as-store"/>
+  <text x="421" y="82" text-anchor="middle" class="as-t">Task queue</text>
+  <text x="421" y="100" text-anchor="middle" class="as-m">Redis LIST</text>
 
-<p><strong>Two delivery models for different reliability needs.</strong> Both async tasks and scheduled execution sit on a pluggable backend interface, with two bundled implementations:</p>
+  <rect x="530" y="54" width="140" height="64" rx="6" class="as-fw"/>
+  <text x="600" y="78" text-anchor="middle" class="as-t">Worker pool</text>
+  <text x="600" y="95" text-anchor="middle" class="as-s">blocks on BRPOP,</text>
+  <text x="600" y="109" text-anchor="middle" class="as-s">then runs the plan</text>
 
-<ul>
-  <li><strong>At-most-once (default, Redis lists)</strong> — once a worker pops a task off the queue, it is gone from the queue. If the worker crashes mid-execution, the task is lost. Cheap, simple, fine for idempotent work and best-effort schedules.</li>
-  <li><strong>At-least-once (Redis Streams)</strong> — uses consumer groups with explicit acknowledgement. A claimed task that is not acknowledged within a timeout is redelivered to another consumer. The worker may see the same task twice if it crashes — design your handler to be idempotent. Right choice for financial actions, compliance jobs, or anything where missing a scheduled run is worse than running it twice.</li>
-  <li><strong>In-memory</strong> — for tests and local development. Same interface, no Redis dependency.</li>
-</ul>
+  <line x1="128" y1="78" x2="172" y2="78" class="as-arr" marker-end="url(#as-b)"/>
+  <text x="150" y="71" text-anchor="middle" class="as-lbl">POST</text>
+  <line x1="172" y1="102" x2="128" y2="102" class="as-arrd" marker-end="url(#as-b)"/>
+  <text x="150" y="116" text-anchor="middle" class="as-lbl">202 · ~10ms</text>
 
-<p>Switching between modes is a wiring change in the agent's <code>main.go</code> — no application logic moves. The right choice depends on what failure mode is more expensive in the workload, not on what the framework forces.</p>
+  <line x1="314" y1="86" x2="358" y2="86" class="as-arrg" marker-end="url(#as-g)"/>
+  <text x="336" y="79" text-anchor="middle" class="as-lblg">enqueue</text>
+  <line x1="482" y1="86" x2="526" y2="86" class="as-arrg" marker-end="url(#as-g)"/>
+  <text x="504" y="79" text-anchor="middle" class="as-lblg">consume</text>
 
-<p><strong>Live metrics across both flows.</strong></p>
+  <line x1="600" y1="120" x2="600" y2="146" class="as-arrg" marker-end="url(#as-g)"/>
+  <text x="608" y="138" class="as-lblg">progress</text>
+  <line x1="244" y1="146" x2="244" y2="120" class="as-arrgd" marker-end="url(#as-g)"/>
+  <text x="252" y="138" class="as-lblg">read</text>
 
-<ul>
-  <li><strong>Async tasks:</strong> <code>async_orchestration.tasks</code> (labeled by status: completed, failed, setup_failed, catalog_failed), <code>async_orchestration.duration_ms</code>, <code>async_orchestration.tool_calls</code>, <code>async_orchestration.tools_per_query</code>. The last one is particularly useful: it tells you the typical "fan-out" of an async request, which feeds capacity planning.</li>
-  <li><strong>Scheduled execution:</strong> <code>executor.tasks.submitted</code> vs <code>executor.tasks.completed</code> shows backlog at a glance. <code>executor.task.wait_ms</code> shows queue latency; <code>executor.task.duration_ms</code> shows execution latency. A widening gap between submitted and completed is the canonical "add workers" signal.</li>
-</ul>
+  <rect x="176" y="150" width="494" height="52" rx="6" class="as-store"/>
+  <text x="192" y="170" class="as-t">Task store</text>
+  <text x="262" y="170" class="as-m">Redis STRING</text>
+  <text x="192" y="190" class="as-s">queued → running · step 2 of 3 · 60% → completed, or canceled on request</text>
 
-<p><strong>Working examples in the cluster.</strong> The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/agent-with-async">agent-with-async</a> example demonstrates the full async pattern — API mode, worker mode, and embedded mode (API + worker in one process for simple deployments). The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/scheduler-tool">scheduler-tool</a> and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/scheduled-executor">scheduled-executor</a> examples make up the complete scheduled-execution stack — the tool runs as a regular framework tool, the executor runs as an independently scalable worker pool, and any target agent can subscribe in one line.</p>
+  <text x="30" y="220" class="as-note">the client polls that store for progress and can cancel at any point — no request has to stay open,</text>
+  <text x="30" y="234" class="as-note">and the client keeps one task ID for status, progress and cancellation</text>
+
+  <!-- ================= lane 2: scheduled ================= -->
+  <text x="30" y="270" class="as-hdr">2 · SCHEDULED — WORK WITH NO CALLER AT ALL</text>
+
+  <rect x="30"  y="286" width="132" height="64" rx="6" class="as-fw"/>
+  <text x="96"  y="310" text-anchor="middle" class="as-t">Scheduler tool</text>
+  <text x="96"  y="327" text-anchor="middle" class="as-m">delay · run_at</text>
+  <text x="96"  y="341" text-anchor="middle" class="as-m">cron_expr</text>
+
+  <rect x="212" y="286" width="118" height="64" rx="6" class="as-store"/>
+  <text x="271" y="310" text-anchor="middle" class="as-t">Schedule store</text>
+  <text x="271" y="327" text-anchor="middle" class="as-s">exactly one</text>
+  <text x="271" y="341" text-anchor="middle" class="as-s">primitive each</text>
+
+  <rect x="380" y="286" width="150" height="64" rx="6" class="as-fw"/>
+  <text x="455" y="310" text-anchor="middle" class="as-t">Executor pool</text>
+  <text x="455" y="327" text-anchor="middle" class="as-s">consumes what is due,</text>
+  <text x="455" y="341" text-anchor="middle" class="as-s">forwards over HTTP</text>
+
+  <rect x="580" y="286" width="130" height="64" rx="6" class="as-fw"/>
+  <text x="645" y="310" text-anchor="middle" class="as-t">Target agent</text>
+  <text x="645" y="327" text-anchor="middle" class="as-s">opts in with one line,</text>
+  <text x="645" y="341" text-anchor="middle" class="as-s">same pipeline as chat</text>
+
+  <line x1="164" y1="318" x2="208" y2="318" class="as-arrg" marker-end="url(#as-g)"/>
+  <text x="186" y="311" text-anchor="middle" class="as-lblg">create</text>
+  <line x1="332" y1="318" x2="376" y2="318" class="as-arrg" marker-end="url(#as-g)"/>
+  <text x="354" y="311" text-anchor="middle" class="as-lblg">due?</text>
+  <line x1="532" y1="318" x2="576" y2="318" class="as-arr" marker-end="url(#as-b)"/>
+  <text x="554" y="311" text-anchor="middle" class="as-lbl">dispatch</text>
+
+  <text x="30" y="370" class="as-note">the scheduler is leader-elected — one active producer — while the executor scales out, and each</text>
+  <text x="30" y="384" class="as-note">task is claimed atomically, so two replicas never fire the same schedule twice</text>
+
+  <!-- delivery semantics: scoped to the dispatch hop only -->
+  <text x="30" y="412" class="as-hdr">DELIVERY SEMANTICS — FOR THAT EXECUTOR → AGENT HOP</text>
+  <rect x="30"  y="422" width="340" height="62" rx="6" class="as-pan"/>
+  <text x="44"  y="442" class="as-pt">At-most-once — BRPOP (default)</text>
+  <text x="44"  y="458" class="as-ps">removed on consume; a crash mid-dispatch loses it</text>
+  <text x="44"  y="476" class="as-good">→ best-effort or duplicate-sensitive schedules</text>
+
+  <rect x="390" y="422" width="340" height="62" rx="6" class="as-pan"/>
+  <text x="404" y="442" class="as-pt">At-least-once — Redis Streams</text>
+  <text x="404" y="458" class="as-ps">stays pending until acked; a reaper reclaims crashed replicas</text>
+  <text x="404" y="476" class="as-good">→ idempotent handlers; financial or compliance jobs</text>
+</svg>
+<figcaption><strong>Figure 11.</strong> <strong>A caller who cannot wait, and a clock.</strong> The async path exists because agent work is not millisecond work — chained model calls, rate-limited APIs and human approvals push one workflow into minutes or hours, which no held-open request survives. The scheduled path exists because some work has no caller at all. They are deliberately separate subsystems rather than one queue with two doors: the async queue feeds a worker pool, while the executor's handoff to an agent is its own hop, which is why the delivery guarantee below attaches only to that arrow.</figcaption>
+</figure>
+
+<p><strong>Pick your delivery guarantee.</strong> Every backend in both subsystems sits behind an interface, so Redis is a default rather than a requirement — Postgres, SQS or an in-memory implementation for tests all satisfy the same contracts. The delivery choice specifically governs the executor's handoff to an agent. At-most-once is the default: the task leaves the queue the moment it is consumed, so an executor that dies mid-dispatch loses that run — simple, no consumer groups, no reaper, and correct whenever a missed run is cheaper than a duplicate one. At-least-once uses Redis Streams, where the task stays pending until it is acknowledged and a companion reaper reclaims work stranded by a crashed replica; your handler has to be idempotent in exchange, which is the right trade for financial actions and compliance jobs. Switching is a wiring change in <code>main.go</code> — no application logic moves.</p>
+
+<p><strong>Events are a third trigger.</strong> Neither a waiting caller nor a clock is required — another system can start the work on the same machinery. The bundled <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/event-driven-agent">event-driven-agent</a> receives Prometheus AlertManager webhooks and turns critical alerts into AI-driven incident investigations, with severity routing and fingerprint deduplication deciding in ordinary code which alerts are worth a model call at all, and human approval gating the destructive writes an investigation might propose. That pattern differs enough from request-response agents to warrant its own treatment.</p>
+
+<p><strong>Working examples.</strong> <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/agent-with-async">agent-with-async</a> demonstrates API mode, worker mode, and embedded mode. <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/scheduler-tool">scheduler-tool</a> and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/scheduled-executor">scheduled-executor</a> make up the complete scheduling stack, and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/event-driven-agent">event-driven-agent</a> runs the webhook path in the same three modes.</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/orchestration/ASYNC_ORCHESTRATION_GUIDE.md">Async Orchestration Guide</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/orchestration/SCHEDULED_TASKS_GUIDE.md">Scheduled Tasks Guide</a>.</p>
 
 <h3 id="hitl">9. Human-in-the-loop</h3>
 
-<p>Some decisions are too consequential for an agent to make alone — placing a financial trade, deleting production data, sending mass communications, approving a refund above a threshold, executing infrastructure changes against a live cluster. Regulated industries also require human approval points as a compliance control. TruvaG3 ships a complete <strong>Human-in-the-loop (HITL)</strong> system that pauses an in-flight request at well-defined moments, persists the execution state, notifies a reviewer, and resumes — or aborts — based on the reviewer's decision. The agent's request path stays continuous from the user's perspective even when a human takes minutes or hours to respond.</p>
+<p>Some decisions are too consequential for an agent to make alone — placing a trade, deleting production data, sending mass communications, approving a refund above a threshold, changing infrastructure on a live cluster. Regulated industries require approval points as a compliance control regardless. TruvaG3 pauses an in-flight request at a defined moment, persists the execution state, notifies a reviewer, and resumes or aborts on their decision. From the user's side the request stays continuous, even when the human takes hours.</p>
 
-<p><strong>Five interrupt points cover every decision moment.</strong> The orchestrator can pause at any of these — chosen by policy, not hard-coded:</p>
+<p><strong>Five interrupt points, chosen by policy rather than hardcoded.</strong> The orchestrator can pause right after a plan is generated, so a reviewer sees the whole DAG before anything runs; before a specific step, to gate individual writes to a sensitive system while reads pass freely; after a step, so the decision is made on the actual result rather than the intent; on an error the framework cannot recover from; or to gather context the agent cannot obtain on its own.</p>
 
-<ul>
-  <li><strong><code>plan_generated</code></strong> — pause right after the LLM produces a plan, before any step runs. The reviewer sees the entire DAG and can approve, edit, or reject. Useful for high-stakes workflows where the <em>whole shape</em> of the action matters.</li>
-  <li><strong><code>before_step</code></strong> — pause before a specific step executes. Useful for fine-grained control: approve every individual write to a sensitive system while letting reads pass freely.</li>
-  <li><strong><code>after_step</code></strong> — pause after a step completes but before the orchestrator continues to the next phase. The reviewer sees the actual result, not just the intent, and can decide whether to proceed. Useful when the next decision depends on what the previous step actually returned.</li>
-  <li><strong><code>on_error</code></strong> — escalate to a human when a step fails in a way the framework's automatic recovery cannot handle. Default action is to abort the workflow, since errors that reach this point are usually genuinely unrecoverable.</li>
-  <li><strong><code>context_gathering</code></strong> — pause to ask the reviewer for information the agent cannot obtain on its own (a missing identifier, a free-text justification, a policy override).</li>
-</ul>
+<figure id="fig-hitl-points">
+<svg viewBox="0 0 760 300" xmlns="http://www.w3.org/2000/svg"
+     style="width:100%;height:auto;display:block;margin:0 auto;background:#ffffff;border-radius:6px;border:1px solid #2a3550;"
+     role="img"
+     aria-label="The orchestration pipeline — plan, then two steps, then synthesize — with the five human-in-the-loop interrupt points marked as amber pause markers along it. plan_generated sits immediately after planning, so a reviewer sees the whole DAG before any step runs. before_step sits ahead of an individual step, to gate a single write while reads pass freely. after_step sits behind a step, so the decision is made on the actual result rather than the intent. on_error hangs below a step and fires when automatic recovery has failed, defaulting to abort. context_gathering hangs above planning and pauses to ask a human for something the agent cannot obtain on its own. Below the pipeline, the seven decisions a reviewer can return are listed as chips: approve, edit, retry, skip, respond, reject and abort, with the first five marked as continuing the workflow and the last two as ending it.">
+  <style>
+    .hp-box  { fill:#ffffff; stroke:#d0d7de; stroke-width:1.2; }
+    .hp-boxt { font:600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#1a1a1a; }
+    .hp-flow { stroke:#d0d7de; stroke-width:1.4; fill:none; }
+    .hp-pause{ fill:#fff8e6; stroke:#d9b35a; stroke-width:1.4; }
+    .hp-bar  { fill:#d9b35a; }
+    .hp-lbl  { font:600 10px ui-monospace, SFMono-Regular, Menlo, monospace; fill:#7a5a16; }
+    .hp-note { font:italic 9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#8c96a3; }
+    .hp-hdr  { font:700 9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0.7px; fill:#8c96a3; }
+    .hp-go   { fill:#e8f6ee; stroke:#3fa96b; stroke-width:1.2; }
+    .hp-stop { fill:#fdecea; stroke:#c0392b; stroke-width:1.2; }
+    .hp-got  { font:600 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#256b45; }
+    .hp-stopt{ font:600 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#a33125; }
+    .hp-tie  { stroke:#d9b35a; stroke-width:1; stroke-dasharray:3,3; }
+  </style>
+  <defs>
+    <marker id="hp-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0,0 L10,5 L0,10 z" fill="#d0d7de"/>
+    </marker>
+  </defs>
 
-<p><strong>Seven decision types — not just "yes" or "no".</strong> When a checkpoint fires, the reviewer responds with one of:</p>
+  <text x="30" y="24" class="hp-hdr">WHERE THE ORCHESTRATOR CAN PAUSE</text>
 
-<ul>
-  <li><strong><code>approve</code></strong> — proceed as planned.</li>
-  <li><strong><code>edit</code></strong> — proceed with modifications. The reviewer can rewrite the plan, change step parameters, or tweak the response before it goes out. The orchestrator picks up the modified version and continues.</li>
-  <li><strong><code>reject</code></strong> — reject the proposed action. The workflow stops cleanly with a structured rejection response.</li>
-  <li><strong><code>skip</code></strong> — skip the current step and continue with the rest of the plan. Useful when one step is irrelevant but the rest of the workflow should still run.</li>
-  <li><strong><code>abort</code></strong> — stop the entire workflow immediately, no continuation.</li>
-  <li><strong><code>retry</code></strong> — retry the step with new parameters supplied by the reviewer. Useful for fixing a known issue the LLM did not anticipate.</li>
-  <li><strong><code>respond</code></strong> — supply the information the agent requested (for <code>context_gathering</code> interrupts).</li>
-</ul>
+  <!-- context_gathering above plan -->
+  <circle cx="96" cy="52" r="11" class="hp-pause"/>
+  <rect x="92.5" y="47" width="2.5" height="10" class="hp-bar"/>
+  <rect x="97" y="47" width="2.5" height="10" class="hp-bar"/>
+  <text x="114" y="50" class="hp-lbl">context_gathering</text>
+  <text x="114" y="62" class="hp-note">ask a human for what the agent cannot infer</text>
+  <line x1="96" y1="63" x2="96" y2="104" class="hp-tie"/>
 
-<p>This richness matters in practice. An approval workflow that only offers "approve" and "reject" forces a back-and-forth (reviewer rejects, agent regenerates, reviewer reviews again). With <code>edit</code> and <code>retry</code>, a reviewer can make a single-touch correction and let the workflow continue — turning a five-minute round-trip into a one-second adjustment.</p>
+  <!-- pipeline -->
+  <rect x="40"  y="104" width="112" height="52" rx="6" class="hp-box"/>
+  <text x="96"  y="135" text-anchor="middle" class="hp-boxt">Plan</text>
+  <rect x="248" y="104" width="104" height="52" rx="6" class="hp-box"/>
+  <text x="300" y="135" text-anchor="middle" class="hp-boxt">Step 1</text>
+  <rect x="424" y="104" width="104" height="52" rx="6" class="hp-box"/>
+  <text x="476" y="135" text-anchor="middle" class="hp-boxt">Step 2</text>
+  <rect x="600" y="104" width="120" height="52" rx="6" class="hp-box"/>
+  <text x="660" y="135" text-anchor="middle" class="hp-boxt">Synthesize</text>
 
-<p><strong>Persistent checkpoints with atomic claim.</strong> When an interrupt fires, the orchestrator saves a full <code>ExecutionCheckpoint</code> to a Redis-backed store: the current plan, all completed step results, the LLM context, the conversation history, and the interrupt reason. A reviewer's decision arrives — possibly minutes or hours later — through any channel: REST API, webhook callback, or SSE stream from a chat UI. The framework <strong>atomically claims</strong> the checkpoint before processing the command, so even if the same approval is submitted from two browser tabs by accident, only one command runs (<code>orchestration.hitl.claim_success_total</code> and <code>orchestration.hitl.claim_skipped_total</code> track claim outcomes).</p>
+  <line x1="152" y1="130" x2="188" y2="130" class="hp-flow" marker-end="url(#hp-a)"/>
+  <line x1="212" y1="130" x2="244" y2="130" class="hp-flow" marker-end="url(#hp-a)"/>
+  <line x1="352" y1="130" x2="388" y2="130" class="hp-flow" marker-end="url(#hp-a)"/>
+  <line x1="412" y1="130" x2="420" y2="130" class="hp-flow" marker-end="url(#hp-a)"/>
+  <line x1="528" y1="130" x2="596" y2="130" class="hp-flow" marker-end="url(#hp-a)"/>
 
-<p><strong>Auto-resume on timeout, fail-safe by default.</strong> Every checkpoint has an expiration TTL. When the TTL elapses without a decision, the framework runs a configurable <code>DefaultAction</code>:</p>
+  <!-- pause markers on the pipeline -->
+  <circle cx="200" cy="130" r="11" class="hp-pause"/>
+  <rect x="196.5" y="125" width="2.5" height="10" class="hp-bar"/>
+  <rect x="201" y="125" width="2.5" height="10" class="hp-bar"/>
+  <text x="200" y="98" text-anchor="middle" class="hp-lbl">plan_generated</text>
+  <text x="200" y="176" text-anchor="middle" class="hp-note">the whole DAG, before anything runs</text>
 
-<ul>
-  <li>The default <code>DefaultAction</code> is <code>reject</code> — fail-safe, the high-stakes action does not happen automatically.</li>
-  <li>For <code>on_error</code> escalation, the default is <code>abort</code> — workflow stops cleanly.</li>
-  <li>Both are overridable per deployment via <code>TRUVAG3_HITL_DEFAULT_ACTION</code> or per checkpoint via policy.</li>
-</ul>
+  <circle cx="400" cy="130" r="11" class="hp-pause"/>
+  <rect x="396.5" y="125" width="2.5" height="10" class="hp-bar"/>
+  <rect x="401" y="125" width="2.5" height="10" class="hp-bar"/>
+  <text x="400" y="98" text-anchor="middle" class="hp-lbl">after_step / before_step</text>
+  <text x="352" y="176" text-anchor="middle" class="hp-note">gate one write; judge the result</text>
 
-<p>The expiry processor scans expired checkpoints in batches; <code>orchestration.hitl.expiry_batch_size</code> and <code>orchestration.hitl.expiry_scan_duration_seconds</code> tell you whether the processor is keeping up.</p>
+  <!-- on_error below step 2 -->
+  <circle cx="476" cy="200" r="11" class="hp-pause"/>
+  <rect x="472.5" y="195" width="2.5" height="10" class="hp-bar"/>
+  <rect x="477" y="195" width="2.5" height="10" class="hp-bar"/>
+  <line x1="476" y1="156" x2="476" y2="189" class="hp-tie"/>
+  <text x="494" y="198" class="hp-lbl">on_error</text>
+  <text x="494" y="210" class="hp-note">automatic recovery gave up — defaults to abort</text>
 
-<p><strong>Webhook notification, pre-built.</strong> Reviewer notification is not the framework's problem — it ships a <code>WebhookInterruptHandler</code> that fires an HTTP POST to a configured URL the moment a checkpoint is created. From there, the integration layer (Slack, Teams, PagerDuty, an internal approval system, a custom dashboard) takes over. <code>orchestration.hitl.webhook_sent_total</code> tracks webhook delivery counts; <code>orchestration.hitl.webhook_duration_seconds</code> tracks the round-trip latency to the notification endpoint.</p>
+  <!-- decisions -->
+  <text x="30" y="246" class="hp-hdr">WHAT THE REVIEWER CAN SEND BACK</text>
+  <rect x="30"  y="256" width="404" height="32" rx="5" class="hp-go"/>
+  <text x="44"  y="277" class="hp-got">approve · edit · retry · skip · respond</text>
+  <text x="420" y="277" text-anchor="end" class="hp-note">workflow continues</text>
+  <rect x="446" y="256" width="284" height="32" rx="5" class="hp-stop"/>
+  <text x="460" y="277" class="hp-stopt">reject · abort</text>
+  <text x="716" y="277" text-anchor="end" class="hp-note">workflow ends</text>
+</svg>
+<figcaption><strong>Figure 12.</strong> <strong>Five places to stop, seven ways to answer.</strong> The green group is what makes this usable in practice: five of the seven replies keep the workflow alive, so a reviewer who spots a wrong parameter fixes it in place instead of rejecting and waiting for the agent to try again. Which points are armed is policy, not code — the same agent can gate every write in one deployment and nothing at all in another.</figcaption>
+</figure>
 
-<p><strong>Approval-latency metric — measure your human SLA.</strong> <code>orchestration.hitl.approval_latency_seconds</code> is the time from checkpoint creation to decision. This is the canonical "how fast does my human approver respond" metric, and it directly drives user-facing latency for HITL-gated workflows. A team running a 95th-percentile dashboard on this metric can prove (or disprove) compliance SLAs at any moment.</p>
+<p><strong>Seven decision types, not just yes and no.</strong> A reviewer can approve, reject, or abort — but also <em>edit</em> the plan or a step's parameters, <em>skip</em> an irrelevant step and let the rest run, <em>retry</em> with corrected parameters, or <em>respond</em> with information the agent asked for. This matters more than it sounds. An approval flow offering only approve and reject forces a round-trip: reject, regenerate, review again. With edit and retry, a reviewer makes a single-touch correction and the workflow continues — a five-minute round-trip becomes a one-second adjustment.</p>
 
-<p><strong>Working example in the cluster.</strong> The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/agent-with-human-approval">agent-with-human-approval</a> example demonstrates the complete pattern: SSE for real-time browser notification, a structured approval dialog, plan-level and step-level approval chained together, auto-resume on timeout, and edit support so the reviewer can rewrite a plan in one round-trip. It is the right starting point for any agent that needs human gating.</p>
+<p><strong>Checkpoints are persistent and atomically claimed.</strong> When an interrupt fires, the full execution state — plan, completed step results, LLM context, conversation history, interrupt reason — is saved to a Redis-backed store. An SSE stream can notify a chat UI immediately; the reviewer's decision can arrive hours later through a REST call or a webhook. The framework claims the checkpoint atomically before processing it, so an approval submitted twice from two browser tabs runs once.</p>
+
+<p><strong>Timeouts fail safe.</strong> Every checkpoint expires, and expiring without a decision defaults to reject — the high-stakes action does not happen automatically — or, for error escalations, to a clean abort. Both are overridable per deployment or per checkpoint.</p>
+
+<p>Notification remains an integration concern, so the framework ships a webhook handler that fires the moment a checkpoint is created and leaves delivery to Slack, Teams, PagerDuty, or an internal approval system. One metric is worth knowing by name: approval latency, from checkpoint creation to decision. It drives user-facing latency for every gated workflow, and a 95th-percentile dashboard on it either proves your compliance SLA or disproves it.</p>
+
+<p><strong>Working example.</strong> <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/agent-with-human-approval">agent-with-human-approval</a> demonstrates the complete pattern — SSE notification in the browser, a structured approval dialog, plan-level and step-level approval chained together, auto-resume on timeout, and edit support.</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/orchestration/HUMAN_IN_THE_LOOP_USER_GUIDE.md">Human-in-the-Loop User Guide</a>.</p>
 
 <h3 id="memory-and-context">10. Memory and context</h3>
 
-<p>A stateless agent starts every request from zero — it does not remember the user's last question, the answer it gave five minutes ago, the long-running investigation that other agents in the same domain have been working on, or the user's stated preferences. For some workflows that is fine. For chat agents, multi-step research, ongoing investigations, and assistant-style products it is not — context across requests is the difference between a helpful agent and an amnesiac one. TruvaG3 ships a three-tier memory system that covers everything from small per-component state to vector-backed semantic recall, with separate stores for shared agent memory and per-user memory so a single agent process can serve many users without leaking one user's facts to another.</p>
+<p>A stateless agent starts every request from zero. It does not remember the user's last question, the answer it gave five minutes ago, the investigation its peers have been running, or anything the user said they prefer. For some workloads that is fine. For chat agents, multi-step research, ongoing investigations, and assistant-style products it is the difference between helpful and amnesiac. TruvaG3 ships three tiers, with shared agent memory and per-user memory kept separate so one process can serve many users without leaking one user's facts into another's context.</p>
 
-<p><strong>Layer 1: Component key-value memory.</strong> A simple per-component <code>core.Memory</code> interface with <code>Get</code>, <code>Set</code>, <code>Delete</code>, and <code>Exists</code>. Useful for small local state — a session counter, a cached API response, a transient flag — that does not need to be shared across replicas. Two implementations ship: in-memory for tests and Redis-backed for production. Every operation is counted under <code>memory.operations</code> (labeled by op), with eviction activity under <code>memory.evictions</code>.</p>
+<figure id="fig-memory-scopes">
+<svg viewBox="0 0 760 318" xmlns="http://www.w3.org/2000/svg"
+     style="width:100%;height:auto;display:block;margin:0 auto;background:#ffffff;border-radius:6px;border:1px solid #2a3550;"
+     role="img"
+     aria-label="The three memory tiers, distinguished by who can see what. On the left, component key-value memory is scoped to a single replica: a small store inside one process, holding a session counter or a cached response, invisible to every other component. In the middle, shared agent memory is scoped to a domain: three agent boxes all read and write one store containing an episodic event log, a vector-backed knowledge store and activity coordination, which is how one agent announces it is investigating an order and another skips that work. On the right, per-user memory is scoped to one person across every agent: two separate user lanes each hold their own facts, summary and embeddings, with a solid divider between them indicating that one user's facts never enter another user's context, and a note that a single forget call erases a lane entirely.">
+  <style>
+    .mz-col  { fill:#ffffff; stroke:#d0d7de; stroke-width:1.2; }
+    .mz-hdr  { font:600 12.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#1a1a1a; }
+    .mz-scope{ font:700 8.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0.7px; fill:#a9862f; }
+    .mz-sub  { font:10px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#6e7781; }
+    .mz-inner{ fill:#f6f8fa; stroke:#d0d7de; stroke-width:1; }
+    .mz-store{ fill:#fff8e6; stroke:#d9b35a; stroke-width:1.2; }
+    .mz-user { fill:#fbfdff; stroke:#9ec5ff; stroke-width:1.2; }
+    .mz-t    { font:10.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#1a1a1a; }
+    .mz-tie  { stroke:#b8bcc2; stroke-width:1; stroke-dasharray:3,3; }
+    .mz-wall { stroke:#c0392b; stroke-width:1.6; stroke-dasharray:5,3; }
+    .mz-note { font:italic 9.5px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill:#8c96a3; }
+  </style>
 
-<p><strong>Layer 2: Shared agent memory.</strong> A richer store designed for agents that work in a shared domain — a fleet of DevOps agents investigating the same incident, a team of research agents covering related topics, a set of compliance agents tracking related policy changes. Three substores:</p>
+  <!-- column 1 -->
+  <rect x="24" y="30" width="222" height="252" rx="7" class="mz-col"/>
+  <text x="230" y="50" text-anchor="end" class="mz-scope">ONE REPLICA</text>
+  <text x="40" y="72" class="mz-hdr">Component KV</text>
+  <text x="40" y="88" class="mz-sub">get · set · delete · exists</text>
+  <rect x="44" y="104" width="182" height="96" rx="5" class="mz-inner"/>
+  <text x="135" y="126" text-anchor="middle" class="mz-t">one process</text>
+  <rect x="66" y="140" width="138" height="46" rx="4" class="mz-store"/>
+  <text x="135" y="159" text-anchor="middle" class="mz-t">session counter</text>
+  <text x="135" y="176" text-anchor="middle" class="mz-sub">cached response · a flag</text>
+  <text x="135" y="232" text-anchor="middle" class="mz-note">nothing outside this pod</text>
+  <text x="135" y="246" text-anchor="middle" class="mz-note">can read it</text>
 
-<ul>
-  <li><strong>Episodic events</strong> — append-only log of meaningful events: tool calls made, findings discovered, decisions taken. Backed by Redis in production, in-memory for tests.</li>
-  <li><strong>Knowledge store (vector-backed)</strong> — semantic search over learned facts and prior conclusions, with Qdrant as the reference vector backend. Fragments are stored (<code>memory.knowledge.fragments_stored</code>), searched (<code>memory.knowledge.search.success</code> / <code>memory.knowledge.search.errors</code>), and surface as relevant context in the prompt when a request comes in. The cache layer is instrumented separately: <code>memory.cache.hits</code> / <code>memory.cache.misses</code> tell you whether vector queries are hitting cache.</li>
-  <li><strong>Activity coordination</strong> — lightweight signals between concurrent agents so they do not duplicate work. Agent A announces "I am investigating order #1234," and Agent B sees the announcement and skips that work. Backed by Redis distributed locks with a TTL.</li>
-</ul>
+  <!-- column 2 -->
+  <rect x="268" y="30" width="222" height="252" rx="7" class="mz-col"/>
+  <text x="474" y="50" text-anchor="end" class="mz-scope">ONE DOMAIN</text>
+  <text x="284" y="72" class="mz-hdr">Shared agent memory</text>
+  <text x="284" y="88" class="mz-sub">episodic · knowledge · coordination</text>
+  <rect x="288" y="102" width="58" height="30" rx="4" class="mz-inner"/>
+  <text x="317" y="121" text-anchor="middle" class="mz-t">agent</text>
+  <rect x="350" y="102" width="58" height="30" rx="4" class="mz-inner"/>
+  <text x="379" y="121" text-anchor="middle" class="mz-t">agent</text>
+  <rect x="412" y="102" width="58" height="30" rx="4" class="mz-inner"/>
+  <text x="441" y="121" text-anchor="middle" class="mz-t">agent</text>
+  <line x1="317" y1="132" x2="360" y2="156" class="mz-tie"/>
+  <line x1="379" y1="132" x2="379" y2="156" class="mz-tie"/>
+  <line x1="441" y1="132" x2="398" y2="156" class="mz-tie"/>
+  <rect x="288" y="156" width="182" height="70" rx="5" class="mz-store"/>
+  <text x="379" y="176" text-anchor="middle" class="mz-t">episodic log · knowledge</text>
+  <text x="379" y="192" text-anchor="middle" class="mz-t">vectors · who-owns-what</text>
+  <text x="379" y="214" text-anchor="middle" class="mz-sub">one store, many agents</text>
+  <text x="379" y="248" text-anchor="middle" class="mz-note">“I am investigating order #1234”</text>
+  <text x="379" y="262" text-anchor="middle" class="mz-note">— so nobody else does</text>
 
-<p><strong>Reflection — periodic LLM-driven memory consolidation.</strong> Raw episodic events accumulate quickly. Left alone, they would make the knowledge store either too noisy (every event surfaces) or too sparse (only recent events surface). The framework ships an opt-in <code>ReflectionJob</code> that periodically reads episodic events older than a configurable threshold (default 7 days), summarizes them through the LLM into stable knowledge fragments, and stores the result in the vector-backed knowledge store. Each pass is wrapped in a <code>memory.reflection_pass</code> span; counters <code>memory.compaction.runs_total</code> and <code>memory.compaction.fragments_created</code>, plus the histogram <code>memory.compaction.duration_ms</code>, expose throughput and failures (<code>memory.compaction.reflection_errors</code>). The effect is similar to what a human team does in a retrospective — extract the durable lessons from the ephemeral activity, and move on.</p>
+  <!-- column 3 -->
+  <rect x="512" y="30" width="224" height="252" rx="7" class="mz-col"/>
+  <text x="720" y="50" text-anchor="end" class="mz-scope">ONE PERSON</text>
+  <text x="528" y="72" class="mz-hdr">Per-user memory</text>
+  <text x="528" y="88" class="mz-sub">extract · reconcile · recall</text>
+  <rect x="530" y="104" width="90" height="112" rx="5" class="mz-user"/>
+  <text x="575" y="124" text-anchor="middle" class="mz-t">user A</text>
+  <text x="575" y="147" text-anchor="middle" class="mz-sub">facts</text>
+  <text x="575" y="163" text-anchor="middle" class="mz-sub">summary</text>
+  <text x="575" y="179" text-anchor="middle" class="mz-sub">embeddings</text>
+  <line x1="628" y1="104" x2="628" y2="216" class="mz-wall"/>
+  <rect x="636" y="104" width="90" height="112" rx="5" class="mz-user"/>
+  <text x="681" y="124" text-anchor="middle" class="mz-t">user B</text>
+  <text x="681" y="147" text-anchor="middle" class="mz-sub">facts</text>
+  <text x="681" y="163" text-anchor="middle" class="mz-sub">summary</text>
+  <text x="681" y="179" text-anchor="middle" class="mz-sub">embeddings</text>
+  <text x="624" y="236" text-anchor="middle" class="mz-note">one process serves both; neither</text>
+  <text x="624" y="250" text-anchor="middle" class="mz-note">sees the other's facts, and</text>
+  <text x="624" y="264" text-anchor="middle" class="mz-note">forget() erases a lane whole</text>
 
-<p><strong>Layer 3: Per-user memory.</strong> For assistant-style agents that serve many users, the framework keeps a separate per-user memory store with three distinct stages, each instrumented:</p>
+  <text x="380" y="304" text-anchor="middle" class="mz-sub">All three attach to the request through pipeline hooks — recall before planning, extraction after synthesis</text>
+</svg>
+<figcaption><strong>Figure 13.</strong> <strong>Three tiers, three blast radii.</strong> The tiers are separated by who can read them, not by how they are stored. That separation is the load-bearing part: shared memory is deliberately wide, so agents working one incident stop duplicating each other, while the red divider on the right is what lets a single process serve thousands of users without one person's stated preferences leaking into another's answer.</figcaption>
+</figure>
 
-<ul>
-  <li><strong>Extraction</strong> — at the end of a conversation, an LLM call extracts candidate facts from what the user said (<code>user_memory.extraction</code> and <code>user_memory.extraction.llm</code> spans in the trace; <code>user_memory.remember.duration_ms</code> histogram).</li>
-  <li><strong>Reconciliation</strong> — each candidate fact is checked against existing facts about that user. The LLM classifies the relationship as one of four operations: <strong><code>ADD</code></strong> (new fact), <strong><code>UPDATE</code></strong> (refines an existing fact), <strong><code>CONTRADICT</code></strong> (replaces a now-wrong fact), or <strong><code>DUPLICATE</code></strong> (already known, discard). Tracked by <code>user_memory.reconciliation.operation</code> labeled by operation type. The contradict path is the most important one in practice — it lets the agent gracefully update its model of the user when they say "actually, never mind, I prefer X now."</li>
-  <li><strong>Recall</strong> — when a new request arrives, the framework runs five distinct recall paths in parallel and merges the results: <strong>identity</strong> (facts about who the user is), <strong>stable_namespace</strong> (facts tagged with stable identifiers), <strong>query</strong> (semantic match against the current request), <strong>summary</strong> (rolling user summary), and <strong>universal</strong> (facts that always apply). Each path is its own span — <code>user_memory.recall.{path}</code> in Jaeger — so you can see which paths contributed to a given response. Total recall latency is <code>user_memory.recall.duration_ms</code>.</li>
-</ul>
+<p><strong>Component key-value memory</strong> is the simple tier — get, set, delete, exists — for small local state like a session counter or a cached response that does not need to be shared across replicas. In-memory for tests, Redis for production.</p>
 
-<p>Per-user memory supports GDPR-style "forget" — a single API call removes every fact, embedding, and summary tied to a user ID. Important for any deployment that has users in regions with right-to-erasure laws.</p>
+<p><strong>Shared agent memory</strong> is for agents working a common domain — a fleet of DevOps agents on one incident, research agents covering related topics. An append-only episodic log records what happened; a vector-backed knowledge store, with Qdrant as the reference backend, surfaces learned facts as relevant context when a request arrives; and lightweight activity coordination keeps concurrent agents from duplicating work, so Agent A announces it is investigating order #1234 and Agent B moves on to something else.</p>
 
-<p><strong>Conversation history protection — three tiers, automatic by default.</strong> Chat agents accumulate messages across turns; left unmanaged, the conversation buffer eventually overflows the LLM's context window. TruvaG3 handles this transparently:</p>
+<p>Raw episodic events pile up fast, and left alone they make recall increasingly noisy while durable patterns remain hard to find. An opt-in reflection job periodically summarizes older events through the LLM and stores the resulting knowledge fragments for later recall. It is what a team does in a retrospective — extract the durable lessons from the ephemeral activity, and move on.</p>
 
-<ul>
-  <li><strong>Tier 1 (default)</strong> — token-budgeted enrichment. Raw turns flow through, with the framework tracking token estimates (<code>conversation_history.estimated_tokens</code>) and emitting <code>conversation_history.prepare</code> spans on every request.</li>
-  <li><strong>Tier 2 (opt-in)</strong> — recursive compaction. When a session grows past a configurable threshold, older turns are summarized into a rolling "earlier in this conversation..." block by the LLM, freeing budget for the live exchange. Compaction events are counted (<code>conversation_history.compactions.total</code>) and their duration tracked (<code>conversation_history.compaction.duration_ms</code>). A summary cache (<code>conversation_history.summary_cache.size</code>) prevents re-summarizing the same older turns on every request.</li>
-  <li><strong>Tier 3 (custom)</strong> — for teams with specific compaction rules (preserve every tool result, drop greetings, structure by topic), the <code>ConversationCompactor</code> interface lets you supply your own logic while reusing the rest of the pipeline.</li>
-</ul>
+<p><strong>Per-user memory</strong> runs in three stages. <em>Extraction</em> pulls candidate facts from what the user said. <em>Reconciliation</em> checks each against what is already known and classifies it as new, a refinement, a contradiction, or a duplicate. The contradiction path matters most because it lets an agent update itself gracefully when a user says, "Actually, never mind; I prefer X now." <em>Recall</em> then runs five paths in parallel on the next request and merges them, each with its own span so you can see which ones shaped a given answer. A single API call implements a GDPR-style forget operation, removing every fact, embedding, and summary tied to a user ID.</p>
 
-<p>Most teams never touch Tier 2 or 3 — Tier 1 with the default budget handles typical chat workloads. The system is layered so the work shows up only when the workload requires it.</p>
+<p><strong>Conversation history is protected automatically.</strong> By default the framework tracks a token budget and lets raw turns through; past a configurable threshold it recursively compacts older turns into a rolling summary, freeing budget for the live exchange. Teams with specific rules — preserve every tool result, drop greetings — can supply their own compactor. Most never need to.</p>
 
-<p><strong>Pipeline hooks are how memory connects to the request path.</strong> All three memory layers are wired into the orchestrator through pipeline hooks (see <a href="#extension-points">§13</a> for the four hook stages). Memory recall typically runs in a <code>BeforePlanningHook</code> (so recalled facts and conversation history enter the planning prompt); memory extraction typically runs in an <code>AfterSynthesisHook</code> (so facts learned during the request are persisted). This means memory is configurable per agent — a tool-only deployment can opt out entirely, a chat agent enables all three layers, and a regulated workflow can swap in a custom hook that audits every memory write.</p>
+<p>All three tiers connect to the request path through pipeline hooks (see <a href="#extension-points">§13</a>): recall before planning so facts enter the prompt, extraction after synthesis so what was learned gets persisted. Memory is therefore configurable per agent — a tool-only deployment opts out, a chat agent turns on all three, a regulated workflow swaps in a hook that audits every write.</p>
 
-<p><strong>Working examples in the cluster.</strong> The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent">travel-chat-agent</a> and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/devops-chat-agent">devops-chat-agent</a> both wire shared memory and per-user memory through pipeline hooks (see <code>UserMemoryBackend</code> / <code>BuildUserMemoryHooks</code> in their <code>chat_agent.go</code>). Their Jaeger traces show the full memory flow — recall paths firing on the request path, extraction firing after synthesis — exactly as described above.</p>
+<p><strong>Working examples.</strong> <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent">travel-chat-agent</a> and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/devops-chat-agent">devops-chat-agent</a> both wire shared and per-user memory through hooks; their traces show recall firing on the way in and extraction firing after synthesis.</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/memory/README.md">memory/README.md</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/AGENT_MEMORY_USER_GUIDE.md">Agent Memory User Guide</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md">Adding Context to Your Agent</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/CONVERSATION_HISTORY_GUIDE.md">Conversation History Guide</a>.</p>
 
 <h3 id="chat-agents">11. Chat agent reference pattern</h3>
 
-<p>Building a practical chat agent involves more than calling an LLM. The agent needs to stream responses (long answers must not block on a final newline), maintain session state (the user expects you to remember the previous turn), support multi-turn context without overflowing the context window, integrate with human-in-the-loop approval flows for sensitive actions, and survive page refreshes, network blips, and concurrent tabs. TruvaG3 ships a complete reference pattern that handles all of this. The pattern is exercised by the bundled chat agents (<a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent">travel-chat-agent</a>, <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/devops-chat-agent">devops-chat-agent</a>) and consumed by the bundled <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/chat-ui">chat-ui</a> frontend.</p>
+<p>A practical chat agent needs more than an LLM call. It has to stream, so a long answer does not block on a final newline. It has to keep session state, so the user's previous turn still exists. It has to carry multi-turn context without overflowing the window, route sensitive actions through approval, and survive page refreshes, network blips, and duplicate tabs. TruvaG3 ships a reference pattern that handles all of it, exercised by the bundled chat agents and consumed by the bundled chat UI.</p>
 
-<p><strong>Server-Sent Events stream eight distinct event types.</strong> Rather than streaming opaque token chunks, the chat pattern emits a typed event stream so the frontend always knows what kind of update it just received:</p>
+<p><strong>The event stream is typed, not a stream of opaque tokens.</strong> Eight Server-Sent Event types tell the frontend exactly what it just received: a new session ID, a human-readable status update ("Phase 2 of 3…"), a completed step with tool name and duration, a text chunk, token usage, a finish reason, a done event with total timing, and a structured error carrying a retryable flag. This is the difference between a chat UI that feels rough at the edges and one that feels finished — a frontend developer wires each event to a specific affordance instead of parsing message text and guessing at intent.</p>
 
-<ul>
-  <li><strong><code>session</code></strong> — new session created. Carries the session ID the client should attach to subsequent requests.</li>
-  <li><strong><code>status</code></strong> — progress update (e.g., <em>"Phase 2 of 3..."</em>, <em>"Analyzing weather data..."</em>). The frontend renders this as a spinner-with-context, not a blank loading state.</li>
-  <li><strong><code>step</code></strong> — a tool call completed. Carries the tool name, success flag, and duration. Power-user dashboards render the per-step execution; consumer UIs filter these out.</li>
-  <li><strong><code>chunk</code></strong> — a part of the AI's response text. Streamed token-by-token so the user sees the answer appearing as it generates.</li>
-  <li><strong><code>usage</code></strong> — token stats for the request (prompt, completion, total). Useful for showing cost transparency in admin UIs.</li>
-  <li><strong><code>finish</code></strong> — the stream is ending and here is why (<code>stop</code>, <code>length</code>, <code>tool_calls</code>, etc.).</li>
-  <li><strong><code>done</code></strong> — the request is complete. Carries the request ID and total duration so the frontend can show the final timing.</li>
-  <li><strong><code>error</code></strong> — something went wrong. Carries a structured error code, a human-readable message, and a retryable flag so the frontend can decide whether to surface a retry button.</li>
-</ul>
+<figure id="fig-chat-surface">
+<img src="https://assets.truvag3.dev/blogs/observability/tokyo-weather-chat-ui-footer.png" alt="The response metadata bar the bundled chat UI renders beneath every reply. A row of chips reports the tools used, the wall-clock duration, and the prompt, completion and total token counts for the request.">
+<figcaption><strong>Figure 14.</strong> <strong>What a typed event stream buys the frontend.</strong> Every chip here is a different SSE event the UI simply listened for — <code>step</code> for the tools, <code>done</code> for the timing, <code>usage</code> for the tokens — rather than a number the frontend had to parse out of a message or ask a second endpoint for. Rendered by the bundled <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/chat-ui">chat-ui</a> example.</figcaption>
+</figure>
 
-<p>This typed event surface is the difference between a chat UI that feels rough at the edges and one that feels polished. A frontend developer can wire each event type to a specific UI affordance without parsing message text or guessing at intent.</p>
+<p><strong>Sessions live in Redis with a sliding window.</strong> Each record carries the user ID, metadata, message history, and timings, under a configurable TTL and a maximum message count that evicts the oldest turns automatically. A per-user index and an active-session counter back the capacity dashboards, and a background cleanup job keeps the Redis footprint bounded.</p>
 
-<p><strong>Session storage with sliding-window history.</strong> Sessions are stored in Redis with a configurable TTL and a maximum-messages limit (when the message count exceeds the cap, the oldest messages are evicted automatically — a sliding window over the conversation). The session record carries the user ID, metadata, message history, and timing fields. Three Redis structures back this: the session record itself, a per-user index of that user's active sessions, and an active-session counter for capacity dashboards. A background cleanup process removes expired sessions on a schedule so the Redis footprint stays bounded.</p>
+<p><strong>Multi-turn context needs no handler code.</strong> The request body carries a session ID; the framework looks up that session's recent messages, packages them into orchestration metadata, and the conversation-history layer from <a href="#memory-and-context">§10</a> handles the rest.</p>
 
-<p><strong>Multi-turn context flows automatically into orchestration.</strong> A chat request body carries the session ID; the framework looks up that session's recent messages, packages them into orchestration metadata, and the conversation-history layer (see <a href="#memory-and-context">§10</a>) handles the rest — Tier 1 enrichment by default, Tier 2 compaction for long sessions. The agent's request handler does not have to do anything special; multi-turn just works.</p>
+<p><strong>Approvals resume inside the conversation.</strong> When a chat request hits a checkpoint (see <a href="#hitl">§9</a>), the session context is persisted alongside it. Hours later, when the reviewer approves, execution restarts <em>in the same session</em> — history intact, orchestrator picking up where it stopped, SSE events flowing to whichever client is currently watching. The user sees a continuous conversation; the operator gets a clean audit trail of who approved what.</p>
 
-<p><strong>HITL resume that preserves the conversation.</strong> When a chat request hits a human-in-the-loop checkpoint (see <a href="#hitl">§9</a>), the framework persists the session context alongside the checkpoint. Hours later, when the reviewer approves, the resume endpoint (<code>POST /hitl/resume/{checkpoint_id}</code>) restarts execution <em>inside the same chat session</em> — the orchestrator picks up where it left off, the conversation history is intact, and the SSE stream continues delivering events to whichever client is currently watching. The user sees a seamless conversation; the operator sees a clean audit trail of who approved what.</p>
-
-<p><strong>Frontend reference, ready to clone.</strong> The bundled <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/chat-ui">chat-ui</a> example ships several HTML frontends that consume the SSE event stream: a generic chat interface, a DevOps-styled chat (for the devops-chat-agent), a HITL approval dashboard, and a dashboard overview. They are deliberately plain HTML + vanilla JavaScript so they are easy to read and adapt — no framework lock-in, no build step. Any production chat product would replace them with a real frontend, but they are a complete starting point that exercises every event type and shows what good handling looks like.</p>
-
-<p><strong>Working examples in the cluster.</strong> travel-chat-agent and devops-chat-agent wire the full pattern end-to-end. Both expose <code>/chat/stream</code> (SSE) plus the session-management capabilities (<code>/chat/session</code>, <code>/chat/session/{id}</code>, <code>/chat/sessions</code>, etc.), use Redis-backed session stores, and integrate with HITL where applicable. devops-chat-agent specifically demonstrates the HITL-resume-in-chat flow, since most DevOps actions need human approval before touching production. The companion qa-agent is a non-streaming orchestration agent (<code>POST /query</code>) that drives autonomous test exploration — it shares the orchestration stack but does not use the SSE chat pattern.</p>
+<p><strong>Working examples.</strong> <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent">travel-chat-agent</a> and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/devops-chat-agent">devops-chat-agent</a> wire the full pattern, both exposing an SSE stream plus session management on Redis; devops-chat-agent specifically demonstrates approval resumption, since most operations against production need gating. The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/chat-ui">chat-ui</a> example ships several frontends — a generic chat, a DevOps-styled chat, an approval dashboard, and an overview — deliberately plain HTML and vanilla JavaScript with no build step, so they are easy to read and adapt.</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/CHAT_AGENT_GUIDE.md">Chat Agent Guide</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/memory-and-chat/CHAT_SESSION_MANAGEMENT_GUIDE.md">Chat Session Management Guide</a>.</p>
 
 <h3 id="security">12. Security and request propagation</h3>
 
-<p>The framework takes a deliberately small position on security: it does not replace your identity provider, your service mesh, your ingress controller, your network policies, or your secrets manager. Those tools exist, your platform team operates them, and they work on TruvaG3 components the same way they work on every other REST service in the cluster — because TruvaG3 components <em>are</em> REST services. What the framework adds on top of that is the small set of hooks and propagation points that an agent workload specifically needs: passing user tokens through a chain of agent and tool calls, attaching tenant and audit metadata that flows the same way, and protecting a handful of framework-internal headers from being accidentally overwritten.</p>
+<p>The framework takes a deliberately narrow role in security. It does not replace your identity provider, your service mesh, your ingress controller, your network policies, or your secrets manager. Those exist, your platform team runs them, and they work on TruvaG3 components the same way they work on every other REST service in the cluster — because TruvaG3 components <em>are</em> REST services. What the framework adds is the narrow set of things an agent workload specifically needs: getting a user's token through a chain of agent and tool calls, carrying tenant and audit metadata along the same path, and keeping its own headers from being clobbered.</p>
 
-<p><strong>Three ways to attach an OAuth Bearer token to outbound calls.</strong> The orchestrator can attach an <code>Authorization: Bearer ...</code> header to every tool and agent call it dispatches, with three resolution paths to suit different deployment shapes:</p>
+<p><strong>Three ways to attach a bearer token</strong> layer from least to most specific. An environment variable covers static service-to-service tokens. A config object covers a token loaded from a vault at startup. Per-request context injection covers user-token pass-through — the handler pulls the token off the incoming request, and every downstream call that request makes runs as the calling user. Per-request values override config, and config overrides environment. A thread-safe setter refreshes tokens at runtime: in-flight requests finish on the old token, while new requests pick up the new one without a restart or a synchronization gap.</p>
 
-<ul>
-  <li><strong>Environment variable</strong> — the simplest path. Set <code>TRUVAG3_OAUTH_TOKEN</code> at deploy time; every outbound call gets the token attached. Right for static service-to-service tokens.</li>
-  <li><strong>Config object</strong> — pass the token (or a token source) into the orchestrator at construction. Right when the token is loaded from a vault or a secret manager at startup.</li>
-  <li><strong>Per-request context injection</strong> — the most flexible path. The agent's HTTP handler extracts the user's token from the incoming request and passes it through Go's <code>context.Context</code>; the orchestrator uses that token for every downstream call this request makes. Right for user-token pass-through, where each request runs as the calling user.</li>
-</ul>
+<p><strong>Custom headers propagate the same way.</strong> Agent workloads almost always carry more than auth — a tenant ID for routing, a correlation ID for the audit trail, a feature-flag bucket. Config-level defaults apply to every outbound call; per-request values override them. The propagated-header field is excluded from the config struct's JSON serialization, so those values cannot leak into request logs or telemetry by accident.</p>
 
-<p>The three paths layer cleanly: per-request context overrides config, config overrides environment. Most deployments use a combination — for example, a default service token from env, with per-request user tokens overriding when present.</p>
+<p><strong>Nine headers are reserved.</strong> The orchestrator sets <code>Authorization</code> and <code>Content-Type</code>, plus seven <code>X-TruvaG3-*</code> headers identifying the request, step, plan, phase, originating agent, the top-level request in a chained call, and the owner of an ongoing investigation. If application code tries to propagate one of those names, the framework's value wins, so a stray propagation cannot silently break authentication, trace correlation, or approval resumption. None are hidden — a tool receiving them can use them for authorization or audit.</p>
 
-<p><strong>Runtime token refresh, no restart needed.</strong> Service tokens expire. When yours does, you call <code>SetOAuthToken(newToken)</code> on the orchestrator and every subsequent outbound call uses the new token. The implementation uses <code>atomic.Value</code> internally, so the refresh is thread-safe — in-flight requests already using the old token complete normally, and new requests get the new token, with no synchronization gap. Token refresh is a runtime operation, not a deploy.</p>
+<p>Secrets and configuration follow Kubernetes conventions — credentials from environment variables sourced from Secrets, non-sensitive settings from ConfigMaps — so whatever workflow you already run, from ExternalSecrets to Vault sidecars, works unchanged. Developer-facing surfaces are off by default: OpenAPI generation is opt-in because the document describes the component's full API, and the <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/operations/DEV_TOOLS_GUIDE.md#7-registry-viewer-overview">Registry Viewer</a> and <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/operations/DEV_TOOLS_GUIDE.md#part-1--swagger-ui-api-exploration">Swagger UI</a> belong behind the network, gateway, or mesh layer, like a database admin console.</p>
 
-<p><strong>Custom header propagation for tenant, audit, and correlation metadata.</strong> Agent workloads almost always need to carry context beyond the auth token — a tenant ID for multi-tenant routing, an audit correlation ID for compliance trails, a feature-flag bucket for A/B testing. The framework supports two layers:</p>
-
-<ul>
-  <li><strong>Config-level defaults</strong> — set <code>PropagatedHeaders</code> on the orchestrator config (e.g., <code>{"X-Tenant-ID": "acme", "X-Environment": "prod"}</code>) and every outbound call carries them. Useful for deployment-wide context.</li>
-  <li><strong>Per-request overrides</strong> — set headers on the request context via <code>WithPropagatedHeaders(ctx, ...)</code> and they override config-level defaults for that one request. Useful when each request has its own tenant or correlation context.</li>
-  <li><strong>Header field name protection</strong> — the JSON serialization of the config struct explicitly excludes <code>PropagatedHeaders</code> (the field is tagged <code>json:"-"</code>) so headers never leak into request logs or telemetry by accident.</li>
-</ul>
-
-<p><strong>Nine framework-internal headers are protected from overwriting.</strong> The orchestrator sets two standard HTTP headers and seven <code>X-TruvaG3-*</code> headers on every outbound call. These are reserved — even if a developer sets the same key in <code>PropagatedHeaders</code>, the framework's value wins. This prevents subtle breakage of authentication, trace correlation, or HITL resume:</p>
-
-<ul>
-  <li><code>Authorization</code> and <code>Content-Type</code> — reserved so a stray propagation cannot override the bearer token or the body format.</li>
-  <li><code>X-TruvaG3-Request-ID</code> — the orchestrator-assigned ID for this top-level request. Used for log and trace correlation end-to-end.</li>
-  <li><code>X-TruvaG3-Step-ID</code> — the specific step within the plan this call corresponds to. Tied to the per-step span in the trace.</li>
-  <li><code>X-TruvaG3-Agent-Name</code> — which agent originated the call. Useful for downstream RBAC checks.</li>
-  <li><code>X-TruvaG3-Phase-Number</code> — for multi-phase iterative plans, which phase this call belongs to.</li>
-  <li><code>X-TruvaG3-Plan-ID</code> — the plan this call is part of.</li>
-  <li><code>X-TruvaG3-Original-Request-ID</code> — for chained agent-to-agent calls, the request ID at the very top of the chain. Lets one trace cover the full fan-out.</li>
-  <li><code>X-TruvaG3-Investigation-Owner</code> — for shared-memory activity coordination, identifies which agent currently owns an ongoing investigation.</li>
-</ul>
-
-<p>Any of these headers arriving at a tool can be used for fine-grained authorization, audit logging, or correlation — none of them are framework-internal in the sense of being hidden.</p>
-
-<p><strong>Secrets and configuration follow Kubernetes conventions.</strong> API keys, OAuth tokens, and provider credentials are read from environment variables, sourced from Kubernetes Secrets. Non-sensitive configuration (registry URL, log level, feature toggles) is sourced from ConfigMaps. The framework imposes no special key-management system — whatever secrets workflow your platform team uses (ExternalSecrets, Sealed Secrets, Vault sidecars, plain Secrets) works without adaptation.</p>
-
-<p><strong>Developer-tool exposure is off by default.</strong> OpenAPI generation is disabled until you explicitly enable it, because the <code>/openapi.json</code> document describes the component's full API surface and most internal services do not need to expose that publicly. The <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/operations/DEV_TOOLS_GUIDE.md#7-registry-viewer-overview">Registry Viewer</a> and <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/operations/DEV_TOOLS_GUIDE.md#part-1--swagger-ui-api-exploration">Swagger UI</a> are developer tooling, not production endpoints — they should be protected at the network, gateway, or mesh layer just like a database admin console or a Prometheus query UI.</p>
-
-<p><strong>What this looks like end-to-end.</strong> A user request hits the agent's ingress with an Authorization header. The agent extracts the user's token, passes it through context, and calls a downstream tool. The orchestrator's outbound call carries: the user's Authorization token (per-request, from context), the tenant ID (config-level), the framework's request ID and step ID (protected). The tool authenticates the user via your existing identity provider, logs the request ID for audit, applies tenant-scoped authorization, and returns. Trace, logs, and audit data all correlate by the request ID. Nothing about this flow is framework-specific — it is the same pattern a well-built REST microservice deployment already uses.</p>
+<p><strong>End-to-end flow.</strong> A request hits the agent's ingress with an Authorization header. The agent extracts the user's token, passes it through context, and calls a downstream tool. The outbound call carries that token, the tenant ID from config, and the framework's request and step IDs. The tool authenticates against your existing identity provider, logs the request ID for audit, applies tenant-scoped authorization, and returns. Traces, logs, and audit data all correlate on the request ID. Nothing about that flow is framework-specific — it is what a well-built REST deployment already does.</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/operations/OAUTH_SECURITY_GUIDE.md">OAuth Security Guide</a>.</p>
 
 <h3 id="extension-points">13. Extension points</h3>
 
-<p>The framework exposes interfaces at the boundaries where teams are most likely to need replacement. Each is behind a Go interface with a default implementation. The main extension points, with examples from the bundled agents:</p>
+<p>The framework exposes interfaces at the boundaries where teams are most likely to need something different, each with a working default behind it.</p>
 
-<p><strong>Pipeline hooks.</strong> Per-stage middleware around the orchestration pipeline. Hooks let application code inject context, short-circuit processing, mutate plans, or post-process responses — without forking the framework. There are four stages:</p>
+<p><strong>Pipeline hooks</strong> are the main one — per-stage middleware around the orchestration pipeline, letting application code inject context, mutate plans, or post-process responses without forking anything. There are four stages. <code>BeforePlanning</code> runs before the planner and is the only stage that can short-circuit the whole pipeline, which is how a semantic cache returns an answer without calling the LLM at all; it is also where RAG context and conversation history get injected. <code>AfterPlanning</code> can validate or rewrite a plan before execution. <code>AfterExecution</code> is observe-only, for analytics and audit logging. <code>AfterSynthesis</code> is where PII redaction, content policy checks, and memory writes go. A failing hook logs a warning and the pipeline continues.</p>
 
-<ul>
-  <li><strong><code>BeforePlanningHook</code></strong> — runs before the planner. Inject RAG context, conversation history, or a semantic-cache lookup. The only stage that can short-circuit the entire pipeline (return a cached response without calling the LLM at all).</li>
-  <li><strong><code>AfterPlanningHook</code></strong> — runs after the LLM produces a plan. Mutate or validate the plan before execution.</li>
-  <li><strong><code>AfterExecutionHook</code></strong> — runs after all tool calls finish. Observe-only — used for analytics, audit logging, and metrics.</li>
-  <li><strong><code>AfterSynthesisHook</code></strong> — runs after the final response is generated. Apply PII redaction, content policy checks, or write the response into memory.</li>
-</ul>
+<p><strong>Custom prompt builders</strong> replace prompt construction while preserving the orchestration interfaces — useful for compliance instructions, custom output formats, tenant-aware system messages, or domain-type rules that teach the planner your vocabulary.</p>
 
-<p>Hooks are resilient by design — a failing hook logs a warning and the pipeline continues. The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/travel-chat-agent">travel-chat-agent</a> and <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/devops-chat-agent">devops-chat-agent</a> examples wire memory hooks across these stages to give chat agents conversation history, semantic recall, and audit trails.</p>
+<p><strong>Every backend sits behind a Go interface.</strong> Discovery, LLM clients, component memory, async task queues and stores, scheduling stores and dispatchers, embedding clients, and the debug stores all have defaults that work out of the box and can be swapped without changing application code. In-memory and mock implementations ship for those most useful in tests, and a conformance package provides reusable contract suites so a replacement can be checked against the same expectations as the built-in one.</p>
 
-<p><strong>Custom prompt builders.</strong> Replace the prompt-construction logic while preserving orchestration interfaces. Useful for compliance instructions, custom output formats, or tenant-aware system messages. The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/agent-with-orchestration">agent-with-orchestration</a> example configures a custom prompt builder with travel-specific type rules so the planner understands domain types out of the box.</p>
-
-<p><strong>Pluggable backend interfaces.</strong> Every backend the framework relies on sits behind a Go interface. Defaults work out of the box; alternatives can be wired in without changing application code:</p>
-
-<ul>
-  <li><code>core.Discovery</code> — service registry (default: Redis or Valkey; in-memory mock ships for tests; other backends such as etcd or Consul require a user-written adapter against the same interface).</li>
-  <li><code>core.AIClient</code> and <code>core.AIRequestClient</code> — compact and presence-aware LLM provider contracts (clients are constructed from registered provider factories, typically registered through opt-in package imports; request-aware enterprise profiles, heterogeneous chain failover, and custom providers are also supported).</li>
-  <li><code>core.Memory</code> — per-component key-value memory (Redis in production, in-memory for tests).</li>
-  <li><code>core.TaskQueue</code> and <code>core.TaskStore</code> — async task backends (Redis lists by default; Redis Streams also bundled). The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/agent-with-async">agent-with-async</a> example wires the full request → task-ID → poll pattern on the default Redis backend.</li>
-  <li><code>core.ScheduleStore</code>, <code>core.TaskDispatcher</code>, <code>core.TaskConsumer</code> — scheduled-execution backends, used by the <a href="https://github.com/truvaagents/truva-g3/tree/main/examples/scheduled-executor">scheduled-executor</a> example.</li>
-  <li>Embedding client, LLM debug store, execution debug store — all behind interfaces with default implementations.</li>
-</ul>
-
-<p>The framework ships in-memory or mock implementations for discovery, component memory, and many memory-related contracts; tests can supply small fakes for the remaining interfaces. The <code>core/conformance</code> package currently provides reusable contract suites for <code>TaskConsumer</code> implementations and for the shared AI option and JSON-value cloning rules.</p>
-
-<p><strong>Custom result processors.</strong> The <code>ResultProcessor</code> interface controls how large tool and agent results are trimmed before they enter LLM prompts. The default <code>StructuralTrimmer</code> preserves JSON structure, key names, and representative samples within byte budgets. Teams with domain-specific outputs (large clinical datasets, deeply nested telemetry payloads) can replace it behind the same interface.</p>
+<p><strong>Result processors</strong> control how large tool and agent results are trimmed before they enter LLM prompts. The default preserves JSON structure, key names, and representative samples within a byte budget; teams with domain-specific payloads — large clinical datasets, deeply nested telemetry — can replace it behind the same interface.</p>
 
 <p><em>Deep dive:</em> <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md">Adding Context to Your Agent</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/orchestration/LLM_PLANNING_PROMPT_GUIDE.md">LLM Planning Prompt Guide</a> · <a href="https://github.com/truvaagents/truva-g3/blob/main/docs/reference/API_REFERENCE.md">API Reference</a>.</p>
 </section>
@@ -1297,7 +1727,7 @@ response, _ := orchestrator.ProcessRequest(ctx,
 
 <p>The orchestrator discovers whatever capabilities are currently registered, asks the LLM for a plan, executes the plan as a DAG, and synthesizes the response. The agent's source code names no tool. Deploy a new tool five minutes later, and the same agent can use it on the next request — no code change, no redeploy.</p>
 
-<p>The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples">bundled examples</a> show the same agent picking different capabilities depending on the question. "Weather in Paris" routes to <code>get_current_weather</code> (served by <code>weather-tool-v2</code>); "stock price of Apple" routes to <code>stock_quote</code> (<code>stock-market-tool</code>); "Capital of Japan" routes to <code>get_country_info</code> (<code>country-info-tool</code>). No hardcoded routing — the LLM picks the capability from the live registry and the framework resolves it to the address.</p>
+<p>The <a href="https://github.com/truvaagents/truva-g3/tree/main/examples">bundled examples</a> show the same agent picking different capabilities depending on the question. "Weather in Paris" routes to <code>get_current_weather</code> (served by <code>weather-tool-v2</code>); "stock price of Apple" routes to <code>stock_quote</code> (<code>stock-market-tool</code>); "capital of Japan" routes to <code>get_country_info</code> (<code>country-info-tool</code>). No hardcoded routing — the LLM picks the capability from the live registry and the framework resolves it to the address.</p>
 
 <h3 id="code-agent-to-agent">One agent calling another</h3>
 
@@ -1325,7 +1755,7 @@ response, _ := orchestrator.ProcessRequest(ctx,
 </ul>
 </section>
 
-<p class="footer-note">TruvaG3 is open source. The source code, the example deployments, the design notes, and the registry viewer are all public. Feedback, issues, and contributions are welcome.</p>
+<p class="footer-note">TruvaG3 is open source. The source code, the example deployments, the design notes, and the Registry Viewer are all public. Feedback, issues, and contributions are welcome.</p>
 
 <p class="copyright">© 2026 <a href="https://github.com/itsneelabh">Neelabh Tripathi</a>. Licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
 
@@ -1334,6 +1764,97 @@ response, _ := orchestrator.ProcessRequest(ctx,
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-go.min.js"></script>
 
+
+<script>
+(function () {
+  var triggers = document.querySelectorAll('article figure > img, article figure > svg');
+  if (!triggers.length) return;
+  var lb = document.createElement('div');
+  lb.className = 'img-lightbox';
+  lb.hidden = true;
+  lb.setAttribute('role', 'dialog');
+  lb.setAttribute('aria-modal', 'true');
+  lb.setAttribute('aria-label', 'Expanded figure');
+  var btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'lb-close';
+  btn.setAttribute('aria-label', 'Close expanded figure');
+  btn.innerHTML = '&times;';
+  var viewport = document.createElement('div');
+  viewport.className = 'lb-viewport';
+  var pic = document.createElement('img');
+  pic.alt = '';
+  viewport.appendChild(pic);
+  var hint = document.createElement('div');
+  hint.className = 'lb-hint';
+  hint.id = 'lb-hint';
+  hint.textContent = 'Click the figure, use the close button, or press Esc';
+  lb.setAttribute('aria-describedby', hint.id);
+  lb.appendChild(btn);
+  lb.appendChild(viewport);
+  lb.appendChild(hint);
+  document.body.appendChild(lb);
+  var previousFocus = null;
+  var objectURL = '';
+  function openLb(trigger) {
+    previousFocus = trigger;
+    pic.alt = trigger.getAttribute('alt') || trigger.getAttribute('aria-label') || '';
+    if (trigger.tagName.toLowerCase() === 'svg') {
+      var serialized = new XMLSerializer().serializeToString(trigger);
+      objectURL = URL.createObjectURL(new Blob([serialized], { type: 'image/svg+xml' }));
+      pic.className = 'lb-svg';
+      pic.src = objectURL;
+    } else {
+      pic.className = 'lb-raster';
+      pic.src = trigger.currentSrc || trigger.src;
+    }
+    lb.hidden = false;
+    lb.classList.add('open');
+    document.documentElement.style.overflow = 'hidden';
+    btn.focus();
+  }
+  function closeLb() {
+    if (!lb.classList.contains('open')) return;
+    lb.classList.remove('open');
+    lb.hidden = true;
+    pic.removeAttribute('src');
+    pic.removeAttribute('class');
+    if (objectURL) {
+      URL.revokeObjectURL(objectURL);
+      objectURL = '';
+    }
+    document.documentElement.style.overflow = '';
+    if (previousFocus) previousFocus.focus();
+    previousFocus = null;
+  }
+  triggers.forEach(function (trigger) {
+    var description = trigger.getAttribute('alt') || trigger.getAttribute('aria-label') || 'figure';
+    trigger.setAttribute('data-lightbox-trigger', '');
+    trigger.setAttribute('tabindex', '0');
+    trigger.setAttribute('role', 'button');
+    trigger.setAttribute('aria-label', 'Expand figure. ' + description);
+    trigger.addEventListener('click', function () { openLb(trigger); });
+    trigger.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openLb(trigger);
+      }
+    });
+  });
+  btn.addEventListener('click', closeLb);
+  lb.addEventListener('click', function (e) {
+    if (e.target === lb || e.target === pic) closeLb();
+  });
+  document.addEventListener('keydown', function (e) {
+    if (!lb.classList.contains('open')) return;
+    if (e.key === 'Escape') closeLb();
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      btn.focus();
+    }
+  });
+})();
+</script>
 
 <script src="/assets/js/toc-rail.js"></script>
 </body>

--- a/www/sitemap.xml
+++ b/www/sitemap.xml
@@ -22,7 +22,7 @@
   </url>
   <url>
     <loc>https://truvag3.dev/blogs/truvag3-introduction</loc>
-    <lastmod>2026-05-22T14:13:39-05:00</lastmod>
+    <lastmod>2026-07-29</lastmod>
   </url>
   <url>
     <loc>https://truvag3.dev/</loc>


### PR DESCRIPTION
## Summary

- revise the TruvaG3 introduction into a shorter, more scannable technical tour
- add and refine architecture diagrams, captions, image zooming, mobile SVG handling, and keyboard-accessible lightbox behavior
- add an early fit/non-fit summary for new readers and simplify wording for an international technical audience
- correct the SSE approval flow and async delivery-semantics explanations
- remove unsupported payload-accuracy percentages and update the sitemap date

## Why

The introduction had accumulated reference-level detail that made the main architecture and operational story difficult for new readers to follow. The update preserves technical depth while providing clearer navigation, visual explanations, and links to the detailed guides.

It also corrects wording that could imply SSE carries reviewer decisions and aligns the scheduling diagram with the documented at-most-once and at-least-once idempotency trade-offs.

## Impact

This changes only the static marketing site. It does not change framework behavior, APIs, or deployment configuration.

## Validation

- `git diff --check`
- inline JavaScript syntax validation with Node.js
- sitemap validation with `xmllint`
- fragment-target and duplicate-ID checks
- sequential figure and image-alt checks
- local HTTP 200 responses for the article and sitemap
