### PR TITLE
chore(release): stage v0.4.0 module references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,28 @@ jobs:
               exit 1
             fi
 
-            module_name="${module_path#github.com/truvaagents/truva-g3/}"
-            release_tag="${module_name}/${module_version}"
-            if git ls-remote --exit-code --tags "$repository_url" "refs/tags/${release_tag}" >/dev/null 2>&1; then
-              echo "::error::go.work still replaces ${module_path} ${module_version}, but ${release_tag} is already published"
-              exit 1
+            if [[ "$module_path" == "github.com/truvaagents/truva-g3" ]]; then
+              release_tag="${module_version}"
+            else
+              module_name="${module_path#github.com/truvaagents/truva-g3/}"
+              release_tag="${module_name}/${module_version}"
             fi
+
+            git ls-remote --exit-code --tags "$repository_url" "refs/tags/${release_tag}" >/dev/null 2>&1 && ls_status=0 || ls_status=$?
+            case "$ls_status" in
+              0)
+                echo "::error::go.work still replaces ${module_path} ${module_version}, but ${release_tag} is already published"
+                exit 1
+                ;;
+              2) ;; # Tag is absent, so the bootstrap replacement remains valid.
+              *)
+                echo "::error::could not determine whether ${release_tag} is published (git ls-remote exited ${ls_status})"
+                exit 1
+                ;;
+            esac
           done < <(
             go work edit -json |
-              jq -r '.Replace[]? | select(.Old.Path | startswith("github.com/truvaagents/truva-g3/")) | [.Old.Path, (.Old.Version // "")] | @tsv'
+              jq -r '.Replace[]? | select(.Old.Path == "github.com/truvaagents/truva-g3" or (.Old.Path | startswith("github.com/truvaagents/truva-g3/"))) | [.Old.Path, (.Old.Version // "")] | @tsv'
           )
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release-state:
+    name: release state
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.work
+      - name: Verify local workspace resolution and release bootstraps
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          while IFS= read -r workspace_dir; do
+            module_path="$(cd "$workspace_dir" && GOWORK=off go list -m -f '{{.Path}}')"
+            resolved_dir="$(go list -m -f '{{.Dir}}' "$module_path")"
+            resolved_dir="$(cd "$resolved_dir" && pwd -P)"
+            expected_dir="$(cd "$workspace_dir" && pwd -P)"
+            if [[ "$resolved_dir" != "$expected_dir" ]]; then
+              echo "::error::${module_path} resolved to ${resolved_dir}; expected local workspace directory ${expected_dir}"
+              exit 1
+            fi
+          done < <(go work edit -json | jq -r '.Use[].DiskPath')
+
+          repository_url="https://github.com/${GITHUB_REPOSITORY}.git"
+          while IFS=$'\t' read -r module_path module_version; do
+            [[ -n "$module_path" ]] || continue
+            if [[ -z "$module_version" ]]; then
+              echo "::error::first-party workspace replacement for ${module_path} must be version-scoped"
+              exit 1
+            fi
+
+            module_name="${module_path#github.com/truvaagents/truva-g3/}"
+            release_tag="${module_name}/${module_version}"
+            if git ls-remote --exit-code --tags "$repository_url" "refs/tags/${release_tag}" >/dev/null 2>&1; then
+              echo "::error::go.work still replaces ${module_path} ${module_version}, but ${release_tag} is already published"
+              exit 1
+            fi
+          done < <(
+            go work edit -json |
+              jq -r '.Replace[]? | select(.Old.Path | startswith("github.com/truvaagents/truva-g3/")) | [.Old.Path, (.Old.Version // "")] | @tsv'
+          )
+
   test:
     name: test
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     name: docusaurus build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7

--- a/ai/go.mod
+++ b/ai/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.57.4
 	github.com/aws/smithy-go v1.27.8
 	github.com/stretchr/testify v1.12.1
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 )

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -14041,9 +14041,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -50,6 +50,7 @@
     "node": ">=20.0"
   },
   "overrides": {
+    "nanoid": "3.3.18",
     "serialize-javascript": "^7.0.5",
     "uuid": "^11.1.1"
   }

--- a/docs/building/AGENT_DEVELOPMENT_GUIDE.md
+++ b/docs/building/AGENT_DEVELOPMENT_GUIDE.md
@@ -1832,10 +1832,10 @@ go 1.27.0
 
 require (
     github.com/google/uuid v1.6.0
-    github.com/truvaagents/truva-g3/ai v0.3.0
-    github.com/truvaagents/truva-g3/core v0.3.0
-    github.com/truvaagents/truva-g3/orchestration v0.3.0
-    github.com/truvaagents/truva-g3/telemetry v0.3.0
+    github.com/truvaagents/truva-g3/ai v0.4.0
+    github.com/truvaagents/truva-g3/core v0.4.0
+    github.com/truvaagents/truva-g3/orchestration v0.4.0
+    github.com/truvaagents/truva-g3/telemetry v0.4.0
     go.opentelemetry.io/otel v1.45.0
 )
 
@@ -1854,7 +1854,7 @@ Those are the minimum framework modules for this orchestration example.
 `memory.ReflectionJob` must add the matching module and local replacement:
 
 ```go
-require github.com/truvaagents/truva-g3/memory v0.3.0
+require github.com/truvaagents/truva-g3/memory v0.4.0
 
 replace github.com/truvaagents/truva-g3/memory => ../../memory
 ```

--- a/docs/building/TOOL_DEVELOPMENT_GUIDE.md
+++ b/docs/building/TOOL_DEVELOPMENT_GUIDE.md
@@ -1106,9 +1106,9 @@ module github.com/truvaagents/truva-g3/examples/your-tool
 go 1.27.0
 
 require (
-    github.com/truvaagents/truva-g3/core v0.9.1
-    github.com/truvaagents/truva-g3/telemetry v0.9.1
-    go.opentelemetry.io/otel v1.38.0
+    github.com/truvaagents/truva-g3/core v0.4.0
+    github.com/truvaagents/truva-g3/telemetry v0.4.0
+    go.opentelemetry.io/otel v1.45.0
 )
 
 // Use local workspace modules for development
@@ -1118,7 +1118,9 @@ replace (
 )
 ```
 
-> **Note:** The `require` versions (e.g., `v0.9.1`) don't matter when `replace` directives are active — Go uses the local paths. The versions are there for when the module is consumed from a registry without replace directives.
+> **Note:** The `replace` directives make local development use the workspace
+> copies. The declared versions still matter for standalone builds, including
+> the Dockerfile below, so they must name published framework releases.
 
 ### Dockerfile (standalone)
 

--- a/examples/agent-example/go.mod
+++ b/examples/agent-example/go.mod
@@ -4,9 +4,9 @@ go 1.27.0
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 )
 
 // Use local workspace modules for development

--- a/examples/agent-with-async/go.mod
+++ b/examples/agent-with-async/go.mod
@@ -4,10 +4,10 @@ go 1.27.0
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 )
 
 require (

--- a/examples/agent-with-human-approval/go.mod
+++ b/examples/agent-with-human-approval/go.mod
@@ -5,10 +5,10 @@ go 1.27.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/agent-with-orchestration/go.mod
+++ b/examples/agent-with-orchestration/go.mod
@@ -4,10 +4,10 @@ go 1.27.0
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/agent-with-resilience/go.mod
+++ b/examples/agent-with-resilience/go.mod
@@ -4,10 +4,10 @@ go 1.27.0
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/resilience v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/resilience v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 )
 
 // Use local workspace modules for development

--- a/examples/agent-with-telemetry/README.md
+++ b/examples/agent-with-telemetry/README.md
@@ -865,9 +865,9 @@ If you have an existing agent based on [agent-example](../agent-example), follow
 **go.mod**:
 ```go
 require (
-    github.com/truvaagents/truva-g3/core v0.6.5
-    github.com/truvaagents/truva-g3/ai v0.6.5
-    github.com/truvaagents/truva-g3/telemetry v0.6.5  // Add this
+    github.com/truvaagents/truva-g3/core v0.4.0
+    github.com/truvaagents/truva-g3/ai v0.4.0
+    github.com/truvaagents/truva-g3/telemetry v0.4.0  // Add this
 )
 ```
 

--- a/examples/agent-with-telemetry/go.mod
+++ b/examples/agent-with-telemetry/go.mod
@@ -4,9 +4,9 @@ go 1.27.0
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/agentic-memory-tool/go.mod
+++ b/examples/agentic-memory-tool/go.mod
@@ -4,10 +4,10 @@ go 1.27.0
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/memory v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/memory v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/arxiv-tool/go.mod
+++ b/examples/arxiv-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/arxiv-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/clinical-trials-tool/go.mod
+++ b/examples/clinical-trials-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/clinical-trials-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/confluence-tool/go.mod
+++ b/examples/confluence-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/confluence-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/country-info-tool/go.mod
+++ b/examples/country-info-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/country-info-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/currency-global-tool/go.mod
+++ b/examples/currency-global-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/currency-global-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/currency-tool/go.mod
+++ b/examples/currency-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/currency-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.45.0
 )

--- a/examples/demographics-tool/go.mod
+++ b/examples/demographics-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/demographics-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/devops-chat-agent/go.mod
+++ b/examples/devops-chat-agent/go.mod
@@ -5,11 +5,11 @@ go 1.27.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/memory v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/memory v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/devops-observability-tool/go.mod
+++ b/examples/devops-observability-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/devops-observability-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/devops-tool/go.mod
+++ b/examples/devops-tool/go.mod
@@ -4,8 +4,8 @@ go 1.27.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/economic-data-tool/go.mod
+++ b/examples/economic-data-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/economic-data-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/event-driven-agent/go.mod
+++ b/examples/event-driven-agent/go.mod
@@ -4,11 +4,11 @@ go 1.27.0
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/memory v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/memory v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 )

--- a/examples/fiscal-data-tool/go.mod
+++ b/examples/fiscal-data-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/fiscal-data-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/flight-tool/go.mod
+++ b/examples/flight-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/flight-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/geocoding-tool/go.mod
+++ b/examples/geocoding-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/geocoding-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.45.0
 )

--- a/examples/github-pr-review-agent/go.mod
+++ b/examples/github-pr-review-agent/go.mod
@@ -5,11 +5,11 @@ go 1.27.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/memory v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/memory v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 )

--- a/examples/github-tool/go.mod
+++ b/examples/github-tool/go.mod
@@ -4,8 +4,8 @@ go 1.27.0
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/grocery-tool/go.mod
+++ b/examples/grocery-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/grocery-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/hotel-tool/go.mod
+++ b/examples/hotel-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/hotel-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/jira-tool/go.mod
+++ b/examples/jira-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/jira-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/my-async-agent/go.mod
+++ b/examples/my-async-agent/go.mod
@@ -3,10 +3,10 @@ module github.com/truvaagents/truva-g3/examples/my-async-agent
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 )
 
 // Use local workspace modules for development

--- a/examples/my-streaming-agent/go.mod
+++ b/examples/my-streaming-agent/go.mod
@@ -3,10 +3,10 @@ module github.com/truvaagents/truva-g3/examples/my-streaming-agent
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 )
 
 // Use local workspace modules for development

--- a/examples/my-tool/go.mod
+++ b/examples/my-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/my-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 )
 
 // Use local workspace modules for development

--- a/examples/news-tool/go.mod
+++ b/examples/news-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/news-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.45.0
 )

--- a/examples/openclaw-tool/go.mod
+++ b/examples/openclaw-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/openclaw-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/openfda-tool/go.mod
+++ b/examples/openfda-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/openfda-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/places-tool/go.mod
+++ b/examples/places-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/places-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/playwright-tool/go.mod
+++ b/examples/playwright-tool/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.0
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/prometheus-query-tool/go.mod
+++ b/examples/prometheus-query-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/prometheus-query-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/pubmed-tool/go.mod
+++ b/examples/pubmed-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/pubmed-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 	golang.org/x/time v0.9.0
 )

--- a/examples/qa-agent/go.mod
+++ b/examples/qa-agent/go.mod
@@ -4,11 +4,11 @@ go 1.27.0
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/memory v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/memory v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/registry-viewer-app/go.mod
+++ b/examples/registry-viewer-app/go.mod
@@ -4,10 +4,10 @@ go 1.27.0
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/memory v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/memory v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	golang.org/x/sync v0.22.0
 )
 

--- a/examples/scheduled-executor/go.mod
+++ b/examples/scheduled-executor/go.mod
@@ -4,9 +4,9 @@ go 1.27.0
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/scheduler-tool/go.mod
+++ b/examples/scheduler-tool/go.mod
@@ -4,10 +4,10 @@ go 1.27.0
 
 require (
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/memory v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/memory v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 )
 
 require (

--- a/examples/semantic-scholar-tool/go.mod
+++ b/examples/semantic-scholar-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/semantic-scholar-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/slack-tool/go.mod
+++ b/examples/slack-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/slack-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/stock-market-tool/go.mod
+++ b/examples/stock-market-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/stock-market-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/system-utilities-tool/go.mod
+++ b/examples/system-utilities-tool/go.mod
@@ -4,8 +4,8 @@ go 1.27.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/tool-example/go.mod
+++ b/examples/tool-example/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/tool-example
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/travel-advisory-tool/go.mod
+++ b/examples/travel-advisory-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/travel-advisory-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/travel-chat-agent/go.mod
+++ b/examples/travel-chat-agent/go.mod
@@ -5,12 +5,12 @@ go 1.27.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/ai v0.3.0
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/memory v0.3.0
-	github.com/truvaagents/truva-g3/orchestration v0.3.0
-	github.com/truvaagents/truva-g3/resilience v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/ai v0.4.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/memory v0.4.0
+	github.com/truvaagents/truva-g3/orchestration v0.4.0
+	github.com/truvaagents/truva-g3/resilience v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/weather-tool-v2/go.mod
+++ b/examples/weather-tool-v2/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/weather-tool-v2
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.45.0
 )

--- a/examples/web-search-tool/go.mod
+++ b/examples/web-search-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/web-search-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/examples/world-health-tool/go.mod
+++ b/examples/world-health-tool/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/examples/world-health-tool
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/truvaagents/truva-g3
 
 go 1.27.0
 
-require github.com/truvaagents/truva-g3/core v0.3.0
+require github.com/truvaagents/truva-g3/core v0.4.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.work
+++ b/go.work
@@ -9,3 +9,10 @@ use (
 	./resilience
 	./telemetry
 )
+
+// Temporary release bootstrap; remove after core/v0.4.0 and telemetry/v0.4.0
+// are published.
+replace (
+	github.com/truvaagents/truva-g3/core v0.4.0 => ./core
+	github.com/truvaagents/truva-g3/telemetry v0.4.0 => ./telemetry
+)

--- a/memory/ARCHITECTURE.md
+++ b/memory/ARCHITECTURE.md
@@ -453,9 +453,9 @@ NOT acceptable:
 module github.com/truvaagents/truva-g3/memory
 
 require (
-    github.com/truvaagents/truva-g3/core v0.1.0       // Required: interfaces and types
-    github.com/truvaagents/truva-g3/telemetry v0.1.0   // Allowed: observability
-    github.com/qdrant/go-client v1.17.0             // Qdrant gRPC client (Apache 2.0)
+    github.com/truvaagents/truva-g3/core v0.4.0        // Required: interfaces and types
+    github.com/truvaagents/truva-g3/telemetry v0.4.0   // Allowed: observability
+    github.com/qdrant/go-client v1.19.0                // Qdrant gRPC client (Apache 2.0)
 )
 ```
 

--- a/memory/go.mod
+++ b/memory/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/qdrant/go-client v1.19.0
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/stretchr/testify v1.12.1
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0

--- a/orchestration/ARCHITECTURE.md
+++ b/orchestration/ARCHITECTURE.md
@@ -209,8 +209,8 @@ Applications wire memory implementations into orchestration hooks at startup.
 module github.com/truvaagents/truva-g3/orchestration
 
 require (
-    github.com/truvaagents/truva-g3/core v0.1.0
-    github.com/truvaagents/truva-g3/telemetry v0.1.0  // Allowed for observability
+    github.com/truvaagents/truva-g3/core v0.4.0
+    github.com/truvaagents/truva-g3/telemetry v0.4.0  // Allowed for observability
     // NO direct imports of ai or resilience modules
 )
 ```

--- a/orchestration/go.mod
+++ b/orchestration/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.12.1
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0

--- a/resilience/go.mod
+++ b/resilience/go.mod
@@ -3,8 +3,8 @@ module github.com/truvaagents/truva-g3/resilience
 go 1.27.0
 
 require (
-	github.com/truvaagents/truva-g3/core v0.3.0
-	github.com/truvaagents/truva-g3/telemetry v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
+	github.com/truvaagents/truva-g3/telemetry v0.4.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/metric v1.45.0
 )

--- a/telemetry/go.mod
+++ b/telemetry/go.mod
@@ -5,7 +5,7 @@ go 1.27.0
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/redis/go-redis/v9 v9.22.0
-	github.com/truvaagents/truva-g3/core v0.3.0
+	github.com/truvaagents/truva-g3/core v0.4.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.45.0


### PR DESCRIPTION
## Summary

- stage every first-party framework and example dependency reference for v0.4.0
- update the tracked agent-development example to use v0.4.0
- keep pre-tag workspace and CI builds resolvable through version-scoped `go.work` replacements only
- pin `nanoid` 3.3.18 and bound the documentation build to 10 minutes

## Why v0.4.0

This release includes Agent Skills V1, request-aware Gemini, first-class OpenRouter support, AI transport hardening, Redis and Qdrant updates, and the Go 1.27 minimum. That scope warrants a pre-1.0 minor release rather than a patch.

## Validation

- all seven framework modules: `go vet`, `go build`, and `go test -race`
- repository Go sources: `goimports`
- all seven framework modules: `golangci-lint` and `gosec`
- all seven framework modules plus optional Bedrock: `govulncheck` 1.7.0
- all 53 example modules: CI-equivalent `go mod tidy && go build ./...` in an isolated copy
- Docusaurus production build
- `git diff --check`

## Dependency-risk disposition

The patchable `nanoid` alert is resolved by pinning 3.3.18.

Two high-severity `image-size` infinite-loop advisories remain transitively reachable through the Docusaurus MDX build loader. Upstream currently publishes no patched release. The dependency processes repository-controlled documentation images at build time; it is not shipped in the generated static site or any Go framework module. This PR bounds the GitHub documentation job to 10 minutes while the upstream fix is tracked. This residual build-time risk is explicitly accepted for the v0.4.0 release.

## Ordered release follow-up

This PR is the first staging step and creates no tags.
The remaining publication sequence is tracked as a blocking checklist in #106.

1. Merge this PR, then tag `core/v0.4.0` at the merge commit.
2. Remove the Core workspace bootstrap, resolve and tidy Telemetry against the published Core tag, merge, then tag `telemetry/v0.4.0`.
3. Remove the Telemetry workspace bootstrap, resolve and tidy the remaining framework modules against both published foundation tags, and run clean external-consumer smoke tests.
4. Tag `ai/v0.4.0`, `memory/v0.4.0`, `orchestration/v0.4.0`, `resilience/v0.4.0`, and root `v0.4.0`, then publish the GitHub release notes.
