### PR TITLE
fix: preserve execution lineage and improve observability

### DIFF
--- a/FRAMEWORK_DESIGN_PRINCIPLES.md
+++ b/FRAMEWORK_DESIGN_PRINCIPLES.md
@@ -1,6 +1,6 @@
 # TruvaG3 Framework Design Principles & Architecture Guidelines
 
-**Version**: 1.3
+**Version**: 1.6
 
 **Purpose**: Ensure consistency and maintainability across all framework development
 
@@ -111,6 +111,74 @@ agent.Run()                                // no way to replace one part without
 ```
 
 **Framework is domain-agnostic.** A corollary of "each module does its job" — the framework provides indexing primitives, storage interfaces, and hook contracts; **domain semantics come from the agent or its tools**. The framework has no opinion about what counts as a "pod", "order", "flight", or "patient". Hardcoding domain-specific patterns into framework defaults (e.g., a regex extractor that matches K8s pod names) is a layering violation: the framework default leaks into every agent regardless of whether it's actually a K8s agent. The right pattern is a framework-level no-op default that the agent or tool overrides with domain-aware logic. See [orchestration/ARCHITECTURE.md:367](orchestration/ARCHITECTURE.md#L367) for the same principle applied to parameter resolution.
+
+#### Payload Fidelity and Application Data Ownership
+
+The framework transports, executes, and records application data; it does not
+decide what that data means. An adopter must be able to inspect the exact input,
+output, error, and model interaction that passed through a local or deployed
+system. Framework-owned observability and persistence must therefore preserve
+application payload fidelity.
+
+1. **Do not silently rewrite application data.** Framework execution,
+   checkpoint, debug, persistence, and observability paths must not
+   automatically redact, mask, filter, summarize, or otherwise replace values
+   in application-owned parameters, prompts, model responses, tool responses,
+   final responses, metadata, or errors. A stored or displayed record must not
+   claim to represent an interaction while containing framework-altered
+   content.
+2. **Do not infer application secrets.** The framework must not maintain field
+   names, patterns, result codes, or heuristics that classify domain data as
+   sensitive. A value such as a proof, account reference, medical identifier,
+   or domain token has meaning only to the application that owns it.
+3. **Sanitization is adopter-owned behavior.** Applications that require
+   redaction or other data-loss prevention must apply it explicitly through
+   their chosen logger, telemetry pipeline, storage implementation, recorder,
+   middleware, or application processing hook. Existing injection interfaces
+   are the customization seam; the framework must not silently install a
+   sanitization policy on the adopter's behalf.
+4. **Configured transformation must be explicit.** If an adopter deliberately
+   supplies a transforming implementation, the transformation and its effect on
+   fidelity belong to that application configuration. A framework default must
+   remain identity-preserving.
+5. **Framework envelopes remain framework-owned.** Validation and normalization
+   of protocol fields such as request IDs, capability schemas, wire envelopes,
+   TTLs, and lifecycle state are still framework responsibilities. That does
+   not authorize mutation of the application payload carried by the envelope.
+6. **Raw debug persistence is an informed opt-in.** Built-in debug stores are
+   disabled by default where documented. When enabled, they preserve payloads
+   without application-specific redaction. Adopters are responsible for access
+   control, retention, encryption, and any required sanitizing store or recorder
+   before using those facilities with sensitive workloads.
+
+**Known transitional exceptions — pending dedicated audit.** Some framework
+call sites that predate this policy still transform error text automatically.
+The known categories are downstream tool/agent failure bodies and errors in the
+orchestration executor; skills AI errors returned by the authoring path or
+recorded for debugging; and selected Redis/provider construction or operational
+diagnostics. These are documented implementation facts, not approved extensions
+of the policy:
+
+- new persistence, execution, checkpoint, debug, or observability paths must
+  comply with the fidelity rules above immediately;
+- existing exception paths must not be copied, broadened, or treated as a
+  security guarantee for adopters;
+- `core.RedactSensitiveText` and `core.RedactSensitiveError` remain available as
+  explicit primitives, but framework defaults must not newly apply them to
+  application-owned content; and
+- removing the legacy calls requires a separate audit of retry decisions, Go
+  error identity, persisted evidence, returned observations, and log/trace
+  behavior. That audit must inventory every framework call site rather than
+  assuming the categories above are exhaustive.
+
+Until that audit is completed, documentation for an affected module must label
+the behavior as legacy and pending removal or redesign. It must not claim that
+the framework generally sanitizes adopter payloads or that adopters can rely on
+automatic redaction.
+
+Tests for execution and observability boundaries must assert this ownership:
+the value dispatched, the value returned, and the value recorded remain the
+same unless the test explicitly installs an adopter-provided transformation.
 
 #### Patterns That Endure
 
@@ -515,7 +583,15 @@ return fmt.Errorf("connection failed: %w", err)
 ## Security Considerations
 
 ### Secrets Management
-- Never log secrets or API keys
+- Framework code must not deliberately add framework-owned credentials to
+  logs, traces, errors, or persisted records.
+- Application payload classification and redaction belong to the adopter; the
+  framework must not guess which application fields are secrets or silently
+  alter application data at an observability boundary.
+- Built-in debug persistence may contain the exact application and model
+  payloads supplied to it. It must remain an informed opt-in, and its
+  documentation must state that the adopter owns access control, retention,
+  encryption, and sanitization requirements.
 - Support secret rotation without restart
 - Use secure defaults (TLS, authentication)
 
@@ -647,6 +723,9 @@ func (t *BaseTool) processRequest() {
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.6 | 2026-08-28 | Made the transitional redaction inventory explicitly include both returned skills-authoring AI errors and skills errors recorded for debugging |
+| 1.5 | 2026-08-28 | Recorded the narrowly scoped legacy error-redaction exceptions pending a dedicated audit without weakening the exact-payload end-state policy for new or modified paths |
+| 1.4 | 2026-08-28 | Established exact application-payload fidelity, prohibited framework-inferred domain secrets and automatic observability redaction, and assigned sanitization and debug-data controls to adopters |
 | 1.3 | 2026-08-20 | Defined application-composed circuit-breaker ownership across optional modules, per-dependency state isolation, and dependency-health classification boundaries |
 | 1.2 | 2026-08-09 | Defined the canonical framework-module DAG and extended its enforcement to production, test, and conformance code |
 | 1.1 | 2026-08-08 | Added safe-customization, invariant-boundary, and cache-identity principles |

--- a/ai/README.md
+++ b/ai/README.md
@@ -487,8 +487,8 @@ client, _ := ai.NewClient(ai.WithAPIKey(os.Getenv("OPENAI_API_KEY")))
 ```go
 response, err := client.GenerateResponse(ctx, prompt, options)
 if err != nil {
-    // Framework observation surfaces sanitize provider errors. Application
-    // logs should classify the error rather than copying a provider body.
+    // Classify the typed provider error instead of copying an arbitrary
+    // provider body into an application log.
     var providerErr core.ProviderError
     if errors.As(err, &providerErr) {
         log.Printf("AI request failed: provider=%s status=%d",
@@ -497,6 +497,12 @@ if err != nil {
     return fallbackResponse, nil
 }
 ```
+
+Some current provider adapters transform selected diagnostic messages before
+recording them. This is a legacy framework exception pending audit, not a
+general promise that returned errors, application logs, or debug records have
+been sanitized. Applications remain responsible for their own logging and data
+protection policy.
 
 3. **⏱️ Set appropriate timeouts**
 ```go

--- a/core/ARCHITECTURE.md
+++ b/core/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # TruvaG3 Core Module Architecture
 
-**Version**: 1.4
+**Version**: 1.5
 **Module**: `github.com/truvaagents/truva-g3/core`  
 **Purpose**: Foundation module architecture, contracts, and design principles  
 **Audience**: Core maintainers, module implementers, LLM coding agents
@@ -809,18 +809,26 @@ logger.Error("Provider request failed", map[string]interface{}{
 return err
 ```
 
-`RedactSensitiveText` is a dependency-free defense-in-depth helper for strings
-that cross log, trace, debug-record, or tool-result boundaries. It recognizes
-common authorization headers, credential assignments, secret-bearing URL user
-information, and credential query parameters while retaining useful diagnostic
-structure. It is not a substitute for avoiding secrets in URLs, payloads,
-prompts, and errors in the first place.
+`RedactSensitiveText` is a dependency-free, explicit, lossy transformation. An
+application or subsystem may choose it for a diagnostic field after deciding
+that reduced fidelity is appropriate. It recognizes common authorization
+headers, credential assignments, secret-bearing URL user information, and
+credential query parameters while retaining useful diagnostic structure. It is
+not a general secret detector, and the framework does not automatically apply
+it as a persistence or observability policy.
 
-When a sanitized error must cross an API boundary, `RedactSensitiveError`
-provides the same observable-message protection while implementing `Unwrap` so
-`errors.Is` and `errors.As` still reach the original cause. Use
-`RedactSensitiveText` for observation-only fields and `RedactSensitiveError`
-when error-chain control flow must survive sanitization.
+When an adopter explicitly chooses to return a transformed error,
+`RedactSensitiveError` provides the same observable-message transformation
+while implementing `Unwrap` so `errors.Is` and `errors.As` still reach the
+original cause. Use `RedactSensitiveText` for observation-only fields and
+`RedactSensitiveError` when error-chain control flow must survive that chosen
+transformation.
+
+Some legacy orchestration, skills, provider, and backend diagnostic paths still
+call these helpers automatically. They are documented exceptions pending a
+dedicated audit, not a security guarantee or a precedent for new framework
+paths. Built-in debug stores preserve the values they receive; applications own
+any required payload classification and sanitization.
 
 #### 2. **Input Validation**
 ```go
@@ -999,6 +1007,7 @@ their packages or vocabulary.
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.5 | 2026-08-29 | Clarified that redaction helpers are explicit adopter/subsystem transformations and documented the remaining automatic framework uses as legacy exceptions |
 | 1.4 | 2026-08-20 | Defined `AIOptions.ResponseFormat="json"` as the sole non-empty portable structured-output value and reserved native formats for `Extra` |
 | 1.3 | 2026-08-17 | Migrated the included Redis implementation to go-redis/v9 with explicit RESP2 compatibility defaults and application-owned RESP3 opt-in |
 | 1.2 | 2026-08-09 | Added generic provenance-aware pipeline short-circuit and named cache-variation contracts without changing legacy hook payloads |

--- a/core/README.md
+++ b/core/README.md
@@ -1384,15 +1384,20 @@ tool.RegisterCapability(core.Capability{
 - Works seamlessly with OpenTelemetry distributed tracing
 - Essential for debugging in production environments
 
-Keep original errors for control flow, but sanitize external/provider/backend
-errors before placing them in logs, traces, debug records, or tool responses.
-`core.RedactSensitiveText` removes common credential assignments,
-authorization values, and secret-bearing URL components while preserving useful
-diagnostic structure. It is defense in depth, so avoid putting raw prompts,
-payloads, endpoints, or credentials into errors in the first place.
-When returning an error across a framework boundary, use
-`core.RedactSensitiveError(err)` to sanitize its observable message without
-breaking `errors.Is` or `errors.As` inspection of the original cause.
+Keep original errors for control flow. If your application deliberately chooses
+to transform a diagnostic field, `core.RedactSensitiveText` removes a bounded
+set of common credential assignments, authorization values, and secret-bearing
+URL components while preserving some diagnostic structure. When your
+application deliberately returns a transformed error,
+`core.RedactSensitiveError(err)` preserves `errors.Is` and `errors.As`
+inspection of the original cause.
+
+These helpers are explicit and lossy; they are not a framework-wide automatic
+redaction guarantee. Built-in debug persistence preserves the values supplied
+to it. A small set of legacy orchestration, skills, provider, and backend paths
+still invokes the helpers automatically pending a dedicated audit. Do not treat
+those exceptions as coverage for application data. Adopters own payload
+classification, access controls, and any required sanitization policy.
 
 ### Provider-Neutral AI Requests
 

--- a/core/redis_client.go
+++ b/core/redis_client.go
@@ -361,7 +361,8 @@ const (
 	// RedisDBTelemetry is for telemetry data
 	RedisDBTelemetry = 6
 
-	// RedisDBLLMDebug is for LLM debug payload storage (orchestration module)
+	// RedisDBLLMDebug is for framework LLM debug payload storage.
+	// Orchestration and telemetry recorders share this persistence format.
 	RedisDBLLMDebug = 7
 
 	// RedisDBExecutionDebug is for execution debug store (DAG visualization)

--- a/core/request_context.go
+++ b/core/request_context.go
@@ -23,9 +23,16 @@ const (
 	contextKeyTokenUsageAccumulator             contextKey = "truvag3_token_usage_accumulator" // #nosec G101 -- context key for LLM token-usage accounting, not a credential
 )
 
-// MaxConversationIDLength is the maximum byte length of a conversation ID.
-// It is a protocol invariant aligned with the telemetry baggage value limit.
-const MaxConversationIDLength = 512
+const (
+	// MetadataConversationID is the framework-owned correlation key used for
+	// conversation identity in metadata, telemetry baggage, and persisted debug
+	// records.
+	MetadataConversationID = "conversation_id"
+
+	// MaxConversationIDLength is the maximum byte length of a conversation ID.
+	// It is a protocol invariant aligned with the telemetry baggage value limit.
+	MaxConversationIDLength = 512
+)
 
 // ConversationIDValidationReason is a bounded classification for a rejected
 // conversation ID. It never contains the rejected value.

--- a/docs/building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md
+++ b/docs/building/ADDING_CONTEXT_TO_YOUR_AGENT_GUIDE.md
@@ -46,7 +46,7 @@ Every hook implements the base `core.PipelineHook` interface (just a `Name()` me
 | `BeforePlanningHook` | Before the planning phase begins | Enrichments | Yes — skip entire pipeline |
 | `AfterPlanningHook` | After each phase reaches a final validated planner-produced plan | Plan (copy-on-write and revalidated) | No |
 | `AfterExecutionHook` | After all tools finish executing | No (observe-only) | No |
-| `AfterSynthesisHook` | After the LLM synthesizes the final response | Response text | No |
+| `AfterSynthesisHook` | After the LLM produces its synthesis draft | Response text | No |
 
 Hook callbacks are **resilient by design**: if a hook returns an error, the
 orchestrator logs a warning and continues. Invalid provenance-aware
@@ -500,7 +500,15 @@ func (h *GuardrailsHook) AfterSynthesis(ctx context.Context, pctx *core.Pipeline
 }
 ```
 
-The `AfterSynthesisHook` runs **after** the LLM has generated the final response. Multiple hooks run in registration order — each receives the output of the previous hook. This makes it easy to chain: first redact PII, then check content policy, then apply formatting.
+The `AfterSynthesisHook` runs **after** the LLM has generated its synthesis
+draft. Multiple hooks run in registration order—each receives the output of the
+previous hook. The normal `ProcessRequest` paths store the chained result as
+`StoredExecution.FinalResponse`, separately from the raw synthesis interaction
+in the LLM debug store. This makes it easy to chain application-owned policies:
+for example, transform PII, then check content policy, then apply formatting.
+
+Workflow-mode `ExecutePlanWithSynthesis` currently does not run this pipeline or
+store a post-hook final response.
 
 > **Streaming note**: In `ProcessRequestStreaming`, tokens have already been streamed to the client by the time `AfterSynthesisHook` runs. The hook operates on the full accumulated response. Use it for post-processing tasks like memory storage, audit logging, or updating the `Response` field in the final `StreamingOrchestratorResponse`.
 

--- a/docs/observability/LOGGING_IMPLEMENTATION_GUIDE.md
+++ b/docs/observability/LOGGING_IMPLEMENTATION_GUIDE.md
@@ -1227,7 +1227,7 @@ Use these field names across all your services:
 | `span_id` | string | Active W3C span identity | "e75ad960517fa8fe" |
 | `checkpoint_id` | string | HITL checkpoint identity | "cp-abc123" |
 | `status` | string | Bounded result status defined by the operation; terminal request records may also use `partial` or `interrupted`, while diagnostics may use `fallback`, `accepted`, or `rejected` | "success", "error", "retry", "partial", "interrupted", "fallback" |
-| `error` | string | Error message safe for structured logging; sanitize external/provider errors | "connection refused" |
+| `error` | string | Error text selected by the log owner; avoid copying arbitrary external bodies and apply an explicit application sanitizer when policy requires it | "connection refused" |
 | `error_type` | string | Bounded error classification for filtering and alerting. AI observations use `ai/providers.NormalizeObservationErrorType` as authoritative: `invalid_request`, `route`, `policy`, `credential`, `transport`, `provider_client`, `provider_rate_limit`, `provider_server`, `decode`, `callback`, `partial_stream`, `cancelled`, `deadline`, or `unknown` | "timeout", "validation", "provider_rate_limit", "store_write" |
 | `response_model` | string | Optional provider-reported public model identity admitted by an explicit provider-scoped validation contract; currently OpenRouter only, bounded to 256 bytes, never route-owned request/deployment identity, and not a metric or stream label | "anthropic/claude-sonnet-4" |
 | `provider_request_id` | string | Optional provider-reported request identity admitted by an explicit provider-scoped validation contract; currently OpenRouter `X-Generation-Id` matching `gen-[A-Za-z0-9_-]+` and bounded to 128 bytes, distinct from framework `request_id`, and not a metric or stream label | "gen-1234" |
@@ -1500,23 +1500,23 @@ Before submitting code, verify:
 - [ ] Using standard field names (see table above)
 
 Errors crossing an external-service or AI-provider boundary may contain response
-bodies, endpoint query values, credential diagnostics, or other sensitive
-material. Framework code must not put the original `err.Error()` on an
-observation surface in those cases. It must preserve the original error for the
-caller while logging a sanitized error message and a bounded `error_type`. The
-AI module implements this boundary with
-`providers.SanitizedObservationError`.
+bodies, endpoint query values, credential diagnostics, or other application
+data. Prefer bounded classifications such as `error_type`, provider, and status
+code instead of copying an arbitrary body into a framework-owned log.
 
-For other framework and application boundaries, use
-`core.RedactSensitiveText(err.Error())` as defense in depth. It covers common
-authorization values, credential assignments, secret-bearing URL user
-information, and credential query parameters. The returned error remains
-unchanged for callers. When the error itself must cross a boundary with a safe
-observable message, wrap `core.RedactSensitiveError(err)` with `%w`; its
-`Unwrap` method preserves `errors.Is` and `errors.As` control flow. Because no
-redactor can recognize arbitrary domain
-secrets, continue to avoid raw endpoint URLs, request/response bodies, prompts,
-and provider diagnostics on observation surfaces.
+`core.RedactSensitiveText` and `core.RedactSensitiveError` are optional, lossy
+primitives. An adopter or subsystem may call them explicitly after choosing
+that fidelity trade-off; they are not automatically installed at every logging,
+trace, or persistence boundary. When chosen, `RedactSensitiveError` preserves
+`errors.Is` and `errors.As` through `Unwrap`.
+
+The AI module currently uses `providers.SanitizedObservationError` on selected
+provider observation paths, and a few orchestration, skills, and backend paths
+also transform errors. These are legacy exceptions pending the framework-wide
+payload-fidelity audit. They are not complete coverage and applications must
+not rely on them as a security boundary. Built-in debug stores preserve the
+values supplied to them; adopters own classification, access control, and any
+required sanitization policy.
 
 ---
 
@@ -2322,7 +2322,7 @@ func (r *Agent) handleRequest(w http.ResponseWriter, req *http.Request) {
 | `conversation_id` | When available | Multiple top-level turns; validated and metric-ineligible in framework flows |
 | `trace_id` / `span_id` | Automatic in context-aware JSON | Log-to-trace correlation |
 | `checkpoint_id` | HITL | One checkpoint |
-| `error` | On errors | Error message; sanitize external/provider errors before logging |
+| `error` | On errors | Error message chosen by the log owner; do not copy arbitrary external bodies, and apply explicit application sanitization when required |
 | `duration_ms` | Recommended | How long it took |
 | `status` | Recommended | success, error, retry |
 | `method` | For HTTP | HTTP method |

--- a/docs/operations/AUTO_DISCOVERY_GUIDE.md
+++ b/docs/operations/AUTO_DISCOVERY_GUIDE.md
@@ -623,7 +623,15 @@ redis-cli TTL "truvag3:services:weather-tool-abc123"
 # 0 or -2 means the record has expired or doesn't exist.
 ```
 
-For a friendlier view of the whole registry, the [`examples/registry-viewer-app/`](https://github.com/truvaagents/truva-g3/tree/main/examples/registry-viewer-app/) example is a standalone web dashboard that shows all registered services, their capabilities, and their health in real time. It's read-only, runs anywhere with access to your Redis, and is useful for both developers and ops.
+For a friendlier view of the whole registry, the
+[`examples/registry-viewer-app/`](https://github.com/truvaagents/truva-g3/tree/main/examples/registry-viewer-app/)
+example is an independently deployable dashboard that shows registered
+services, capabilities, health, execution evidence, HITL, skills, memory, and
+optional trace enrichment. Its backend currently imports TruvaG3 modules, so
+moving the source to another repository requires dependency and container-build
+changes. Most views are observational, but it is not globally read-only: HITL
+commands and Skills administration are intentional mutation surfaces, and
+grouped execution reads prune only confirmed-missing DB 8 index members.
 
 The framework also emits Prometheus metrics for discovery operations (`discovery.registrations`, `discovery.lookups`, `discovery.lookup.duration_ms`). See [`examples/k8-deployment/OBSERVABILITY.md`](https://github.com/truvaagents/truva-g3/blob/main/examples/k8-deployment/OBSERVABILITY.md) for the full metric catalog.
 

--- a/docs/operations/DEV_TOOLS_GUIDE.md
+++ b/docs/operations/DEV_TOOLS_GUIDE.md
@@ -514,7 +514,14 @@ Sections 7 and 8 cover the second tool: the Registry Viewer web app. If Swagger 
 
 ## 7. Registry Viewer Overview
 
-Open [http://registry.localhost](http://registry.localhost) against the local kind cluster and you land in a single-page web app with six tabs across the top: **Registry**, **LLM Debug**, **HITL Interrupted**, **Execution DAG**, **Skills**, and **Memory**. Each tab is its own view of the system, backed by a framework store or management API and refreshing on demand or on a timer. Most views are observational. The two deliberate mutation surfaces are HITL Approve/Reject commands and skill validation, publication, and guarded version deletion.
+Open [http://registry.localhost](http://registry.localhost) against the local
+kind cluster and you land in a single-page web app with six tabs across the top:
+**Registry**, **LLM Debug**, **HITL Interrupted**, **Execution DAG**, **Skills**,
+and **Memory**. Each tab is backed by a framework store, management API, or
+optional trace query. Most activity is observational. Deliberate business/control
+mutations are HITL Approve/Reject and skill publication/deletion; execution
+grouping also performs bounded maintenance by removing confirmed-dead IDs from
+DB 8 indexes.
 
 The app is a reference implementation — not a framework component. It ships in [`examples/registry-viewer-app/`](https://github.com/truvaagents/truva-g3/tree/main/examples/registry-viewer-app) and you can fork it, strip it down, or rewrite it for your own environment. It demonstrates how framework interfaces and the included Redis/Valkey and optional Qdrant adapters can back a small Go + vanilla-JS operational UI. The Skills view calls the provider-neutral `SkillAdminHandler`; it does not make raw Redis writes.
 
@@ -535,21 +542,43 @@ All six views use a consistent list-and-detail visual language. Most have a **li
 
 ### How It Gets Its Data
 
-The Registry Viewer does not scrape logs or talk to Prometheus. Its observational views read the included Redis and Qdrant-backed stores. HITL actions proxy a command to the owning agent, while Skills actions call the framework's management handler. Its data comes from these sources:
+The Registry Viewer does not scrape logs or query Prometheus. Its observational
+views read the included Redis and Qdrant-backed stores, and the execution detail
+endpoint optionally queries Jaeger for linked traces and deterministic pipeline-
+hook spans. HITL actions proxy a command to the owning agent, while Skills
+actions call the framework's management handler. Grouped execution reads also
+perform bounded DB 8 index hygiene as described below. Its data comes from these
+sources:
 
 | Source | What it holds | Which views use it |
 |--------|---------------|--------------------|
 | Redis `truvag3:services:*` (DB 0) | Service registrations (tools and agents) with TTL refresh | Registry view; also feeds `/swagger-urls.json` for the Swagger UI dropdown |
 | Redis `truvag3:llm:debug:*` (DB 7) | Full LLM interaction records (prompt, response, tokens, duration, type, category, success). The store has two writers (see `truvag3:llm:debug:*` row in §7 view summary above): the orchestration module's `RedisLLMDebugStore` and `telemetry.RedisLLMCallRecorder`. Both write the same record format. | LLM Debug view; DAG detail panel's LLM Calls tab fetches the same record by request ID |
 | Redis HITL checkpoint store (`{base-prefix}[:{agent-name}]:checkpoint:*`; base defaults to `truvag3:hitl`) | Pending and expired checkpoints with plan, current step, resolved parameters, decision, status, agent name, agent address, request mode. Configure the base with `TRUVAG3_HITL_KEY_PREFIX`; the framework appends `TRUVAG3_AGENT_NAME` or `TRUVAG3_K8S_SERVICE_NAME` when present. | HITL Interrupted view; DAG detail panel's HITL tab |
-| Redis `truvag3:execution:debug:*` (DB 8) | Full execution records (plan, per-step results, LLM interactions for pre/post hooks, HITL events, phase count, regeneration events). Written by `orchestration.RedisExecutionDebugStore` independently of the LLM debug store — the two have separate enable flags and separate Redis databases. | Execution DAG view |
+| Redis `truvag3:execution:debug:*` (DB 8) | Full execution records (plan, per-step results, HITL state, phase history, skill evidence, metadata, and optional post-`AfterSynthesis` application response). Written by `orchestration.RedisExecutionDebugStore` independently of DB 7. Grouped/timeline reads may remove a confirmed-missing member from execution/conversation sorted-set indexes, but never delete an execution record. | Execution DAG view |
+| Jaeger Query API (optional) | Execution trace, linked trigger traces, and deterministic `BeforePlanning`, `AfterPlanning`, `AfterExecution`, and `AfterSynthesis` hook spans. Configured with `JAEGER_QUERY_URL`; trace links redirect through `JAEGER_UI_URL`. | Execution DAG full-flow graph and hook tabs |
 | Provider-neutral skill management API; included Redis keys under `truvag3:skills:{store}:*` (DB 9) | Published skill metadata, immutable manifests/resources, version history and tombstones, revision tokens, and body-free audit records | Skills view; Execution DAG's Skills tab reads the separate execution-debug evidence for a request |
 | Redis shared memory keys (episodic events, activities, investigations, digest cache) | Source agents' episodic events; live activity signals from `ActivityCoordinator`; investigation locks from `InvestigationCoordinator`; cached compaction digests | Memory view |
 | Qdrant collections (when `TRUVAG3_VECTOR_DB_URL` is set) | Semantic knowledge vectors (Phase 2 shared memory) | Memory view (knowledge detail) — currently behind feature flag |
 
-Registry Viewer is not the source of truth: restarting it loses no persisted data. Its Registry, LLM Debug, execution, and memory surfaces are lenses over framework state. Its Skills surface is also the bundled management client and host, so successful publication or deletion intentionally changes the authoritative skill store through framework concurrency, validation, protection, and audit rules.
+Registry Viewer is not the source of truth: restarting it loses no persisted
+data. Its Registry, LLM Debug, execution, and memory surfaces are lenses over
+framework state. The execution list has one maintenance side effect: after an
+authoritative DB 8 record is confirmed absent, the Viewer removes that stale ID
+from the affected sorted-set index. Consequently DB 7 may be read-only to the
+Viewer, while DB 8 requires index-write permission. Its Skills surface is also
+the bundled management client and host, so successful publication or deletion
+intentionally changes the authoritative skill store through framework
+concurrency, validation, protection, and audit rules.
 
-> **Privacy design note — user memory.** You'll notice the Memory view only shows **shared memory** (domain-scoped events and investigations). There is no tab, list, or browser for **user memory** (per-user facts). This is intentional: user memory holds potentially personal or sensitive data, and exposing it in a general-purpose developer dashboard would be the wrong default. If a developer legitimately needs to inspect what's stored for a given user, they query the vector DB (Qdrant) and the user-memory Redis keys directly with the credentials they already have. The dashboard stays generic; the privacy-bearing data stays behind an explicit access step. The Execution DAG view still surfaces **user-memory activity** during a specific execution — which recall and extraction calls ran, how long they took, whether reconciliation fired — but it never shows the *contents* of the facts stored, only the hook invocations.
+> **User-memory boundary.** The Memory view exposes shared memory only; there is
+> no per-user fact browser. Pre/Post-Execution hook cards show lifecycle activity
+> without rendering stored fact bodies. However, opt-in LLM debug persistence
+> preserves complete prompts and responses. A planning prompt can therefore
+> contain user-memory enrichment that was actually supplied to the model, and
+> the LLM Debug or execution LLM Calls view can display it. Protect Registry
+> Viewer and DB 7 accordingly; the framework does not silently redact those
+> payloads.
 
 ### Prerequisites
 
@@ -560,7 +589,7 @@ For the views to show data, the underlying features have to be enabled in your c
 | Registry | Services must register with a shared Redis via `core.WithDiscovery(true, "redis")`. This is the default for every example tool/agent in the repo. |
 | LLM Debug | Two enablement paths, often both at once: (a) **Orchestrator-internal calls** (`plan_generation`, `tiered_selection`, `synthesis_streaming`, memory hooks, error analysis, etc.) populate the store automatically when the orchestrator is constructed with `TRUVAG3_LLM_DEBUG_ENABLED=true` — the orchestration module's `RedisLLMDebugStore` is wired up by the factory. (b) **Direct agent AI calls** (an agent that calls `ai.GenerateResponse(...)` outside of an orchestration step) populate the store only when the agent wraps its AI client with `ai.NewInstrumentedClient(..., debugRecorder, ...)` using `telemetry.NewRedisLLMCallRecorder`. See [`examples/agent-with-telemetry/research_agent.go`](https://github.com/truvaagents/truva-g3/blob/main/examples/agent-with-telemetry/research_agent.go) for the wiring. Most chat agents in the kind cluster don't need (b) because their LLM calls go through the orchestrator and are captured by (a). |
 | HITL Interrupted | At least one agent must run the orchestration module with HITL enabled (`HITLConfig.Enabled: true` and a configured checkpoint store). See [HUMAN_IN_THE_LOOP_USER_GUIDE.md](../orchestration/HUMAN_IN_THE_LOOP_USER_GUIDE.md). |
-| Execution DAG | The orchestrator must run with `TRUVAG3_EXECUTION_DEBUG_STORE_ENABLED=true`. This is **independent** of `TRUVAG3_LLM_DEBUG_ENABLED` — the execution debug store and the LLM debug store live in separate Redis databases (DB 8 and DB 7) and are wired by separate factory branches. In practice you almost always want both enabled, because the DAG view's LLM Calls tab pulls data from the LLM debug store. See the per-agent enablement table below — not every example chat agent in the kind cluster has both set, and the asymmetric setups are the most common gotchas. |
+| Execution DAG | The orchestrator must run with `TRUVAG3_EXECUTION_DEBUG_STORE_ENABLED=true`. This is **independent** of `TRUVAG3_LLM_DEBUG_ENABLED`—DB 8 supplies execution evidence and DB 7 supplies LLM/hook interactions. Configure Registry Viewer `JAEGER_QUERY_URL` for optional trace-backed hook and linked-trace enrichment and `JAEGER_UI_URL` for the Trace link. Redis evidence remains usable when Jaeger is unavailable. |
 | Skills | The Registry Viewer must compose its skills backend and `SkillAdminHandler`; the bundled deployment does this with `TRUVAG3_SKILLS_REDIS_DB=9`. Runtime skill evidence inside an execution also requires that agent to enable skills and `TRUVAG3_EXECUTION_DEBUG_STORE_ENABLED=true`. Full skill-bearing prompts require `TRUVAG3_LLM_DEBUG_ENABLED=true`. |
 | Memory | Agents must be wired with shared memory via `memory.NewSharedBackends(...)` and `orchestration.BuildMemoryHooks(...)`. See [AGENT_MEMORY_USER_GUIDE.md](../memory-and-chat/AGENT_MEMORY_USER_GUIDE.md). `TRUVAG3_AGENT_DOMAIN` must be set so the view has a domain to pick from in its dropdown. |
 
@@ -568,13 +597,19 @@ On the local kind cluster, **enablement varies per agent** because the env vars 
 
 | Agent | `TRUVAG3_LLM_DEBUG_ENABLED` | `TRUVAG3_EXECUTION_DEBUG_STORE_ENABLED` | Implication |
 |-------|:--:|:--:|---|
-| `travel-chat-agent` | ❌ | ✅ | Appears in Execution DAG view; its orchestrator-internal LLM calls are NOT recorded to LLM Debug, so the DAG's LLM Calls tab is empty for its records |
+| `travel-chat-agent` | ✅ | ✅ | Fully populated across execution, LLM, skill, and configured hook evidence; actual visibility still depends on which features ran for a request |
 | `devops-chat-agent` | ✅ | ✅ | Fully populated across both views |
 | `qa-agent` | ✅ | ✅ | Fully populated |
 | `event-driven-agent` | ✅ | ✅ | Fully populated |
 | `agent-with-telemetry` (research-agent-telemetry) | ✅ | ❌ | Its direct AI calls (instrumented client) appear in LLM Debug, but it does NOT appear in the Execution DAG view at all because the execution store isn't enabled |
 
-So the most common gotchas are exactly the asymmetric setups above: a request that shows up in DAG but has an empty LLM Calls tab (executor enabled, LLM debug disabled), or a record that shows up in LLM Debug but has no corresponding row in DAG (LLM debug enabled, executor disabled). Always check both env vars on a new agent.
+The asymmetric setup shown above explains why `agent-with-telemetry` can have a
+record in LLM Debug without a corresponding Execution DAG row. The reverse
+configuration is also possible for a custom or newly created agent: enabling
+the execution store but disabling LLM debug produces a DAG row whose LLM Calls
+tab has no DB 7 interactions. None of the other agents in this table currently
+uses that reverse configuration. Always check both environment variables when
+diagnosing a new agent.
 
 ---
 
@@ -588,7 +623,7 @@ This section walks through each view in detail: what the list panel shows, what 
 
 This is the simplest view and the one you'll open first when checking whether a deployment succeeded. It lists every tool and agent currently registered in Redis under `truvag3:services:*`, with the Redis TTL driving health — a service that stops sending heartbeats drops off the list within 30 seconds.
 
-**List panel.** A sortable table with columns:
+**List panel.** A sortable table of registered service rows with these columns:
 - **Type** — `tool` or `agent` (with an icon for quick scanning)
 - **Name** — service name as registered (e.g. `weather-tool-v2`)
 - **Health** — color-coded badge: `healthy`, `degraded`, `unhealthy`, or `unknown`
@@ -674,11 +709,20 @@ This is the operational queue for Human-in-the-Loop checkpoints. Every time an a
 
 This is the view you open when logs aren't enough. It takes a single orchestration execution and assembles **every piece of data the orchestrator recorded about it** into one interactive timeline: the planned DAG, per-step results, skill lifecycle evidence, all LLM calls grouped by phase, pre-execution hooks, post-execution hooks, HITL checkpoints that fired during the run, and any plan regenerations that happened mid-flight. This is the most information-dense view in the app and where most debugging time is spent.
 
-**List panel.** A sortable table with columns:
+**List panel.** Conversation grouping is the default. A conversation header
+shows its matching/total turn count and can be expanded into chronological user
+turns. HITL resumes and delegated work appear as related executions under their
+owner when that relationship is verifiable. If the owner record has expired,
+the row is kept visible without drawing a false parent branch and is labeled
+**Parent execution unavailable**. Incomplete lineage metadata is labeled
+separately from confirmed retention loss. A **Grouped / Flat** control exposes
+the legacy one-row-per-execution list when needed.
+
+Each execution row retains these sortable columns:
 - **Status** — success / failed / interrupted (with colored icon)
 - **Request** — the original user query text (sortable by request text)
 - **Steps** — how many steps the plan had
-- **Duration** — total execution time (sortable)
+- **Duration** — best available non-additive elapsed envelope (sortable)
 - **Created** — when the request started (sortable, default-sorted descending so the newest is at the top)
 
 **Filters.** Search box (matches request ID or query text) plus **All / Success / Failed / Interrupted**.
@@ -687,15 +731,29 @@ This is the view you open when logs aren't enough. It takes a single orchestrati
 
 #### Tab 1: DAG Visualization
 
-The headline tab. Renders the execution as an interactive graph using Cytoscape.js with the Dagre layout algorithm. Each node is a step, each edge is a dependency (explicit `depends_on` or implicit sequential). Click a node to see that step's details inline; click an edge to see the template binding that ties the two steps together.
+The headline tab renders the execution as an interactive graph using
+Cytoscape.js with the Dagre layout algorithm. Tool nodes have unique displayed
+step numbers across the selected execution, including an HITL continuation;
+phase-local step IDs remain visible as identifiers. Click a node for details or
+an edge for its relationship.
+
+Edges do not all mean the same thing. Scheduler dependencies control execution
+order within a plan. Cross-phase data-lineage edges show that a later step read
+prior-phase results but do not impose scheduler order. Phase-transition and
+pipeline-hook edges describe lifecycle flow. The popup and legend identify the
+edge type so visual provenance is not mistaken for a planner or scheduler
+contract.
 
 The header strip above the canvas shows a comprehensive metadata line:
 - Original request text (click to expand/collapse if truncated)
 - Agent name (which agent owned this execution)
-- Request ID and trace ID (W3C trace ID for Jaeger cross-reference)
-- Step count and total duration (executor time + LLM time, both measured and displayed)
+- Request ID and one compact **Trace** link to the configured Jaeger UI
+- Step count and **Elapsed** time: the largest credible phase-loop,
+  step-timestamp, and LLM/step wall-clock envelope, without adding overlapping
+  durations
 - Success / failed / interrupted badge
-- LLM call count (if any)
+- LLM call count and aggregate call time (if any); aggregate call time is a
+  workload measure and may overlap elapsed time
 - HITL badge (if HITL fired but didn't interrupt)
 - Phase count (for iterative multi-phase plans — shown when > 1)
 - Forced-terminal badge (when the orchestrator had to force-terminate a phase)
@@ -704,16 +762,24 @@ Below the header, if the plan was regenerated mid-flight, a warning strip shows 
 
 A **Steps Only / Full Flow toggle** at the top switches between two modes:
 - **Steps Only** — just the tool-invocation steps, clean and compact
-- **Full Flow** — steps + every LLM planning/synthesis call + every HITL checkpoint, interleaved in chronological order. This is the full timeline of the execution from the orchestrator's point of view
+- **Full Flow** — steps + orchestration/agent LLM calls + HITL checkpoints +
+  trace-backed deterministic pipeline hooks, interleaved by lifecycle and
+  timing evidence. Jaeger enrichment is optional; its absence does not remove
+  the Redis-backed execution record.
 
 #### Tab 2: Pre-Execution
 
-Only visible when the execution had `BeforePlanning` hooks that ran. Shows the hook activity that happened *before* the planner even saw the prompt:
+Visible when trace or debug evidence contains `BeforePlanning` or
+`AfterPlanning` activity. It shows context preparation before planning and
+deterministic/LLM-backed plan governance around the planner:
 
 - **User Memory Enrichment** — which recall calls ran (`user_memory_recall_identity`, `user_memory_recall_summary`, `user_memory_recall_query`, `user_memory_recall_universal`), how long each took, and whether the `user_memory_enrichment_injected` step succeeded (meaning the `<user_profile>` XML fragment made it into the plan-generation prompt). Note: this tab shows that the enrichment ran, not the contents of the profile itself — see the privacy note in §7.
 - **Memory Compaction** — `activity_compaction_incremental` calls and their durations. Useful for diagnosing slow first-requests where the digest cache was cold.
 
-This tab is the place to look when you suspect the LLM didn't see the context you expected.
+Trace-backed hook cards can prove that a deterministic hook ran even when it
+made no LLM call. This tab is the place to look when you suspect the planner did
+not receive expected context or a post-planning policy altered/validated its
+plan.
 
 #### Tab 3: Step Details
 
@@ -723,20 +789,42 @@ When a step retried, you can see exactly how many attempts happened and which re
 
 #### Tab 4: LLM Calls
 
-Only visible when the execution had LLM interactions recorded. Shows every LLM call the orchestrator made during this execution, in order, with full prompts and responses. This is functionally a filtered slice of LLM Debug constrained to one execution, rendered inline alongside the DAG context.
+Only visible when the execution had LLM interactions recorded. This tab shows
+the orchestration-level calls for the execution—planning, selection,
+continuation, error-analysis, synthesis, and similar calls—in contiguous display
+order. Hook-internal interactions are intentionally routed to Pre-Execution or
+Post-Execution so the same call is not presented twice. The cross-request LLM
+Debug view remains the place to inspect every stored interaction family.
 
-Each call shows: type (e.g. `plan_generation`, `continuation_plan_generation`, `continuation_plan_regeneration`, `tiered_selection`, `synthesis_streaming`, plus the `user_memory_*` family — `user_memory_recall_identity`, `user_memory_recall_summary`, `user_memory_recall_query`, `user_memory_recall_universal`, `user_memory_enrichment_injected`, `user_memory_extraction`, `user_memory_similarity_search`, `user_memory_reconciliation`, `user_memory_remember`, `user_memory_summary`, `user_memory_summary_remember`), category (`llm`, `embedding`), model, token counts (prompt + completion + total), duration, attempt number, temperature, max tokens, success flag, full prompt, and full response. Click an interaction to expand the prompt or response; they're long.
+Each call shows its type, category, model, token counts, aggregate call duration,
+attempt number, generation settings, success state, prompt, and response. Click
+an interaction to expand long content. The synthesis card is labeled **Pre-hook
+LLM synthesis output**, and its response expander says **View Pre-hook Output**,
+because the model output precedes application `AfterSynthesis` hooks. This
+pre-hook output is never presented as proof of the final business response.
 
 **When to open this tab vs. the LLM Debug view:** use this tab when you already have the request ID open and want to see the LLM calls in the context of the steps they produced. Use the LLM Debug view when you want to search across requests (e.g., "show me every synthesis call that errored yesterday").
 
 #### Tab 5: Post-Execution
 
-Only visible when the execution had `AfterSynthesis` hooks that ran. The mirror image of Pre-Execution:
+Visible when an `AfterExecution`/`AfterSynthesis` hook ran or when the execution
+contains a stored post-hook application response. It is the mirror image of
+Pre-Execution:
+
+- **Post-hook application response** — the `StoredExecution.FinalResponse`
+  captured after `AfterSynthesis` hooks, with its source label. If it differs
+  from non-streaming synthesis, the application changed the draft. On native
+  streaming, the card also warns that post-hook text can differ from content
+  already streamed to the client.
 
 - **Event Summarization** — LLM calls that generated the episodic event text written to shared memory
 - **User Memory Write-back** — `user_memory_extraction`, `user_memory_embed_candidate`, `user_memory_similarity_search`, `user_memory_reconciliation` (per-candidate path) or `user_memory_reconciliation_batch` + per-item `user_memory_reconciliation_batch_item` rows (batched path), `user_memory_reconciliation_skip` (no neighbors), and `user_memory_remember`. The batched path emits ONE `user_memory_reconciliation_batch` row with category `llm` carrying the full token usage, plus N lightweight `_batch_item` rows with category `derived` so the registry viewer's LLM-call totals are not double-counted. Same privacy rule as Pre-Execution: you see the invocations, not the fact contents.
 
-This tab answers "what did the system learn from this request?"
+This tab answers both "what did the system learn from this request?" and "what
+application response existed after post-synthesis governance?" Workflow-mode
+`ExecutePlanWithSynthesis` and older records can legitimately lack the latter;
+the UI states that no post-hook evidence was stored instead of treating the raw
+synthesis as the outcome.
 
 #### Tab 6: HITL
 
@@ -745,6 +833,14 @@ Only visible when a checkpoint fired during this execution. Shows the checkpoint
 - What decision triggered it (policy match, sensitive-capability match, semantic retry request)
 - When and how it was resolved (approve / reject / expire with default action)
 - The resumed execution path, if any
+
+For current complete records, lifecycle joins use the exact checkpoint ID. The
+initial interruption and its resume are linked when their checkpoint identities
+agree; unrelated interrupted siblings are not attached merely because they
+share an `original_request_id`. For an older or partial interrupted record that
+has no checkpoint identity at all, the Viewer falls back to the shared initial
+request ID and can therefore attach multiple siblings from that request family.
+Treat that fallback as less precise than an identity-backed lifecycle.
 
 Useful for tracing "the user approved X, then what happened?"
 
@@ -791,7 +887,13 @@ This view is for inspecting the state of **shared memory** (domain-scoped). It a
 
 **Header stats.** Domain, Events, Investigations.
 
-**What this view does not show.** As noted in §7, **user memory is not surfaced here by design**. There is no per-user fact list, no browser for the vector DB entries, and no "what does this system remember about alice@example.com" lookup. User-memory activity is visible in the Execution DAG view (Pre-Execution and Post-Execution tabs) at the hook-invocation level, but never at the fact-contents level. If you need to inspect the actual facts stored for a user, query Qdrant directly using the collection name and user ID key — credentials are the same ones the agent uses.
+**What this view does not show.** The Memory view has no per-user fact list,
+vector-entry browser, or identity lookup. Pre/Post-Execution presents user-
+memory hook activity without fact bodies. This does not make Registry Viewer a
+payload-redaction boundary: when LLM debug is enabled, full planning and hook
+prompts/responses can contain the user context supplied to a model and are
+visible in LLM Debug or LLM Calls. Direct Qdrant inspection is still required
+to enumerate authoritative stored facts.
 
 **Typical workflow.** Two agents keep making conflicting decisions about the same entity (say, the same Kubernetes deployment). You open Memory view, pick the `infrastructure` domain, widen the time range to 7 days, and scroll the event list looking for what each agent recorded about that entity. The Digest tab tells you what the LLM is currently reading about the domain; the Live Activity tab tells you whether one of the agents is mid-investigation right now.
 
@@ -878,7 +980,7 @@ When you're stuck and not sure which tab to open, scan this table.
 - **[`examples/registry-viewer-app/static/js/views/registry.js`](https://github.com/truvaagents/truva-g3/blob/main/examples/registry-viewer-app/static/js/views/registry.js)** — Registry view (§8.1).
 - **[`examples/registry-viewer-app/static/js/views/llm-debug.js`](https://github.com/truvaagents/truva-g3/blob/main/examples/registry-viewer-app/static/js/views/llm-debug.js)** — LLM Debug view (§8.2).
 - **[`examples/registry-viewer-app/static/js/views/hitl.js`](https://github.com/truvaagents/truva-g3/blob/main/examples/registry-viewer-app/static/js/views/hitl.js)** — HITL Interrupted view (§8.3).
-- **[`examples/registry-viewer-app/static/js/views/dag.js`](https://github.com/truvaagents/truva-g3/blob/main/examples/registry-viewer-app/static/js/views/dag.js)** — Execution DAG view (§8.4) — the largest view, ~3,300 lines.
+- **[`examples/registry-viewer-app/static/js/views/dag.js`](https://github.com/truvaagents/truva-g3/blob/main/examples/registry-viewer-app/static/js/views/dag.js)** — Execution DAG view (§8.4), including grouped lineage, full-flow graph, and all detail tabs. Treat its size as implementation detail rather than a stable contract.
 - **[`examples/registry-viewer-app/static/js/views/skills.js`](https://github.com/truvaagents/truva-g3/blob/main/examples/registry-viewer-app/static/js/views/skills.js)** — Skill package-management view (§8.6).
 - **[`examples/registry-viewer-app/static/js/views/memory.js`](https://github.com/truvaagents/truva-g3/blob/main/examples/registry-viewer-app/static/js/views/memory.js)** — Memory view (§8.5).
 - **[`examples/registry-viewer-app/k8-deployment.yaml`](https://github.com/truvaagents/truva-g3/blob/main/examples/registry-viewer-app/k8-deployment.yaml)** — Kubernetes deployment and service.

--- a/docs/operations/OAUTH_SECURITY_GUIDE.md
+++ b/docs/operations/OAUTH_SECURITY_GUIDE.md
@@ -538,9 +538,10 @@ This means:
 
 Serialization tags do not sanitize arbitrary error text or application logs.
 Never log complete headers, token responses, credential-bearing URLs, or raw
-OAuth provider bodies. Preserve original errors for control flow, but pass
-external diagnostic strings through `core.RedactSensitiveText` before writing
-them to logs, traces, debug records, or client-visible responses.
+OAuth provider bodies. Preserve original errors for control flow. The refresh
+example below explicitly chooses `core.RedactSensitiveText` for its application
+log policy; that lossy helper is not automatically applied by the framework and
+is not a general detector for domain secrets.
 
 ### Thread-Safe Token Storage
 

--- a/docs/orchestration/ASYNC_ORCHESTRATION_GUIDE.md
+++ b/docs/orchestration/ASYNC_ORCHESTRATION_GUIDE.md
@@ -1584,10 +1584,14 @@ Set these environment variables to enable advanced observability:
 |----------|-------------|---------|
 | `TRUVAG3_EXECUTION_DEBUG_STORE_ENABLED` | Enable execution storage for DAG visualization | `false` |
 | `TRUVAG3_LLM_DEBUG_ENABLED` | Enable LLM debug payload capture | `false` |
-| `TRUVAG3_LLM_DEBUG_TTL` | Retention for successful LLM records | `24h` |
-| `TRUVAG3_LLM_DEBUG_ERROR_TTL` | Retention for error records | `168h` (7 days) |
+| `TRUVAG3_LLM_DEBUG_TTL` | Base retention for successful LLM records | `24h` |
+| `TRUVAG3_LLM_DEBUG_ERROR_TTL` | Base retention for error records | `168h` (7 days) |
 
 **What Gets Recorded:**
+
+These TTLs are initial minimums. Execution-lineage, HITL, and explicit
+investigation retention can extend current/root LLM and execution evidence and
+never shorten a longer or persistent lifetime.
 
 **Execution DAG Store** (`TRUVAG3_EXECUTION_DEBUG_STORE_ENABLED=true`):
 - The routing plan (steps, dependencies, tool selections)
@@ -1745,8 +1749,8 @@ See [examples/k8-deployment/grafana.yaml](https://github.com/truvaagents/truva-g
 | `GROQ_API_KEY` | Groq API key (alternative provider) | - | `gsk-...` |
 | `TRUVAG3_EXECUTION_DEBUG_STORE_ENABLED` | Enable execution storage for DAG visualization | `false` | `true` |
 | `TRUVAG3_LLM_DEBUG_ENABLED` | Enable LLM debug payload capture | `false` | `true` |
-| `TRUVAG3_LLM_DEBUG_TTL` | Retention for successful LLM records | `24h` | `48h` |
-| `TRUVAG3_LLM_DEBUG_ERROR_TTL` | Retention for error records | `168h` | `336h` |
+| `TRUVAG3_LLM_DEBUG_TTL` | Base retention for successful LLM records | `24h` | `48h` |
+| `TRUVAG3_LLM_DEBUG_ERROR_TTL` | Base retention for error records | `168h` | `336h` |
 
 > 📖 **AI Provider Configuration**: For comprehensive information on configuring AI providers, model aliases, provider chains with failover, and environment variable overrides for models, see the [AI Providers Setup Guide](../building/AI_PROVIDERS_SETUP_GUIDE.md). It covers:
 > - All supported providers (OpenAI, Anthropic, OpenRouter, Groq, DeepSeek, Gemini, Ollama, etc.)

--- a/docs/orchestration/ERROR_HANDLING_GUIDE.md
+++ b/docs/orchestration/ERROR_HANDLING_GUIDE.md
@@ -455,7 +455,13 @@ executor.SetMaxSemanticRetries(2)            // Max Layer 4 attempts
 
 ### For Tool Developers
 
-1. **Always use your tool's `sendUpstreamError` method + `core.ClassifyUpstreamError` for upstream API errors.** Classify the original error, then pass only `core.RedactSensitiveText(err.Error())` into the response and observation surfaces. This preserves routing without propagating common credential forms.
+1. **Define and use your tool's upstream-error policy consistently.** The
+   reference examples use `sendUpstreamError` plus
+   `core.ClassifyUpstreamError`, then explicitly choose
+   `core.RedactSensitiveText(err.Error())` for their application response and
+   observation surfaces. That transformation belongs to the tool; the
+   framework does not install it automatically or guarantee that it recognizes
+   domain secrets.
 
 2. **Use your tool's `sendError` method only for tool-local validation** — decode failures, missing required fields, invalid formats detected before calling the upstream API.
 

--- a/docs/orchestration/HUMAN_IN_THE_LOOP_USER_GUIDE.md
+++ b/docs/orchestration/HUMAN_IN_THE_LOOP_USER_GUIDE.md
@@ -111,7 +111,7 @@ TRUVAG3_HITL_DEFAULT_TIMEOUT=5m              # 5 minute approval window
 
 **What do these settings mean?**
 
-- `TRUVAG3_AGENT_NAME`: Scopes this agent's HITL state in Redis to `truvag3:hitl:<agent_name>:*`. Without it, all agents pointed at the same Redis share `truvag3:hitl:pending`, and anything that fans out across agents (such as the registry viewer's HITL list) will see duplicates. K8s manifests typically set this; for local dev with more than one HITL agent on the same Redis, set it explicitly. The framework logs a startup Warn if it detects the shared-prefix configuration. See [Agent Isolation](#agent-isolation) for the full mechanism.
+- `TRUVAG3_AGENT_NAME`: Scopes this agent's HITL state in Redis to `truvag3:hitl:<agent_name>:*`. Without it, all agents pointed at the same Redis share `truvag3:hitl:pending`, so a fan-out can receive the same checkpoint from several agents. The current Registry Viewer deduplicates that response by `checkpoint_id`, but identity is still required for correct ownership, routing, and isolation. K8s manifests typically set it; for local dev with more than one HITL agent on the same Redis, set it explicitly. The framework logs a startup Warn if it detects the shared-prefix configuration. See [Agent Isolation](#agent-isolation) for the full mechanism.
 - `TRUVAG3_HITL_ENABLED`: The master switch. Without this, nothing HITL-related happens.
 - `TRUVAG3_HITL_REQUIRE_PLAN_APPROVAL`: When true, the AI pauses after generating a plan but before executing anything. This lets you review the entire plan at once.
 - `TRUVAG3_HITL_DEFAULT_TIMEOUT`: How long to wait for human response. After this, the system takes a default action (usually reject for safety).
@@ -1482,19 +1482,27 @@ processor, err := orchestration.NewCheckpointExpiryProcessor(
 )
 ```
 
-### Duplicate Checkpoints in the Registry Viewer (Visual Only)
+### Shared-prefix duplicates at the aggregation boundary
 
-**What you see:** The viewer's "HITL interrupted" screen shows several rows that all have the same `checkpoint_id`, `request_id`, and timestamps. Approving one row doesn't make the others disappear until the next refresh.
+**What happens:** Multiple agents that share `truvag3:hitl:pending` can each
+return the same checkpoint to a fan-out caller. The current Registry Viewer
+deduplicates its merged list by `checkpoint_id`, so this condition should not
+create duplicate rows in the UI.
 
-**Why it happens:** Multiple agents are sharing the same Redis pending index (`truvag3:hitl:pending`) because none of them have an agent identity configured. Each agent's `GET /hitl/checkpoints` endpoint legitimately returns the full shared list, and the viewer's fan-out concatenates the responses. This is distinct from the multi-pod processing issue above — the underlying checkpoint is processed once correctly; only the *display* duplicates.
+This remains a configuration defect even when the UI hides its visual symptom:
+checkpoint ownership and command routing are ambiguous, and another management
+client may not deduplicate.
 
-**Diagnostic:** Inspect the viewer API response directly and count distinct vs. total `checkpoint_id` values:
+**Diagnostic:** Inspect the Viewer API response and agent configuration:
 
 ```bash
 curl -s http://<viewer>/api/hitl/checkpoints | jq '.checkpoints | length, (map(.checkpoint_id) | unique | length)'
 ```
 
-If total > distinct, you're hitting this case. If total == distinct and growing, you're seeing genuine checkpoint accumulation (tune `TRUVAG3_HITL_DEFAULT_TIMEOUT`).
+For the current Viewer, total and distinct should match. If they do not, the
+deployed Viewer is older than this implementation or its deduplication has
+regressed. Matching counts do not prove correct isolation; confirm every
+logical agent has its own resolved prefix.
 
 **How to fix:** Give each agent a distinct identity so their Redis prefixes don't collide. Any of these works:
 
@@ -1509,7 +1517,10 @@ TRUVAG3_K8S_SERVICE_NAME=my-agent
 TRUVAG3_HITL_KEY_PREFIX=truvag3:hitl:my-agent
 ```
 
-Or pass `orchestration.WithCheckpointKeyPrefix("…")` to `NewRedisCheckpointStore`. The framework logs a startup Warn pointing at this — check agent logs for "using shared key prefix" before the duplication appears in the UI.
+Or pass `orchestration.WithCheckpointKeyPrefix("…")` to
+`NewRedisCheckpointStore`. The framework logs a startup Warn pointing at this;
+check agent logs for "using shared key prefix" even when the Viewer shows only
+one deduplicated row.
 
 See [Agent Isolation](#agent-isolation) for the full mechanism and why each path works.
 
@@ -1866,7 +1877,14 @@ Whichever path you choose, this agent's checkpoints are stored at `{prefix}:chec
 
 #### What the framework does on its own
 
-K8s replicas of one Deployment naturally share `TRUVAG3_K8S_SERVICE_NAME`, but `applyConfigToComponent` collapses them to a single service-discovery entry (`base.ID = config.Name`), so the registry viewer hits only one replica per logical agent. Replica sharing is intentional and doesn't produce duplicates. The duplication surfaces only when (a) multiple **logical** agents share a prefix, or (b) operators force instance-scoped registration via per-pod `TRUVAG3_AGENT_ID`.
+K8s replicas of one Deployment naturally share `TRUVAG3_K8S_SERVICE_NAME`, but
+`applyConfigToComponent` collapses them to a single service-discovery entry
+(`base.ID = config.Name`), so the Registry Viewer hits only one replica per
+logical agent. Replica sharing is intentional. Duplicate upstream checkpoint
+responses can arise when multiple **logical** agents share a prefix or when
+operators force instance-scoped registration via per-pod
+`TRUVAG3_AGENT_ID`; the current Viewer deduplicates those responses for display
+but cannot repair the underlying ownership configuration.
 
 If isolation isn't configured, you'll see this in the agent's startup logs:
 

--- a/docs/orchestration/PIPELINE_HOOKS_GUIDE.md
+++ b/docs/orchestration/PIPELINE_HOOKS_GUIDE.md
@@ -67,7 +67,7 @@ There are four stage interfaces. A single hook type can implement as many as it 
 | `BeforePlanningHook` | Before the planning phase begins | Enrichments | **Yes** — skips the entire pipeline | Yes |
 | `AfterPlanningHook` | After each phase reaches one final validated planner-produced plan | The plan | No | Yes |
 | `AfterExecutionHook` | After all tools finish executing | No (observe-only) | No | Yes |
-| `AfterSynthesisHook` | After the LLM synthesizes the final response | Response text | No | Yes |
+| `AfterSynthesisHook` | After the LLM produces its synthesis draft | Response text | No | Yes |
 
 Two properties define the whole system and are worth committing to memory:
 
@@ -129,7 +129,15 @@ runners and validation logic live in `orchestration/pipeline_hooks.go`.
 
 > **Streaming caveat**
 >
-> On the streaming path, tokens are sent to the client *during* synthesis. By the time `AfterSynthesis` hooks run, the user has already seen the text. The returned (possibly mutated) string updates the final `OrchestratorResponse.Response` for recording purposes, but **it cannot un-stream what was already delivered**. If you need to *block* content before the user sees it, do it in a `BeforePlanning` hook, in a guarded prompt builder, or use the non-streaming path. See `orchestrator.go:3510-3513`.
+> On the streaming path, tokens are sent to the client *during* synthesis. By
+> the time `AfterSynthesis` hooks run, the user has already seen the text. The
+> returned (possibly mutated) string updates the final
+> `OrchestratorResponse.Response` and is stored separately as
+> `StoredExecution.FinalResponse`, but **it cannot un-stream what was already
+> delivered**. The LLM debug synthesis interaction remains the streamed/raw
+> model draft. If you need to *block* content before the user sees it, do it in
+> a `BeforePlanning` hook, in a guarded prompt builder, or use the non-streaming
+> path.
 
 ---
 
@@ -608,6 +616,11 @@ There is no exported NoOp hook in non-test code; if you want one for tests, the 
 | Can't find the hook in a trace | Telemetry provider not configured, or hook never matched its stage | Verify telemetry is initialized; look for span `pipeline.hook.<stage>.<name>` |
 
 To verify a hook fired, look in Jaeger for its span (`pipeline.hook.before_planning.<name>`) or grep agent logs for the hook name. The DAG/registry-viewer debug UI surfaces `BeforePlanning` activity under its **Pre-Execution** tab and `AfterSynthesis` activity under **Post-Execution** — see the [Dev Tools Guide](../operations/DEV_TOOLS_GUIDE.md).
+
+This hook pipeline applies to the normal `ProcessRequest` paths.
+`ExecutePlanWithSynthesis` is workflow mode and currently does not invoke these
+hooks or store a post-hook `FinalResponse`; its synthesis record is model output
+only.
 
 That's the whole surface: four stages, one shared context, fail-open semantics. Wire a hook, confirm its span shows up in a trace, and build out from there. Happy hooking!
 

--- a/docs/overview/FRAMEWORK_FEATURES_GUIDE.md
+++ b/docs/overview/FRAMEWORK_FEATURES_GUIDE.md
@@ -843,7 +843,11 @@ See [Logging Implementation Guide](../observability/LOGGING_IMPLEMENTATION_GUIDE
 
 #### LLM And Execution Debug Stores
 
-Debug stores can persist full LLM payloads and execution records with TTLs for troubleshooting orchestration behavior. The telemetry package also includes LLM call recording interfaces for storing request/response metadata outside the request path.
+Debug stores can persist full LLM payloads and execution records with base TTLs
+for troubleshooting orchestration behavior. HITL, related-lineage, and explicit
+investigation retention may extend those minimums. The telemetry package also
+includes LLM call recording interfaces for storing request/response metadata
+outside the request path.
 
 See [Environment Variables Guide](../reference/ENVIRONMENT_VARIABLES_GUIDE.md#llm-debug-configuration), [API Reference: LLM Debug Store](../reference/API_REFERENCE.md#llm-debug-store), and [API Reference: LLM Call Recording](../reference/API_REFERENCE.md#llm-call-recording).
 
@@ -854,7 +858,9 @@ The Registry Viewer is a developer-facing runtime dashboard. It can inspect:
 - service registry
 - LLM debug records
 - HITL checkpoints
-- execution DAGs
+- conversation-grouped execution lineage and interactive DAGs
+- raw synthesis evidence versus stored post-`AfterSynthesis` application responses
+- optional Jaeger-linked traces and deterministic pipeline-hook spans
 - skill package management and version history
 - per-execution skill pinning, activation, resource loading, and prompt projection evidence
 - shared memory

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -3885,8 +3885,13 @@ recorder, err := telemetry.NewRedisLLMCallRecorder(
 if err != nil {
     log.Printf("LLM recording disabled: %v", err)
     recorder = nil // InstrumentedClient falls back to NoOp
+} else {
+    defer func() {
+        if closeErr := recorder.Close(); closeErr != nil {
+            log.Printf("LLM recorder close failed: %v", closeErr)
+        }
+    }()
 }
-defer recorder.Close()
 ```
 
 ### Distributed Tracing
@@ -5816,13 +5821,17 @@ require `ExecutionStorageProvider`, making atomic lineage promotion and
 TTL-preserving content rewrites compile-time provider requirements.
 
 Interrupted executions receive at least the maximum of normal retention, error
-retention, and the checkpoint's remaining approval lifetime. Storing a related
-execution promotes its existing root execution, trace mapping, conversation
-index, and current/root LLM-debug evidence to the selected minimum lifetime.
-`ExtendTTL` follows retained root links recursively with cycle protection.
-Normal extension reads a small retention-link projection instead of decoding
-the full execution payload, and direct Redis performs the related key updates
-inside its retry/circuit-breaker boundary. A missing requested execution returns
+retention, and the checkpoint's remaining approval lifetime. Within the
+execution store, storing a related execution promotes its existing root
+execution, trace mapping, and conversation index to the selected minimum
+lifetime. Final execution recording separately promotes current/root LLM-debug
+evidence through `LLMDebugRetentionPreserver`, with
+`LLMDebugStore.ExtendTTL` used as a compatibility fallback.
+`ExecutionStore.ExtendTTL` follows retained root links recursively with cycle
+protection. Normal extension reads a small
+retention-link projection instead of decoding the full execution payload, and
+direct Redis performs the related key updates inside its retry/circuit-breaker
+boundary. A missing requested execution returns
 `ErrExecutionRecordNotFound`. If the requested execution exists but a later
 ancestor has expired, the available retained chain is extended successfully
 and traversal stops without recreating the ancestor.

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -3865,6 +3865,17 @@ func NewRedisLLMCallRecorder(opts ...RecorderOption) (*RedisLLMCallRecorder, err
 
 **Built-in resilience:** Layer 1 retry with exponential backoff (3 attempts, 100ms→2s) and failure cooldown (5 failures within 30s triggers cooldown).
 
+The Redis write is an atomic append/metadata/index/minimum-TTL operation. It
+does not shorten a longer lifetime or make a persistent record expiring, so it
+can safely share a request record with `orchestration.RedisLLMDebugStore` after
+execution or lineage retention has been promoted. The built-in recorder
+preserves the prompt, system prompt, response, description, and error text it
+receives; it does not infer sensitive application fields or silently redact
+their values. Applications that require sanitization must supply it explicitly
+through their logger, telemetry pipeline, recorder, storage implementation, or
+middleware and must govern access, encryption, and retention for this opt-in
+debug data.
+
 **Example:**
 ```go
 recorder, err := telemetry.NewRedisLLMCallRecorder(
@@ -5602,7 +5613,20 @@ type LLMDebugStore interface {
     // ListRecent returns recent records for UI listing (newest first)
     ListRecent(ctx context.Context, limit int) ([]LLMDebugRecordSummary, error)
 }
+
+// Optional capability used by final execution recording. It establishes a
+// minimum lifetime for existing and future writes without creating an empty
+// debug record.
+type LLMDebugRetentionPreserver interface {
+    PreserveRetention(ctx context.Context, requestID string, duration time.Duration) error
+}
 ```
+
+`RedisLLMDebugStore` implements `LLMDebugRetentionPreserver` with a small
+request-scoped retention-floor key. Both the orchestration writer and
+`telemetry.RedisLLMCallRecorder` consult it atomically, so late or
+cross-process writes inherit the final execution lifetime. Custom stores that
+do not implement the optional capability continue through `ExtendTTL`.
 
 #### LLMInteraction Type
 
@@ -5762,12 +5786,46 @@ type IndexTTLManager interface {
         minTTL time.Duration,
     ) error
 }
+
+type KeyTTLManager interface {
+    // ExtendKeyTTL preserves an existing key for at least minTTL. It does not
+    // create a missing key, shorten a longer TTL, or expire a persistent key.
+    ExtendKeyTTL(ctx context.Context, key string, minTTL time.Duration) error
+
+    // SetKeyWithMinimumTTL writes value atomically while preserving the larger
+    // of the previous remaining TTL and minTTL. Persistent keys stay persistent.
+    SetKeyWithMinimumTTL(
+        ctx context.Context,
+        key string,
+        value string,
+        minTTL time.Duration,
+    ) error
+}
+
+type ExecutionStorageProvider interface {
+    StorageProvider
+    KeyTTLManager
+}
 ```
 
 Use `lister, ok := store.(ConversationExecutionLister)`; the NoOp store does
 not advertise the capability. Provider-backed stores may implement
 `IndexTTLManager`, but its absence is supported through bounded lazy index
-cleanup.
+cleanup. `NewExecutionStoreWithProvider` and `WithExecutionStoreProvider`
+require `ExecutionStorageProvider`, making atomic lineage promotion and
+TTL-preserving content rewrites compile-time provider requirements.
+
+Interrupted executions receive at least the maximum of normal retention, error
+retention, and the checkpoint's remaining approval lifetime. Storing a related
+execution promotes its existing root execution, trace mapping, conversation
+index, and current/root LLM-debug evidence to the selected minimum lifetime.
+`ExtendTTL` follows retained root links recursively with cycle protection.
+Normal extension reads a small retention-link projection instead of decoding
+the full execution payload, and direct Redis performs the related key updates
+inside its retry/circuit-breaker boundary. A missing requested execution returns
+`ErrExecutionRecordNotFound`. If the requested execution exists but a later
+ancestor has expired, the available retained chain is extended successfully
+and traversal stops without recreating the ancestor.
 
 `StoredExecution.Metadata` and `ExecutionSummary.Metadata` carry the
 framework-owned `MetadataConversationID`. Read it with
@@ -5784,6 +5842,10 @@ type ExecutionStoreConfig struct {
     ConversationIndexScanLimit int // default 5000
 }
 ```
+
+Non-positive `TTL` and `ErrorTTL` values in programmatic configuration are
+normalized to the standard 24-hour and 7-day defaults. They do not disable
+persistence or produce an invalid Redis expiry.
 
 The included direct Redis adapter exposes both store-owned and
 application-owned construction paths:
@@ -5822,7 +5884,8 @@ options apply afterward. `WithExecutionDebugRedisURL` and
 
 Positive programmatic values are authoritative. Per-call result limits are
 clamped to `ConversationQueryLimit`, and stale-index work is bounded by
-`ConversationIndexScanLimit`.
+`ConversationIndexScanLimit`. After explicit adapter options are applied,
+non-positive normal or error TTLs are normalized to the framework defaults.
 
 | Variable | Default |
 |---|---:|

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1494,8 +1494,8 @@ func (h *HotelHandler) handleSearch(rw http.ResponseWriter, r *http.Request) {
 
 #### RedactSensitiveText
 
-Sanitizes untrusted diagnostic text before it is written to logs, traces,
-execution/debug state, or another model prompt:
+Explicit helpers that an application, adapter, or framework subsystem may call
+when it has deliberately chosen to transform diagnostic text:
 
 ```go
 func RedactSensitiveText(value string) string
@@ -1513,13 +1513,21 @@ basic authorization values, credential-bearing URL user information, and common
 credential query parameters. It retains surrounding diagnostic structure and
 replaces values with `[REDACTED]`.
 
-This is defense in depth, not a general secret detector. Applications should
-still avoid placing credentials in URLs, response bodies, errors, prompts, or
-logs. The orchestration executor applies the helper to downstream failure text
-before retry/error-analysis prompts, state, logs, traces, checkpoints, and
-execution debug records. Successful tool payloads are not rewritten because
-they are application data. Tools that return logs or other observability data
-should sanitize those lines before returning them.
+This is a lossy, pattern-based transformation, not a general secret detector
+and not a framework-wide persistence guarantee. Built-in debug stores and
+recorders preserve the values supplied to them. Applications that require
+redaction must choose and install that policy explicitly through their logger,
+telemetry pipeline, recorder, storage implementation, middleware, or processing
+hooks.
+
+Some older framework paths still invoke these helpers before storage or
+observation. In particular, the orchestration executor currently transforms
+downstream failure text used by retry/error-analysis and error surfaces, and
+selected skills and provider diagnostics have similar behavior. These are
+legacy implementation exceptions pending the audit required by
+`FRAMEWORK_DESIGN_PRINCIPLES.md`; adopters must not rely on them as complete or
+stable sanitization. Successful application payloads are not automatically
+rewritten.
 
 Use `RedactSensitiveText` when only an observation field needs sanitization.
 Use `RedactSensitiveError` when the sanitized error is returned: its `Error`
@@ -1568,6 +1576,8 @@ func WithStepID(ctx context.Context, id string) context.Context
 func GetStepID(ctx context.Context) string
 
 // Validate and carry opaque multi-turn correlation.
+const MetadataConversationID = "conversation_id"
+
 func ValidateConversationID(id string) ConversationIDValidationReason
 func WithConversationID(ctx context.Context, id string) context.Context
 func GetConversationID(ctx context.Context) string
@@ -1577,6 +1587,10 @@ func WithoutConversationID(ctx context.Context) context.Context
 
 `ValidateConversationID` accepts 1–512 bytes from the documented
 W3C-baggage-safe visible-ASCII subset and returns a bounded reason enum.
+`MetadataConversationID` is the shared framework-owned metadata and baggage
+key. `orchestration.MetadataConversationID` remains an alias so applications
+can continue to set orchestration request metadata without importing a second
+package.
 `WithConversationID` records a programmatic candidate. An explicit
 `X-TruvaG3-Conversation-ID` candidate has precedence regardless of call order;
 invalid raw values are not retained. `WithoutConversationID` shadows inherited
@@ -3860,8 +3874,8 @@ func NewRedisLLMCallRecorder(opts ...RecorderOption) (*RedisLLMCallRecorder, err
 | `WithRecorderRedisURL(url)` | Redis connection URL |
 | `WithRecorderRedisDB(db)` | Redis database number (default: 7) |
 | `WithRecorderLogger(logger)` | Logger for recorder operations |
-| `WithRecorderTTL(ttl)` | TTL for successful records (default: 24h) |
-| `WithRecorderErrorTTL(ttl)` | TTL for error records (default: 7 days) |
+| `WithRecorderTTL(ttl)` | Base TTL for successful records (default: 24h); an existing longer/persistent lifetime or retention floor wins |
+| `WithRecorderErrorTTL(ttl)` | Base TTL for error records (default: 7 days); an existing longer/persistent lifetime or retention floor wins |
 
 **Built-in resilience:** Layer 1 retry with exponential backoff (3 attempts, 100ms→2s) and failure cooldown (5 failures within 30s triggers cooldown).
 
@@ -4756,6 +4770,7 @@ type Orchestrator interface {
     // 2. Returns a complete OrchestratorResponse (not raw ExecutionResult)
     // 3. Stores execution to ExecutionStore for DAG visualization
     // 4. Sets up context baggage for request_id propagation
+    // It does not run pipeline hooks or store a post-hook FinalResponse.
     ExecutePlanWithSynthesis(ctx context.Context, plan *RoutingPlan, originalRequest string) (*OrchestratorResponse, error)
 
     // GetExecutionHistory returns recent execution history
@@ -4772,7 +4787,7 @@ type Orchestrator interface {
 |--------|----------|
 | `ProcessRequest` | Natural language requests with AI-driven planning |
 | `ExecutePlan` | Pre-defined workflows when you need raw results for custom synthesis |
-| `ExecutePlanWithSynthesis` | Pre-defined workflows with full observability (DAG visualization, LLM debug store) |
+| `ExecutePlanWithSynthesis` | Pre-defined workflow execution with synthesis, DAG visualization, and LLM debug evidence; no application pipeline hooks or post-hook `FinalResponse` |
 
 **Example - ExecutePlanWithSynthesis:**
 ```go
@@ -5766,14 +5781,45 @@ type LLMDebugRecordSummary struct {
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TRUVAG3_LLM_DEBUG_ENABLED` | `false` | Enable debug capture |
-| `TRUVAG3_LLM_DEBUG_TTL` | `24h` | TTL for successful records |
-| `TRUVAG3_LLM_DEBUG_ERROR_TTL` | `168h` | TTL for error records (7 days) |
+| `TRUVAG3_LLM_DEBUG_TTL` | `24h` | Base TTL for successful records; longer lineage floors are preserved |
+| `TRUVAG3_LLM_DEBUG_ERROR_TTL` | `168h` | Base TTL for error records (7 days); HITL or investigation retention may extend it |
 | `TRUVAG3_LLM_DEBUG_REDIS_DB` | `7` | Redis database index |
 
 ### Execution Debug Store
 
 `ExecutionStore` remains the required request-oriented persistence contract.
 Conversation lookup is additive capability discovery:
+
+```go
+type StoredExecution struct {
+    // Existing correlation, request, plan, result, HITL, phase, skill, and
+    // metadata fields are omitted here for brevity.
+
+    // FinalResponse is the terminal application response captured after
+    // AfterSynthesis hooks on the normal ProcessRequest paths.
+    FinalResponse       *string `json:"final_response,omitempty"`
+    FinalResponseSource string  `json:"final_response_source,omitempty"`
+}
+
+const FinalResponseSourceAfterSynthesisHooks = "after_synthesis_hooks"
+```
+
+The LLM debug store retains the model's synthesis output. That output is a raw
+LLM draft, not proof of what the application ultimately returned. When the
+normal buffered or native-streaming `ProcessRequest` path reaches its terminal
+response, the execution recorder stores the post-`AfterSynthesis` value in
+`FinalResponse` and labels its source with
+`FinalResponseSourceAfterSynthesisHooks`. Registry Viewer displays that value
+under Post-Execution and keeps the synthesis interaction under LLM Calls.
+On native streaming, tokens were already emitted before `AfterSynthesis` ran;
+the stored value is the post-hook response object and may differ from text the
+client already received.
+
+`ExecutePlanWithSynthesis` is workflow mode: it executes a supplied plan and
+performs synthesis, but it does not run application pipeline hooks and does not
+currently store `FinalResponse`. Consumers must therefore treat its synthesis
+record as model output, not as post-hook application evidence. Historical
+records written before these fields existed also legitimately omit them.
 
 ```go
 type ConversationExecutionLister interface {

--- a/docs/reference/ENVIRONMENT_VARIABLES_GUIDE.md
+++ b/docs/reference/ENVIRONMENT_VARIABLES_GUIDE.md
@@ -1395,8 +1395,8 @@ Configure LLM debug payload storage for debugging orchestration issues. This fea
 | Variable | Default | Status | Description | Source |
 |----------|---------|--------|-------------|--------|
 | `TRUVAG3_LLM_DEBUG_ENABLED` | `false` | **Implemented** | Enable LLM debug payload storage | [orchestration/interfaces.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/interfaces.go) |
-| `TRUVAG3_LLM_DEBUG_TTL` | `24h` | **Implemented** | Retention period for successful debug records | [orchestration/redis_llm_debug_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_llm_debug_store.go) |
-| `TRUVAG3_LLM_DEBUG_ERROR_TTL` | `168h` (7 days) | **Implemented** | Retention period for error debug records (longer for troubleshooting) | [orchestration/redis_llm_debug_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_llm_debug_store.go) |
+| `TRUVAG3_LLM_DEBUG_TTL` | `24h` | **Implemented** | Base retention for successful debug records; a longer execution-lineage floor is preserved | [orchestration/redis_llm_debug_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_llm_debug_store.go) |
+| `TRUVAG3_LLM_DEBUG_ERROR_TTL` | `168h` (7 days) | **Implemented** | Base retention for error debug records; lineage, HITL, or investigation retention may extend it | [orchestration/redis_llm_debug_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_llm_debug_store.go) |
 | `TRUVAG3_LLM_DEBUG_REDIS_DB` | `7` | **Implemented** | Redis database number for debug storage (uses `core.RedisDBLLMDebug`) | [orchestration/redis_llm_debug_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_llm_debug_store.go) |
 
 ### How It Works
@@ -1405,7 +1405,14 @@ When enabled, the orchestrator automatically captures:
 - **Request payloads**: Full prompts sent to the LLM
 - **Response payloads**: Complete LLM responses (parsed and raw)
 - **Timing metadata**: Duration, timestamps, retry attempts
-- **Error context**: Parse failures, validation errors with original content
+- **Error context**: The error value supplied to the recorder. A small set of
+  legacy executor, skills, and provider paths still transforms errors before
+  recording; this is not a general sanitization guarantee.
+
+The built-in recorder preserves the prompt and response values it receives.
+This feature is therefore an informed opt-in: applications own access control,
+encryption, retention policy, and any explicit sanitization required for their
+data.
 
 ### Example: Enable Debug Storage
 
@@ -1450,8 +1457,8 @@ Configure execution debug storage for DAG visualization and debugging. This feat
 | Variable | Default | Status | Description | Source |
 |----------|---------|--------|-------------|--------|
 | `TRUVAG3_EXECUTION_DEBUG_STORE_ENABLED` | `false` | **Implemented** | Enable/disable execution debug storage | [orchestration/interfaces.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/interfaces.go) |
-| `TRUVAG3_EXECUTION_DEBUG_TTL` | `24h` | **Implemented** | Retention period for successful execution records | [orchestration/redis_execution_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_execution_store.go) |
-| `TRUVAG3_EXECUTION_DEBUG_ERROR_TTL` | `168h` (7 days) | **Implemented** | Retention period for failed execution records (longer for troubleshooting) | [orchestration/redis_execution_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_execution_store.go) |
+| `TRUVAG3_EXECUTION_DEBUG_TTL` | `24h` | **Implemented** | Base retention for successful execution records; related-lineage promotion may extend it | [orchestration/redis_execution_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_execution_store.go) |
+| `TRUVAG3_EXECUTION_DEBUG_ERROR_TTL` | `168h` (7 days) | **Implemented** | Base retention for failed execution records; HITL approval windows and investigation extensions may retain them longer | [orchestration/redis_execution_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_execution_store.go) |
 | `TRUVAG3_EXECUTION_DEBUG_KEY_PREFIX` | `truvag3:execution:debug` | **Implemented** | Key prefix for all storage keys. Allows multi-tenant deployments or custom namespacing. | [orchestration/redis_execution_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_execution_store.go) |
 | `TRUVAG3_EXECUTION_DEBUG_REDIS_DB` | `8` | **Implemented** | Redis database number (uses `core.RedisDBExecutionDebug`) | [orchestration/redis_execution_store.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/redis_execution_store.go) |
 | `TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT` | `1000` | **Implemented** | Maximum executions returned by one framework conversation lookup | [orchestration/interfaces.go](https://github.com/truvaagents/truva-g3/blob/main/orchestration/interfaces.go) |
@@ -1465,6 +1472,13 @@ default construction, or passed directly in `ExecutionStoreConfig`, is
 authoritative. The per-call `limit` passed to `ListByConversationID` is clamped
 to `ConversationQueryLimit`; stale-index work is independently bounded by
 `ConversationIndexScanLimit`.
+
+The TTL variables select the initial minimum, not an absolute deletion time.
+An interrupted record receives at least the larger of the normal TTL, error
+TTL, and remaining approval window. Storing or explicitly extending a related
+execution promotes the available lineage without shortening an existing longer
+or persistent lifetime. Final execution recording applies the corresponding
+minimum to current and root LLM-debug evidence, including late writes.
 
 ### Correlation and baggage protocol limits
 
@@ -1983,13 +1997,16 @@ answers.
 | `TRUVAG3_SKILL_AUTHORING_MAX_PACKAGE_BYTES` | `1048576` | **Example Only** | HTTP package body host override. |
 | `TRUVAG3_SKILL_ADMIN_MAX_DELETE_VERSIONS` | `100` | **Example Only** | Maximum inclusive deletion range accepted by the host. |
 | `TRUVAG3_SKILL_AUTHORING_ADVICE_MAX_OUTPUT_TOKENS` | `1024` | **Example Only** | Optional authoring-advisor output ceiling; the bundled host does not configure an advisor in V1. |
+| `JAEGER_QUERY_URL` | disabled for a direct binary; `http://jaeger-query` through `setup.sh deploy` | **Example Only** | Server-side Jaeger Query base URL used for optional execution and pipeline-hook enrichment. |
+| `JAEGER_UI_URL` | `http://jaeger.localhost` | **Example Only** | Browser-facing Jaeger base URL used by the Registry Viewer trace redirect. |
 
-The authoring-limit variables belong to the example host, not framework-global
-configuration. Other hosts pass `SkillAuthoringLimits` and
+These Registry Viewer variables belong to the example host, not framework-global
+configuration. Other skills hosts pass `SkillAuthoringLimits` and
 `SkillAdministrationLimits` directly to `NewSkillAdminHandler`. The Registry
 Viewer binary reads these values from its process environment; its bundled
 `setup.sh` does not automatically forward authoring/admin overrides from the
-invoking shell into Kubernetes.
+invoking shell into Kubernetes. It does forward the two Jaeger values into the
+deployment ConfigMap.
 
 ---
 

--- a/examples/registry-viewer-app/Dockerfile
+++ b/examples/registry-viewer-app/Dockerfile
@@ -1,6 +1,8 @@
-# Dockerfile for registry-viewer-app
-# This is a standalone app - no truvag3 framework dependencies required
-# Usage: docker build -t registry-viewer:latest .
+# Dockerfile for a source-level registry-viewer-app checkout.
+# In the TruvaG3 repository, use setup.sh and Dockerfile.workspace; this file
+# requires the go.mod replace directives to resolve to released or copied
+# framework modules before it can be built outside the workspace.
+# Usage after that preparation: docker build -t registry-viewer:latest .
 
 FROM golang:1.27.0-alpine AS builder
 
@@ -51,7 +53,7 @@ RUN chown appuser:appgroup /app/registry-viewer && \
 USER appuser
 
 # Set default PORT
-ENV PORT=8100
+ENV PORT=8361
 
 # Expose port
 EXPOSE ${PORT}

--- a/examples/registry-viewer-app/README.md
+++ b/examples/registry-viewer-app/README.md
@@ -1,6 +1,10 @@
 # Registry Viewer App
 
-A standalone, real-time web dashboard for viewing services registered in a Redis-based service registry. This app is designed to be fully independent and can be extracted to its own repository without any modifications.
+An independently deployable, real-time web dashboard for inspecting the TruvaG3
+service registry, execution records, LLM debug data, HITL checkpoints, skills,
+memory, and traces. The backend currently imports TruvaG3 framework modules;
+moving its source to another repository therefore requires the dependency and
+container-build changes described below.
 
 ## Table of Contents
 
@@ -49,7 +53,7 @@ A standalone, real-time web dashboard for viewing services registered in a Redis
 ### UI Features
 - Dark theme optimized for monitoring
 - Navigation for Registry, LLM Debug, HITL, Execution DAG, Skills, and Memory
-- Zero external framework dependencies
+- Vanilla HTML, CSS, and JavaScript frontend with no browser framework dependency
 
 ### Skills Management
 
@@ -94,9 +98,9 @@ Once complete, the dashboard is available at:
 
 | Service | URL | Description |
 |---------|-----|-------------|
-| **Registry Viewer** | http://localhost:8100 | Web dashboard for service registry |
-| **API** | http://localhost:8100/api/services | JSON list of registered services |
-| **Health** | http://localhost:8100/api/health | Health check endpoint |
+| **Registry Viewer** | http://localhost:8361 | Web dashboard for service registry |
+| **API** | http://localhost:8361/api/services | JSON list of registered services |
+| **Health** | http://localhost:8361/api/health | Health check endpoint |
 
 ### Run Locally with Mock Data
 
@@ -109,7 +113,7 @@ cd examples/registry-viewer-app
 ./setup.sh run
 ```
 
-Open http://localhost:8100 in your browser.
+Open http://localhost:8361 in your browser.
 
 ## Setup Script Commands
 
@@ -129,7 +133,7 @@ Docker:
 Kubernetes Deployment:
   deploy        Build, load to Kind, and deploy to K8s
   rebuild       Rebuild with --no-cache and redeploy
-  forward       Port forward from K8s to localhost:8100
+  forward       Port forward from K8s to localhost:8361
   logs          Stream logs from K8s pod
   cleanup       Remove deployed resources
 ```
@@ -143,7 +147,7 @@ Kubernetes Deployment:
 | `-mock` | `true` | Use mock data instead of Redis |
 | `-redis-url` | `redis://localhost:6379` | Redis connection URL |
 | `-namespace` | `truvag3` | Redis key namespace for service discovery |
-| `-port` | `8100` | HTTP server port |
+| `-port` | `8361` | HTTP server port |
 
 ### Environment Variables
 
@@ -157,6 +161,8 @@ Environment variables override command-line flags, making the app easy to config
 | `PORT` | HTTP server port (overrides `-port`) |
 | `APP_ENV` | Selects the `development` (default), `staging`, or `production` telemetry profile |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP/HTTP endpoint used by Registry Viewer and framework telemetry |
+| `JAEGER_QUERY_URL` | Server-side Jaeger Query base URL used to enrich execution details. A direct binary start leaves enrichment disabled; `setup.sh deploy` supplies `http://jaeger-query` by default. |
+| `JAEGER_UI_URL` | Browser-facing Jaeger UI base URL used by trace redirects (default `http://jaeger.localhost`) |
 | `TRUVAG3_SKILLS_REDIS_DB` | Redis role database for skill packages (default `9`) |
 | `TRUVAG3_SKILL_AUTHORING_MAX_NAME_CHARS` | Maximum namespace/name/domain/tag/resource slug length (default `64`) |
 | `TRUVAG3_SKILL_AUTHORING_MAX_DESCRIPTION_CHARS` | Maximum main skill catalog-description length (default `1024`) |
@@ -208,6 +214,7 @@ REDIS_URL=redis://custom-redis:6379 ./setup.sh deploy
 | `GET /api/executions` | List recent executions in the existing flat response shape |
 | `GET /api/executions?group_conversations=true` | List server-owned conversation groups; stable DB 8 sorts support filter-aware cursor pagination |
 | `GET /api/executions/{request_id}/unified` | Get the unified execution, DAG, LLM, HITL, trace, and conversation detail |
+| `GET /api/traces/{trace_id}` | Temporarily redirect the browser to the trace page under the configured `JAEGER_UI_URL` |
 | `GET /api/conversations?conversation_id={id}` | Get one verified chronological conversation timeline |
 | `GET /api/v1/skills` | List body-free published skill metadata; optional `namespace`, `domain`, `tag`, and `limit` filters |
 | `GET /api/v1/skills/schema` | Get the complete authoring JSON Schema with its active constraints |
@@ -329,7 +336,7 @@ The app expects services to be stored in Redis with keys matching the pattern `{
 # Deploy to existing Kind cluster (build + load into Kind + apply manifest)
 ./setup.sh deploy
 
-# Port forward the app to localhost:8100
+# Port forward the app to localhost:8361
 ./setup.sh forward
 ```
 
@@ -339,40 +346,58 @@ The app expects services to be stored in Redis with keys matching the pattern `{
 
 ```
 registry-viewer-app/
-├── main.go              # Go backend with embedded static files
-├── go.mod               # Go module (standalone, no framework deps)
-├── go.sum               # Dependency checksums
-├── static/
-│   └── index.html       # Single-page frontend (HTML/CSS/JS)
-├── Dockerfile           # Container build
-├── k8-deployment.yaml   # Kubernetes manifests
-├── setup.sh             # Setup and deployment script
-└── README.md            # This file
+├── main.go                  # HTTP server, registry, execution, HITL, and memory APIs
+├── conversation_api.go      # Conversation grouping and timeline API
+├── jaeger_trace.go          # Jaeger enrichment and browser redirect
+├── skills_api.go            # Skills management API host
+├── redis_storage_provider.go # Redis adapter used by viewer APIs
+├── go.mod                   # Module plus local framework replacements
+├── go.sum                   # Dependency checksums
+├── static/                  # HTML, CSS, JavaScript, and image assets
+├── tests/                   # Frontend Node.js tests
+├── Dockerfile.workspace     # Supported in-repository container build
+├── Dockerfile               # Prepared standalone-checkout container build
+├── k8-deployment.yaml       # Kubernetes manifests
+├── setup.sh                 # Local and Kind deployment commands
+└── README.md                # This file
 ```
 
 ## Extracting to Standalone Repository
 
-This app is designed to be fully portable. To use it as a standalone project:
+The application is independently deployable, but its source is not currently a
+single-folder standalone module. Its module path is
+`github.com/truvaagents/truva-g3/examples/registry-viewer-app`, and `go.mod`
+imports `core`, `memory`, `orchestration`, and `telemetry` through local
+`../../...` replacements.
 
-1. Copy the entire `registry-viewer-app` folder
-2. No modifications needed - just build and run
-3. The module path is generic (`registry-viewer-app`)
-4. Only direct runtime dependency is `github.com/redis/go-redis/v9`
+To move it to a separate repository:
+
+1. Copy the complete `registry-viewer-app` directory, including `static/` and
+   the frontend tests.
+2. Choose the new module path and update the `module` directive.
+3. Remove the local `replace` directives and depend on released TruvaG3 module
+   versions that contain the APIs used by the viewer, or copy and maintain those
+   modules in the new repository.
+4. Update the container build. In this repository, `setup.sh` deliberately uses
+   `Dockerfile.workspace` so it can copy the local framework modules. The
+   source-level `Dockerfile` is usable only after the dependencies above resolve
+   without reaching outside its build context.
+5. Run the Go and frontend tests before building the binary or image.
 
 ```bash
-# In a new location/repo
+# After updating the module dependencies in the new repository
+GOWORK=off go test ./...
 go build -o registry-viewer .
 ./registry-viewer
 ```
 
 ## Port Allocation
 
-Default port `8100` was chosen to avoid conflicts with common service ports:
-- 8080-8099: Reserved for example tools and agents
-- 3000: Grafana
-- 6379: Redis
-- 9090: Prometheus
-- 16686: Jaeger
+Port `8361` is reserved for Registry Viewer in the central
+[examples port catalog](../README.md#ports). Keep the binary, container,
+Kubernetes manifest, setup script, and documentation on that value unless the
+catalog allocation is deliberately changed. Shared infrastructure such as
+Redis, Grafana, Prometheus, and Jaeger retains its own ports and ingress routes.
 
 ## Build Environment Variables
 
@@ -380,6 +405,8 @@ Default port `8100` was chosen to avoid conflicts with common service ports:
 |----------|-------------|
 | `REDIS_URL` | Override Redis URL for deployment (default: extracted from redis.yaml) |
 | `REDIS_NAMESPACE` | Redis key namespace (default: `truvag3`) |
+| `JAEGER_QUERY_URL` | Jaeger Query base URL supplied to the Deployment (default: `http://jaeger-query`) |
+| `JAEGER_UI_URL` | Browser-facing Jaeger UI base URL supplied to the Deployment (default: `http://jaeger.localhost`) |
 | `DOCKER_NO_CACHE` | Set to `true` for fresh Docker build |
 
 ## Related Orchestration Environment Variables

--- a/examples/registry-viewer-app/README.md
+++ b/examples/registry-viewer-app/README.md
@@ -231,10 +231,19 @@ REDIS_URL=redis://custom-redis:6379 ./setup.sh deploy
 default. The framework does not add authentication or authorization—the host,
 ingress, service mesh, and platform policy own endpoint protection.
 
-The conversation endpoints read the existing framework-owned Redis DB 7 and
-DB 8 data. The Registry Viewer does not create, repair, expire, or otherwise
-mutate execution or conversation indexes, so read-only DB 7/8 credentials are
-sufficient.
+This applies to the complete Viewer, not only Skills. When LLM or execution
+debugging is enabled, the UI can expose full prompts, model responses, tool
+results, errors, metadata, and user context that actually reached the recorder.
+Built-in stores preserve those payloads rather than inferring redaction. Do not
+expose the bundled local ingress to an untrusted network without an application-
+owned authentication, authorization, and data-protection layer.
+
+The conversation endpoints read framework-owned LLM evidence from Redis DB 7
+and execution evidence from DB 8. DB 7 is read-only to the Viewer. DB 8 is not:
+grouped and timeline reads remove only index members whose authoritative
+execution key has been confirmed missing. They never delete an execution record
+or invent a relationship. The Viewer therefore needs read access to DB 7 and
+read/write access to the DB 8 sorted-set indexes.
 
 ### Grouped execution safety bounds
 
@@ -254,17 +263,25 @@ Viewer implementation limits, not `TRUVAG3_*` framework configuration:
 | LLM Debug interactions accepted per execution | 100 |
 | LLM Debug interaction bytes accepted per execution | 4 MiB |
 | Maximum encoded grouped cursor length | 2048 bytes |
+| Background stale global-index scan | 200 members, at most once per 30 seconds per Viewer process |
 
 When a DB 8 membership or grouping bound is reached, the response sets
 `partial=true` and omits a grouped continuation cursor. The existing flat
 execution list remains available for request-by-request troubleshooting.
 
-Combined duration sorting (`sort=total_duration_ms`) includes LLM duration read
-from mutable DB 7 data. It is therefore a bounded point-in-time sort: when more
-groups exist than the requested limit, the response is partial and does not
-provide a continuation cursor. A supplied duration-sort cursor is rejected.
-Created and request-text sorts use immutable DB 8 values and retain grouped
-keyset pagination.
+Elapsed-duration sorting (`sort=total_duration_ms`, retained as the compatible
+query name) uses a non-additive wall-clock envelope. The baseline is the stored
+phase-loop duration. Step timestamps may extend that envelope, and bounded DB 7
+enrichment may extend it to include LLM calls that occurred outside the first
+and last recorded step. The Viewer takes the largest credible envelope; it does
+not add step and LLM durations that may overlap. Aggregate LLM call time is
+reported separately.
+
+Because the elapsed envelope can depend on mutable DB 7 evidence, duration
+sorting is a bounded point-in-time sort: when more groups exist than the
+requested limit, the response is partial and does not provide a continuation
+cursor. A supplied duration-sort cursor is rejected. Created and request-text
+sorts use immutable DB 8 values and retain grouped keyset pagination.
 
 If a DB 7 enrichment read fails or reaches any enrichment bound, timeline and
 grouped responses set `llm_enrichment_incomplete=true`. Created and request-text
@@ -273,6 +290,36 @@ optional DB 7 details do not suppress their valid `next_cursor`. Combined
 duration sorting sets `partial=true` when enrichment is incomplete because DB 7
 contributes to its ordering. The Viewer does not publish a partial per-execution
 LLM duration or call count as though it were complete.
+
+For HITL resume records, elapsed observation ignores restored pre-checkpoint
+steps and uses resume-owned steps/phases plus later LLM evidence. This prevents
+the human approval wait from being presented as active compute time.
+
+### Raw synthesis and terminal application response
+
+The LLM Calls tab shows the synthesis interaction as model evidence. The card is
+labeled **Pre-hook LLM synthesis output**, and its response expander says **View
+Pre-hook Output**, because application `AfterSynthesis` hooks may change that
+content. When the execution record contains `final_response` with source
+`after_synthesis_hooks`, the Post-Execution tab shows that post-hook application
+response separately.
+
+Workflow-mode `ExecutePlanWithSynthesis` does not run pipeline hooks and does
+not currently store a post-hook final response. Older records also predate this
+field. In both cases, the absence message means only that no governed terminal
+response was stored; it does not convert the synthesis draft into proof of the
+business outcome.
+
+### Unified-detail enrichment cost
+
+Each `GET /api/executions/{request_id}/unified` load is assembled on demand and
+is not cached by the Viewer. It reads the DB 8 execution, reads bounded DB 7 LLM
+evidence, may fan out to agent checkpoint APIs for HITL state, and may inspect
+up to 200 recent execution summaries to find an HITL sibling. When
+`JAEGER_QUERY_URL` is configured, it also makes one synchronous Jaeger request
+with a three-second HTTP client timeout and an 8 MiB response limit. Jaeger
+failure marks trace enrichment unavailable but does not fail the Redis-backed
+execution detail.
 
 ## Service Data Structure
 
@@ -420,8 +467,8 @@ Enable LLM debug storage to capture full request/response payloads for troublesh
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TRUVAG3_LLM_DEBUG_ENABLED` | `false` | Enable LLM debug payload storage |
-| `TRUVAG3_LLM_DEBUG_TTL` | `24h` | Retention period for successful debug records |
-| `TRUVAG3_LLM_DEBUG_ERROR_TTL` | `168h` (7 days) | Retention period for error debug records |
+| `TRUVAG3_LLM_DEBUG_TTL` | `24h` | Base retention for successful debug records; lineage promotion may extend it |
+| `TRUVAG3_LLM_DEBUG_ERROR_TTL` | `168h` (7 days) | Base retention for error debug records; HITL or investigation retention may extend it |
 | `TRUVAG3_LLM_DEBUG_REDIS_DB` | `7` | Redis database number for debug storage |
 
 **Example:**

--- a/examples/registry-viewer-app/conversation_api.go
+++ b/examples/registry-viewer-app/conversation_api.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"math"
 	"net/http"
 	"sort"
@@ -108,9 +109,11 @@ type indexedExecution struct {
 }
 
 type executionReadCache struct {
-	records  map[string]*StoredExecution
-	missing  map[string]struct{}
-	hydrated int
+	records       map[string]*StoredExecution
+	missing       map[string]struct{}
+	unreadable    map[string]struct{}
+	hydrated      int
+	exactHydrated int
 }
 
 type llmDebugEnrichment struct {
@@ -120,8 +123,11 @@ type llmDebugEnrichment struct {
 }
 
 var (
-	llmDebugReadClient   *redis.Client
-	llmDebugReadClientMu sync.Mutex
+	llmDebugReadClient     *redis.Client
+	llmDebugReadClientMu   sync.Mutex
+	staleIndexSweepMu      sync.Mutex
+	staleIndexSweepCursor  uint64
+	staleIndexSweepLastRun time.Time
 )
 
 func getLLMDebugReadClient() (*redis.Client, error) {
@@ -154,15 +160,33 @@ func summarizeExecution(execution *StoredExecution) ExecutionSummary {
 		CreatedAt:         execution.CreatedAt,
 		Metadata:          execution.Metadata,
 	}
+	if execution.Checkpoint != nil {
+		summary.HITLCheckpointID = execution.Checkpoint.CheckpointID
+	} else {
+		summary.HITLCheckpointID = execution.Metadata["resume_checkpoint_id"]
+	}
 	if execution.Result != nil {
 		summary.Success = execution.Result.Success
 		summary.TotalDurationMs = execution.Result.TotalDuration / 1_000_000
+		summary.WallClockDurationMs = summary.TotalDurationMs
+		if summary.WallClockDurationMs > 0 {
+			summary.DurationSource = "phase_loop_fallback"
+		}
 		summary.StepCount = len(execution.Result.Steps)
 		for _, step := range execution.Result.Steps {
 			if !step.Success {
 				summary.FailedSteps++
 			}
 		}
+	}
+	summary.observedStart, summary.observedEnd = executionObservationWindow(execution)
+	if observed := observedDurationMilliseconds(summary.observedStart, summary.observedEnd); observed > 0 {
+		summary.WallClockDurationMs, summary.DurationSource = preferDurationCandidate(
+			summary.WallClockDurationMs,
+			summary.DurationSource,
+			observed,
+			"step_time_envelope",
+		)
 	}
 	return summary
 }
@@ -174,8 +198,9 @@ func viewerConversationIndexKey(conversationID string) string {
 
 func newExecutionReadCache() *executionReadCache {
 	return &executionReadCache{
-		records: make(map[string]*StoredExecution),
-		missing: make(map[string]struct{}),
+		records:    make(map[string]*StoredExecution),
+		missing:    make(map[string]struct{}),
+		unreadable: make(map[string]struct{}),
 	}
 }
 
@@ -184,6 +209,29 @@ func (c *executionReadCache) load(
 	client *redis.Client,
 	requestIDs []string,
 ) (bool, error) {
+	remaining := viewerExecutionHydrationLimit - c.hydrated
+	loaded, partial, err := c.loadWithBudget(ctx, client, requestIDs, remaining)
+	c.hydrated += loaded
+	return partial, err
+}
+
+func (c *executionReadCache) loadExactOwners(
+	ctx context.Context,
+	client *redis.Client,
+	requestIDs []string,
+) (bool, error) {
+	remaining := viewerExactOwnerHydrationLimit - c.exactHydrated
+	loaded, partial, err := c.loadWithBudget(ctx, client, requestIDs, remaining)
+	c.exactHydrated += loaded
+	return partial, err
+}
+
+func (c *executionReadCache) loadWithBudget(
+	ctx context.Context,
+	client *redis.Client,
+	requestIDs []string,
+	remaining int,
+) (int, bool, error) {
 	unknown := make([]string, 0, len(requestIDs))
 	seen := make(map[string]struct{}, len(requestIDs))
 	for _, requestID := range requestIDs {
@@ -200,19 +248,21 @@ func (c *executionReadCache) load(
 		if _, ok := c.missing[requestID]; ok {
 			continue
 		}
+		if _, ok := c.unreadable[requestID]; ok {
+			continue
+		}
 		unknown = append(unknown, requestID)
 	}
 
-	remaining := viewerExecutionHydrationLimit - c.hydrated
 	truncated := len(unknown) > remaining
 	if remaining <= 0 {
-		return len(unknown) > 0, nil
+		return 0, len(unknown) > 0, nil
 	}
 	if len(unknown) > remaining {
 		unknown = unknown[:remaining]
 	}
 	if len(unknown) == 0 {
-		return truncated, nil
+		return 0, truncated, nil
 	}
 
 	keys := make([]string, len(unknown))
@@ -221,9 +271,9 @@ func (c *executionReadCache) load(
 	}
 	values, err := client.MGet(ctx, keys...).Result()
 	if err != nil {
-		return truncated, fmt.Errorf("failed to hydrate executions: %w", err)
+		return 0, truncated, fmt.Errorf("failed to hydrate executions: %w", err)
 	}
-	c.hydrated += len(unknown)
+	partial := truncated
 	for i, value := range values {
 		requestID := unknown[i]
 		if value == nil {
@@ -237,17 +287,164 @@ func (c *executionReadCache) load(
 		case []byte:
 			data = typed
 		default:
-			c.missing[requestID] = struct{}{}
+			c.unreadable[requestID] = struct{}{}
+			partial = true
 			continue
 		}
 		execution, decodeErr := deserializeExecution(data)
 		if decodeErr != nil {
-			c.missing[requestID] = struct{}{}
+			c.unreadable[requestID] = struct{}{}
+			partial = true
 			continue
 		}
 		c.records[requestID] = execution
 	}
-	return truncated, nil
+	return len(unknown), partial, nil
+}
+
+func pruneConfirmedMissingIndexMembers(
+	ctx context.Context,
+	client *redis.Client,
+	indexKey string,
+	requestIDs []string,
+	missing map[string]struct{},
+) {
+	stale := make([]interface{}, 0)
+	seen := make(map[string]struct{}, len(requestIDs))
+	for _, requestID := range requestIDs {
+		if _, duplicate := seen[requestID]; duplicate {
+			continue
+		}
+		seen[requestID] = struct{}{}
+		if _, confirmedMissing := missing[requestID]; confirmedMissing {
+			stale = append(stale, requestID)
+		}
+	}
+	if len(stale) == 0 {
+		return
+	}
+	if err := client.ZRem(ctx, indexKey, stale...).Err(); err != nil {
+		log.Printf("[WARN] execution index cleanup failed")
+	}
+}
+
+// maintainStaleGlobalExecutionIndex periodically advances a bounded Redis
+// ZSCAN cursor. Unlike newest-first page cleanup, repeated eligible calls
+// eventually inspect old members outside the normal hydration window without
+// adding a scan and hydration round trip to every grouped-list request.
+func maintainStaleGlobalExecutionIndex(ctx context.Context, client *redis.Client) {
+	if !staleIndexSweepMu.TryLock() {
+		return
+	}
+	defer staleIndexSweepMu.Unlock()
+	now := time.Now()
+	if !staleIndexSweepLastRun.IsZero() &&
+		now.Sub(staleIndexSweepLastRun) < viewerStaleIndexMaintenanceInterval {
+		return
+	}
+	// Advance the eligibility clock before Redis work so a temporary backend
+	// failure cannot make every incoming list request repeat the same sweep.
+	staleIndexSweepLastRun = now
+
+	rows, nextCursor, err := client.ZScan(
+		ctx,
+		executionIndexKey,
+		staleIndexSweepCursor,
+		"",
+		viewerStaleIndexMaintenanceBatch,
+	).Result()
+	if err != nil {
+		log.Printf("[WARN] execution index maintenance scan failed")
+		return
+	}
+	requestIDs := make([]string, 0, len(rows)/2)
+	for index := 0; index+1 < len(rows); index += 2 {
+		requestIDs = append(requestIDs, rows[index])
+	}
+	if len(requestIDs) == 0 {
+		staleIndexSweepCursor = nextCursor
+		return
+	}
+	keys := make([]string, len(requestIDs))
+	for index, requestID := range requestIDs {
+		keys[index] = executionKeyPrefix + requestID
+	}
+	values, err := client.MGet(ctx, keys...).Result()
+	if err != nil {
+		log.Printf("[WARN] execution index maintenance hydration failed")
+		return
+	}
+	missing := make(map[string]struct{})
+	for index, value := range values {
+		if value == nil {
+			missing[requestIDs[index]] = struct{}{}
+		}
+	}
+	pruneConfirmedMissingIndexMembers(
+		ctx,
+		client,
+		executionIndexKey,
+		requestIDs,
+		missing,
+	)
+	staleIndexSweepCursor = nextCursor
+}
+
+func unresolvedExecutionOwnerIDs(
+	summaries map[string]ExecutionSummary,
+) []string {
+	ownerIDs := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, summary := range summaries {
+		if isTopLevelExecution(summary) {
+			continue
+		}
+		ownerID := summary.OriginalRequestID
+		if _, exists := summaries[ownerID]; exists {
+			continue
+		}
+		if _, duplicate := seen[ownerID]; duplicate {
+			continue
+		}
+		seen[ownerID] = struct{}{}
+		ownerIDs = append(ownerIDs, ownerID)
+	}
+	return ownerIDs
+}
+
+func hydrateAndClassifyGroupedExecutionOwners(
+	ctx context.Context,
+	client *redis.Client,
+	cache *executionReadCache,
+	summaries map[string]ExecutionSummary,
+) (bool, error) {
+	ownerIDs := unresolvedExecutionOwnerIDs(summaries)
+	partial, err := cache.loadExactOwners(ctx, client, ownerIDs)
+	if err != nil {
+		return partial, err
+	}
+	for _, ownerID := range ownerIDs {
+		if execution := cache.records[ownerID]; execution != nil {
+			summaries[ownerID] = summarizeExecution(execution)
+		}
+	}
+	for requestID, summary := range summaries {
+		if isTopLevelExecution(summary) {
+			continue
+		}
+		if _, ownerPresent := summaries[summary.OriginalRequestID]; ownerPresent {
+			continue
+		}
+		if _, confirmedMissing := cache.missing[summary.OriginalRequestID]; confirmedMissing {
+			summary.RelationStatus = "owner_unavailable"
+			summary.MissingOwnerID = summary.OriginalRequestID
+		} else {
+			summary.RelationStatus = "owner_unknown"
+			partial = true
+		}
+		summaries[requestID] = summary
+	}
+	return partial, nil
 }
 
 func handleConversationTimeline(w http.ResponseWriter, r *http.Request) {
@@ -348,6 +545,20 @@ func loadConversationTimeline(
 	if err != nil {
 		return nil, err
 	}
+	pruneConfirmedMissingIndexMembers(
+		ctx,
+		client,
+		executionIndexKey,
+		globalIDs,
+		cache.missing,
+	)
+	pruneConfirmedMissingIndexMembers(
+		ctx,
+		client,
+		conversationKey,
+		reverseIDs,
+		cache.missing,
+	)
 
 	reverseSet := make(map[string]struct{}, len(reverseIDs))
 	for _, requestID := range reverseIDs {
@@ -371,6 +582,36 @@ func loadConversationTimeline(
 			continue
 		}
 		verified[requestID] = summarizeExecution(execution)
+	}
+	ownerIDs := unresolvedExecutionOwnerIDs(verified)
+	ownerHydrationPartial, err := cache.loadExactOwners(ctx, client, ownerIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, ownerID := range ownerIDs {
+		execution := cache.records[ownerID]
+		if execution == nil ||
+			execution.Metadata[orchestration.MetadataConversationID] != conversationID {
+			continue
+		}
+		verified[ownerID] = summarizeExecution(execution)
+	}
+	ownerClassificationPartial := ownerHydrationPartial
+	for requestID, summary := range verified {
+		if isTopLevelExecution(summary) {
+			continue
+		}
+		if _, ownerPresent := verified[summary.OriginalRequestID]; ownerPresent {
+			continue
+		}
+		if _, confirmedMissing := cache.missing[summary.OriginalRequestID]; confirmedMissing {
+			summary.RelationStatus = "owner_unavailable"
+			summary.MissingOwnerID = summary.OriginalRequestID
+		} else {
+			summary.RelationStatus = "owner_unknown"
+			ownerClassificationPartial = true
+		}
+		verified[requestID] = summary
 	}
 	membershipChecks := make(map[string][]string)
 	for requestID := range verified {
@@ -403,7 +644,7 @@ func loadConversationTimeline(
 		conversationID,
 		summaries,
 		enrichment,
-		reverseMore || globalMore || hydrationPartial,
+		reverseMore || globalMore || hydrationPartial || ownerClassificationPartial,
 		indexIncomplete,
 		enrichmentIncomplete || enrichmentErr != nil,
 	), nil
@@ -660,6 +901,14 @@ func loadGroupedExecutions(
 	if err != nil {
 		return nil, err
 	}
+	pruneConfirmedMissingIndexMembers(
+		ctx,
+		client,
+		executionIndexKey,
+		globalIDs,
+		cache.missing,
+	)
+	maintainStaleGlobalExecutionIndex(ctx, client)
 	partial := globalPartial || hydrationPartial
 
 	conversationOrder := make([]string, 0)
@@ -706,6 +955,15 @@ func loadGroupedExecutions(
 		return nil, err
 	}
 	partial = partial || reverseHydrationPartial
+	for _, conversationID := range conversationOrder {
+		pruneConfirmedMissingIndexMembers(
+			ctx,
+			client,
+			viewerConversationIndexKey(conversationID),
+			reverseMembers[conversationID],
+			cache.missing,
+		)
+	}
 
 	snapshotScoreNumber, _ := strconv.ParseFloat(snapshotScore, 64)
 	summariesByID := make(map[string]ExecutionSummary)
@@ -781,6 +1039,17 @@ func loadGroupedExecutions(
 			indexIncomplete[groupedConversationKey(conversationID)] = true
 		}
 	}
+
+	ownerPartial, err := hydrateAndClassifyGroupedExecutionOwners(
+		ctx,
+		client,
+		cache,
+		summariesByID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	partial = partial || ownerPartial
 
 	summaries := make([]ExecutionSummary, 0, len(summariesByID))
 	for _, summary := range summariesByID {
@@ -1100,20 +1369,31 @@ func buildGroupedExecutionUnits(
 
 		matching := make([]ExecutionSummary, 0, len(topLevel))
 		for _, member := range topLevel {
-			if executionMatchesGroupedQuery(member, conversationID, query) {
+			if executionMatchesGroupedQuery(member, conversationID, query) ||
+				anyExecutionMatchesGroupedQuery(
+					relatedByOwner[member.RequestID],
+					conversationID,
+					query,
+				) {
 				matching = append(matching, member)
 			}
 		}
 		if len(matching) == 0 {
-			if len(topLevel) > 0 ||
-				query.Status != "all" ||
-				(query.Search != "" &&
-					!strings.Contains(strings.ToLower(conversationID), query.Search)) {
+			if len(topLevel) > 0 {
+				continue
+			}
+			matchingOrphans := make([]ExecutionSummary, 0, len(orphans))
+			for _, orphan := range orphans {
+				if executionMatchesGroupedQuery(orphan, conversationID, query) {
+					matchingOrphans = append(matchingOrphans, orphan)
+				}
+			}
+			if len(matchingOrphans) == 0 {
 				continue
 			}
 			// Preserve a globally-discovered related execution even when its
 			// owning top-level record is outside the bounded snapshot.
-			matching = append(matching, orphans[0])
+			matching = append(matching, matchingOrphans[0])
 		}
 
 		anchor := matching[0]
@@ -1185,6 +1465,19 @@ func executionMatchesGroupedQuery(
 		strings.Contains(strings.ToLower(conversationID), query.Search)
 }
 
+func anyExecutionMatchesGroupedQuery(
+	summaries []ExecutionSummary,
+	conversationID string,
+	query *groupedExecutionQuery,
+) bool {
+	for _, summary := range summaries {
+		if executionMatchesGroupedQuery(summary, conversationID, query) {
+			return true
+		}
+	}
+	return false
+}
+
 func groupedExecutionSortValue(
 	summary ExecutionSummary,
 	field string,
@@ -1198,7 +1491,7 @@ func groupedExecutionSortValue(
 	case "total_duration_ms":
 		return groupedSortValue{
 			Kind:   "number",
-			Number: summary.TotalDurationMs + summary.LLMTotalDurationMs,
+			Number: primaryExecutionDurationMs(summary),
 		}
 	default:
 		return groupedSortValue{
@@ -1206,6 +1499,13 @@ func groupedExecutionSortValue(
 			Number: summary.CreatedAt.UnixNano(),
 		}
 	}
+}
+
+func primaryExecutionDurationMs(summary ExecutionSummary) int64 {
+	if summary.WallClockDurationMs > 0 {
+		return summary.WallClockDurationMs
+	}
+	return summary.TotalDurationMs
 }
 
 func compareGroupedExecutionPosition(
@@ -1520,6 +1820,19 @@ func enrichExecutionSummariesFromLLMDebug(
 		}
 		enrichment[requestID] = item
 		summaries[summaryIndex].LLMTotalDurationMs = item.TotalDurationMs
+		start, end := extendWindowWithLLMInteractions(
+			summaries[summaryIndex].observedStart,
+			summaries[summaryIndex].observedEnd,
+			deduped,
+		)
+		if observed := observedDurationMilliseconds(start, end); observed > 0 {
+			summaries[summaryIndex].WallClockDurationMs, summaries[summaryIndex].DurationSource = preferDurationCandidate(
+				summaries[summaryIndex].WallClockDurationMs,
+				summaries[summaryIndex].DurationSource,
+				observed,
+				"llm_and_step_time_envelope",
+			)
+		}
 	}
 	return enrichment, incomplete, nil
 }

--- a/examples/registry-viewer-app/conversation_api_test.go
+++ b/examples/registry-viewer-app/conversation_api_test.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func newConversationAPIRedis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+	server := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return server, client
+}
+
+func storeViewerExecution(
+	t *testing.T,
+	client *redis.Client,
+	execution StoredExecution,
+) {
+	t.Helper()
+	data, err := json.Marshal(execution)
+	if err != nil {
+		t.Fatalf("marshal execution: %v", err)
+	}
+	if err := client.Set(
+		context.Background(),
+		executionKeyPrefix+execution.RequestID,
+		data,
+		time.Hour,
+	).Err(); err != nil {
+		t.Fatalf("store execution: %v", err)
+	}
+}
+
+func TestBuildGroupedExecutionUnitsMatchesRelatedResumeRequestID(t *testing.T) {
+	createdAt := time.Date(2026, time.August, 27, 15, 35, 0, 0, time.UTC)
+	const (
+		originalRequestID = "workflow-original-1787844868392776305"
+		resumeRequestID   = "workflow-resume-1787844987556516340"
+	)
+	summaries := []ExecutionSummary{
+		{
+			RequestID:       originalRequestID,
+			OriginalRequest: "Investigate delayed operation",
+			Interrupted:     true,
+			CreatedAt:       createdAt,
+		},
+		{
+			RequestID:         resumeRequestID,
+			OriginalRequestID: originalRequestID,
+			OriginalRequest:   "Investigate delayed operation",
+			Success:           true,
+			CreatedAt:         createdAt.Add(time.Minute),
+		},
+	}
+	query := &groupedExecutionQuery{
+		Search:    resumeRequestID,
+		Status:    "all",
+		Sort:      "created_at",
+		Direction: "desc",
+	}
+
+	groups := buildGroupedExecutionUnits(summaries, nil, nil, query)
+
+	if len(groups) != 1 {
+		t.Fatalf("group count = %d, want 1", len(groups))
+	}
+	if len(groups[0].Turns) != 1 {
+		t.Fatalf("turn count = %d, want 1", len(groups[0].Turns))
+	}
+	turn := groups[0].Turns[0]
+	if turn.Execution.RequestID != originalRequestID {
+		t.Fatalf("owner request ID = %q, want %q", turn.Execution.RequestID, originalRequestID)
+	}
+	if len(turn.RelatedExecutions) != 1 ||
+		turn.RelatedExecutions[0].RequestID != resumeRequestID {
+		t.Fatalf("related executions = %#v, want resume %q", turn.RelatedExecutions, resumeRequestID)
+	}
+}
+
+func TestBuildGroupedExecutionUnitsDoesNotMatchUnrelatedChild(t *testing.T) {
+	createdAt := time.Date(2026, time.August, 27, 15, 35, 0, 0, time.UTC)
+	summaries := []ExecutionSummary{
+		{
+			RequestID:       "original-request",
+			OriginalRequest: "Investigate delayed operation",
+			Interrupted:     true,
+			CreatedAt:       createdAt,
+		},
+		{
+			RequestID:         "resume-request",
+			OriginalRequestID: "original-request",
+			OriginalRequest:   "Investigate delayed operation",
+			Success:           true,
+			CreatedAt:         createdAt.Add(time.Minute),
+		},
+	}
+	query := &groupedExecutionQuery{
+		Search:    "some-other-request",
+		Status:    "all",
+		Sort:      "created_at",
+		Direction: "desc",
+	}
+
+	groups := buildGroupedExecutionUnits(summaries, nil, nil, query)
+
+	if len(groups) != 0 {
+		t.Fatalf("group count = %d, want 0", len(groups))
+	}
+}
+
+func TestExactOwnerHydrationAttachesOwnerOutsideInitialSnapshot(t *testing.T) {
+	_, client := newConversationAPIRedis(t)
+	ctx := context.Background()
+	createdAt := time.Date(2026, time.August, 28, 1, 0, 0, 0, time.UTC)
+	storeViewerExecution(t, client, StoredExecution{
+		RequestID:         "exact-owner",
+		OriginalRequestID: "exact-owner",
+		OriginalRequest:   "Initial request",
+		CreatedAt:         createdAt,
+	})
+	summaries := map[string]ExecutionSummary{
+		"related-child": {
+			RequestID:         "related-child",
+			OriginalRequestID: "exact-owner",
+			OriginalRequest:   "Resume request",
+			CreatedAt:         createdAt.Add(time.Minute),
+		},
+	}
+	partial, err := hydrateAndClassifyGroupedExecutionOwners(
+		ctx,
+		client,
+		newExecutionReadCache(),
+		summaries,
+	)
+	if err != nil || partial {
+		t.Fatalf("owner hydration = (partial=%v, err=%v)", partial, err)
+	}
+	if _, exists := summaries["exact-owner"]; !exists {
+		t.Fatal("exact owner was not hydrated")
+	}
+
+	groups := buildGroupedExecutionUnits(summariesToSlice(summaries), nil, nil, &groupedExecutionQuery{
+		Status: "all", Sort: "created_at", Direction: "desc", Limit: 50,
+	})
+	if len(groups) != 1 || len(groups[0].Turns) != 1 ||
+		len(groups[0].Turns[0].RelatedExecutions) != 1 {
+		t.Fatalf("exact owner lineage was not attached: %#v", groups)
+	}
+}
+
+func TestOwnerClassificationDistinguishesUnavailableFromUnknown(t *testing.T) {
+	_, client := newConversationAPIRedis(t)
+	ctx := context.Background()
+	newSummaries := func() map[string]ExecutionSummary {
+		return map[string]ExecutionSummary{
+			"child": {
+				RequestID:         "child",
+				OriginalRequestID: "absent-owner",
+				CreatedAt:         time.Now(),
+			},
+		}
+	}
+
+	confirmed := newSummaries()
+	partial, err := hydrateAndClassifyGroupedExecutionOwners(
+		ctx,
+		client,
+		newExecutionReadCache(),
+		confirmed,
+	)
+	if err != nil || partial {
+		t.Fatalf("confirmed missing classification = (partial=%v, err=%v)", partial, err)
+	}
+	if got := confirmed["child"]; got.RelationStatus != "owner_unavailable" ||
+		got.MissingOwnerID != "absent-owner" {
+		t.Fatalf("confirmed missing summary = %#v", got)
+	}
+
+	unknown := newSummaries()
+	cache := newExecutionReadCache()
+	cache.exactHydrated = viewerExactOwnerHydrationLimit
+	partial, err = hydrateAndClassifyGroupedExecutionOwners(ctx, client, cache, unknown)
+	if err != nil || !partial {
+		t.Fatalf("bounded owner classification = (partial=%v, err=%v)", partial, err)
+	}
+	if got := unknown["child"]; got.RelationStatus != "owner_unknown" ||
+		got.MissingOwnerID != "" {
+		t.Fatalf("unknown owner summary = %#v", got)
+	}
+}
+
+func TestConfirmedMissingIndexCleanupPreservesUnreadableRecords(t *testing.T) {
+	_, client := newConversationAPIRedis(t)
+	ctx := context.Background()
+	for index, requestID := range []string{"missing", "unreadable"} {
+		if err := client.ZAdd(ctx, executionIndexKey, redis.Z{
+			Score: float64(index), Member: requestID,
+		}).Err(); err != nil {
+			t.Fatalf("seed index: %v", err)
+		}
+	}
+	if err := client.Set(ctx, executionKeyPrefix+"unreadable", "not-json", time.Hour).Err(); err != nil {
+		t.Fatalf("seed unreadable record: %v", err)
+	}
+	cache := newExecutionReadCache()
+	partial, err := cache.load(ctx, client, []string{"missing", "unreadable"})
+	if err != nil || !partial {
+		t.Fatalf("cache load = (partial=%v, err=%v)", partial, err)
+	}
+	pruneConfirmedMissingIndexMembers(
+		ctx,
+		client,
+		executionIndexKey,
+		[]string{"missing", "unreadable"},
+		cache.missing,
+	)
+	if _, err := client.ZScore(ctx, executionIndexKey, "missing").Result(); err != redis.Nil {
+		t.Fatal("confirmed missing member remains indexed")
+	}
+	if _, err := client.ZScore(ctx, executionIndexKey, "unreadable").Result(); err != nil {
+		t.Fatal("unreadable but existing record was incorrectly pruned")
+	}
+}
+
+func TestBoundedMaintenanceEventuallyPrunesOldStaleMembers(t *testing.T) {
+	_, client := newConversationAPIRedis(t)
+	ctx := context.Background()
+	for index := 0; index < viewerStaleIndexMaintenanceBatch*3; index++ {
+		requestID := fmt.Sprintf("stale-%04d", index)
+		if err := client.ZAdd(ctx, executionIndexKey, redis.Z{
+			Score: float64(index), Member: requestID,
+		}).Err(); err != nil {
+			t.Fatalf("seed stale index: %v", err)
+		}
+	}
+	staleIndexSweepMu.Lock()
+	staleIndexSweepCursor = 0
+	staleIndexSweepLastRun = time.Time{}
+	staleIndexSweepMu.Unlock()
+	for attempt := 0; attempt < 20; attempt++ {
+		maintainStaleGlobalExecutionIndex(ctx, client)
+		remaining, err := client.ZCard(ctx, executionIndexKey).Result()
+		if err != nil {
+			t.Fatalf("count stale index: %v", err)
+		}
+		if remaining == 0 {
+			break
+		}
+		staleIndexSweepMu.Lock()
+		staleIndexSweepLastRun = time.Time{}
+		staleIndexSweepMu.Unlock()
+	}
+	if remaining, err := client.ZCard(ctx, executionIndexKey).Result(); err != nil || remaining != 0 {
+		t.Fatalf("stale members remaining after bounded sweeps = %d", remaining)
+	}
+}
+
+func TestStaleIndexMaintenanceIsRateLimited(t *testing.T) {
+	_, client := newConversationAPIRedis(t)
+	ctx := context.Background()
+	staleIndexSweepMu.Lock()
+	staleIndexSweepCursor = 0
+	staleIndexSweepLastRun = time.Time{}
+	staleIndexSweepMu.Unlock()
+	t.Cleanup(func() {
+		staleIndexSweepMu.Lock()
+		staleIndexSweepCursor = 0
+		staleIndexSweepLastRun = time.Time{}
+		staleIndexSweepMu.Unlock()
+	})
+
+	if err := client.ZAdd(ctx, executionIndexKey, redis.Z{
+		Score: 1, Member: "first-stale",
+	}).Err(); err != nil {
+		t.Fatalf("seed first stale member: %v", err)
+	}
+	maintainStaleGlobalExecutionIndex(ctx, client)
+	if _, err := client.ZScore(ctx, executionIndexKey, "first-stale").Result(); err != redis.Nil {
+		t.Fatalf("eligible sweep did not remove first stale member: %v", err)
+	}
+
+	if err := client.ZAdd(ctx, executionIndexKey, redis.Z{
+		Score: 2, Member: "second-stale",
+	}).Err(); err != nil {
+		t.Fatalf("seed second stale member: %v", err)
+	}
+	maintainStaleGlobalExecutionIndex(ctx, client)
+	if _, err := client.ZScore(ctx, executionIndexKey, "second-stale").Result(); err != nil {
+		t.Fatalf("rate-limited sweep unexpectedly removed second member: %v", err)
+	}
+
+	staleIndexSweepMu.Lock()
+	staleIndexSweepLastRun = time.Now().Add(-viewerStaleIndexMaintenanceInterval)
+	staleIndexSweepMu.Unlock()
+	maintainStaleGlobalExecutionIndex(ctx, client)
+	if _, err := client.ZScore(ctx, executionIndexKey, "second-stale").Result(); err != redis.Nil {
+		t.Fatalf("eligible follow-up sweep did not remove second stale member: %v", err)
+	}
+}
+
+func summariesToSlice(summaries map[string]ExecutionSummary) []ExecutionSummary {
+	result := make([]ExecutionSummary, 0, len(summaries))
+	for _, summary := range summaries {
+		result = append(result, summary)
+	}
+	return result
+}

--- a/examples/registry-viewer-app/go.mod
+++ b/examples/registry-viewer-app/go.mod
@@ -3,6 +3,7 @@ module github.com/truvaagents/truva-g3/examples/registry-viewer-app
 go 1.27.0
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/truvaagents/truva-g3/core v0.4.0
 	github.com/truvaagents/truva-g3/memory v0.4.0
@@ -21,6 +22,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/qdrant/go-client v1.18.3 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect

--- a/examples/registry-viewer-app/jaeger_trace.go
+++ b/examples/registry-viewer-app/jaeger_trace.go
@@ -1,0 +1,292 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const maxJaegerTraceResponseBytes = 8 * 1024 * 1024
+
+var jaegerTraceIDPattern = regexp.MustCompile(`^[[:xdigit:]]{16,32}$`)
+var jaegerSpanIDPattern = regexp.MustCompile(`^[[:xdigit:]]{16}$`)
+
+type LinkedTrace struct {
+	TraceID         string `json:"trace_id"`
+	SpanID          string `json:"span_id,omitempty"`
+	Relationship    string `json:"relationship"`
+	SourceOperation string `json:"source_operation,omitempty"`
+}
+
+// PipelineHookExecution is a trace-backed observation of one framework
+// pipeline-hook invocation. Hook implementations are not necessarily backed by
+// an LLM call, so this model is deliberately independent of LLMInteraction.
+type PipelineHookExecution struct {
+	TraceID       string    `json:"trace_id"`
+	SpanID        string    `json:"span_id,omitempty"`
+	OperationName string    `json:"operation_name"`
+	Phase         string    `json:"phase"`
+	HookName      string    `json:"hook_name"`
+	Status        string    `json:"status"`
+	StartedAt     time.Time `json:"started_at"`
+	DurationUS    int64     `json:"duration_us"`
+}
+
+type jaegerTraceResponse struct {
+	Data []struct {
+		Spans []jaegerTraceSpan `json:"spans"`
+	} `json:"data"`
+}
+
+type jaegerTraceSpan struct {
+	TraceID       string                 `json:"traceID"`
+	SpanID        string                 `json:"spanID"`
+	ParentSpanID  string                 `json:"parentSpanID,omitempty"`
+	OperationName string                 `json:"operationName"`
+	StartTime     int64                  `json:"startTime"` // microseconds since Unix epoch
+	Duration      int64                  `json:"duration"`  // microseconds
+	Tags          []jaegerTraceTag       `json:"tags"`
+	References    []jaegerTraceReference `json:"references"`
+}
+
+type jaegerTraceTag struct {
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
+}
+
+type jaegerTraceReference struct {
+	RefType string `json:"refType"`
+	TraceID string `json:"traceID"`
+	SpanID  string `json:"spanID"`
+}
+
+type jaegerTraceLinkage struct {
+	TaskID              string
+	TaskDurationMs      int64
+	TaskOperation       string
+	LinkedTriggerTraces []LinkedTrace
+	PipelineHooks       []PipelineHookExecution
+}
+
+var pipelineHookPhases = []string{
+	"before_planning",
+	"after_planning",
+	"after_execution",
+	"after_synthesis",
+}
+
+var (
+	jaegerQueryURL   = strings.TrimRight(strings.TrimSpace(getEnvOrDefault("JAEGER_QUERY_URL", "")), "/")
+	jaegerUIURL      = strings.TrimRight(strings.TrimSpace(getEnvOrDefault("JAEGER_UI_URL", "http://jaeger.localhost")), "/")
+	jaegerReadClient = &http.Client{Timeout: 3 * time.Second}
+)
+
+func jaegerBrowserTraceURL(traceID string) (string, error) {
+	traceID = strings.TrimSpace(traceID)
+	if !jaegerTraceIDPattern.MatchString(traceID) {
+		return "", fmt.Errorf("trace ID is invalid")
+	}
+	base, err := url.Parse(jaegerUIURL)
+	if err != nil || (base.Scheme != "http" && base.Scheme != "https") ||
+		base.Host == "" || base.User != nil || base.RawQuery != "" || base.Fragment != "" {
+		return "", fmt.Errorf("jaeger UI URL is invalid")
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + "/trace/" + traceID
+	return base.String(), nil
+}
+
+func handleJaegerTraceRedirect(w http.ResponseWriter, r *http.Request) {
+	traceID := strings.TrimPrefix(r.URL.Path, "/api/traces/")
+	target, err := jaegerBrowserTraceURL(traceID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+}
+
+func fetchJaegerTraceLinkage(ctx context.Context, traceID string) (*jaegerTraceLinkage, error) {
+	if jaegerQueryURL == "" {
+		return nil, fmt.Errorf("jaeger query URL is not configured")
+	}
+	traceID = strings.TrimSpace(traceID)
+	if !jaegerTraceIDPattern.MatchString(traceID) {
+		return nil, fmt.Errorf("trace ID is invalid")
+	}
+	base, err := url.Parse(jaegerQueryURL)
+	if err != nil || (base.Scheme != "http" && base.Scheme != "https") ||
+		base.Host == "" || base.User != nil || base.RawQuery != "" || base.Fragment != "" {
+		return nil, fmt.Errorf("jaeger query URL is invalid")
+	}
+	traceURL := strings.TrimRight(base.String(), "/") + "/api/traces/" + url.PathEscape(traceID)
+	// #nosec G704 -- traceURL is built from an operator-owned, validated
+	// http(s) base URL and a bounded hexadecimal trace identifier.
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		traceURL,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create Jaeger trace request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	// #nosec G704 -- req.URL was validated above and cannot be influenced by
+	// arbitrary path, query, credential, or scheme input.
+	resp, err := jaegerReadClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("query Jaeger trace: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("query Jaeger trace: HTTP %d", resp.StatusCode)
+	}
+	limited := io.LimitReader(resp.Body, maxJaegerTraceResponseBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("read Jaeger trace: %w", err)
+	}
+	if len(body) > maxJaegerTraceResponseBytes {
+		return nil, fmt.Errorf("jaeger trace exceeds %d bytes", maxJaegerTraceResponseBytes)
+	}
+	var payload jaegerTraceResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("decode Jaeger trace: %w", err)
+	}
+	if len(payload.Data) == 0 {
+		return nil, fmt.Errorf("jaeger trace not found")
+	}
+	return extractJaegerTraceLinkage(traceID, payload.Data[0].Spans), nil
+}
+
+func extractJaegerTraceLinkage(executionTraceID string, spans []jaegerTraceSpan) *jaegerTraceLinkage {
+	linkage := &jaegerTraceLinkage{}
+	seenLinks := make(map[string]struct{})
+	for _, span := range spans {
+		if hook, ok := pipelineHookExecutionFromSpan(executionTraceID, span); ok {
+			linkage.PipelineHooks = append(linkage.PipelineHooks, hook)
+		}
+		isTaskProcess := span.OperationName == "task.process"
+		if isTaskProcess {
+			linkage.TaskOperation = span.OperationName
+			linkage.TaskDurationMs = span.Duration / 1000
+			for _, tag := range span.Tags {
+				if tag.Key == "task.id" {
+					if value, ok := tag.Value.(string); ok {
+						linkage.TaskID = value
+					}
+				}
+			}
+		}
+		for _, reference := range span.References {
+			if reference.RefType != "FOLLOWS_FROM" ||
+				!jaegerTraceIDPattern.MatchString(reference.TraceID) ||
+				(reference.SpanID != "" && !jaegerSpanIDPattern.MatchString(reference.SpanID)) ||
+				reference.TraceID == executionTraceID {
+				continue
+			}
+			key := reference.TraceID + "\x00" + reference.SpanID
+			if _, duplicate := seenLinks[key]; duplicate {
+				continue
+			}
+			seenLinks[key] = struct{}{}
+			linkage.LinkedTriggerTraces = append(linkage.LinkedTriggerTraces, LinkedTrace{
+				TraceID:         reference.TraceID,
+				SpanID:          reference.SpanID,
+				Relationship:    reference.RefType,
+				SourceOperation: span.OperationName,
+			})
+		}
+	}
+	sort.SliceStable(linkage.PipelineHooks, func(i, j int) bool {
+		return linkage.PipelineHooks[i].StartedAt.Before(linkage.PipelineHooks[j].StartedAt)
+	})
+	return linkage
+}
+
+func pipelineHookExecutionFromSpan(traceID string, span jaegerTraceSpan) (PipelineHookExecution, bool) {
+	const prefix = "pipeline.hook."
+	if !strings.HasPrefix(span.OperationName, prefix) {
+		return PipelineHookExecution{}, false
+	}
+
+	remainder := strings.TrimPrefix(span.OperationName, prefix)
+	phase := ""
+	hookName := ""
+	for _, candidate := range pipelineHookPhases {
+		candidatePrefix := candidate + "."
+		if strings.HasPrefix(remainder, candidatePrefix) {
+			phase = candidate
+			hookName = strings.TrimSpace(strings.TrimPrefix(remainder, candidatePrefix))
+			break
+		}
+	}
+	if phase == "" || hookName == "" {
+		return PipelineHookExecution{}, false
+	}
+
+	status := "completed"
+	for _, tag := range span.Tags {
+		switch tag.Key {
+		case "error":
+			if failed, ok := tag.Value.(bool); ok && failed {
+				status = "failed"
+			}
+		case "otel.status_code":
+			if value, ok := tag.Value.(string); ok && strings.EqualFold(value, "error") {
+				status = "failed"
+			}
+		}
+	}
+
+	durationUS := span.Duration
+	if durationUS < 0 {
+		durationUS = 0
+	}
+	spanID := span.SpanID
+	if !jaegerSpanIDPattern.MatchString(spanID) {
+		spanID = ""
+	}
+	startedAt := time.Time{}
+	if span.StartTime > 0 {
+		startedAt = time.UnixMicro(span.StartTime).UTC()
+	}
+
+	return PipelineHookExecution{
+		TraceID:       traceID,
+		SpanID:        spanID,
+		OperationName: span.OperationName,
+		Phase:         phase,
+		HookName:      hookName,
+		Status:        status,
+		StartedAt:     startedAt,
+		DurationUS:    durationUS,
+	}, true
+}
+
+func enrichUnifiedViewWithTrace(ctx context.Context, unified *UnifiedExecutionView) {
+	if unified == nil || unified.TraceID == "" || useMock {
+		return
+	}
+	linkage, err := fetchJaegerTraceLinkage(ctx, unified.TraceID)
+	if err != nil {
+		unified.TraceEnrichmentStatus = "unavailable"
+		return
+	}
+	unified.TraceEnrichmentStatus = "available"
+	unified.AsyncTaskID = linkage.TaskID
+	unified.LinkedTraces = linkage.LinkedTriggerTraces
+	unified.PipelineHooks = linkage.PipelineHooks
+	if linkage.TaskDurationMs > 0 {
+		unified.WallClockDurationMs = linkage.TaskDurationMs
+		unified.DurationSource = "jaeger_task.process"
+	}
+}

--- a/examples/registry-viewer-app/jaeger_trace_test.go
+++ b/examples/registry-viewer-app/jaeger_trace_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type jaegerRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn jaegerRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func TestEnrichUnifiedViewWithTraceSurfacesAsyncLineageAndWallClock(t *testing.T) {
+	const executionTraceID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const triggerTraceID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	previousClient := jaegerReadClient
+	jaegerReadClient = &http.Client{Transport: jaegerRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/api/traces/"+executionTraceID {
+			t.Fatalf("path = %q, want execution trace API path", r.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(`{
+          "data":[{"spans":[{
+			"traceID":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"spanID":"1111111111111111",
+            "operationName":"task.process",
+            "duration":70677352,
+            "tags":[{"key":"task.id","type":"string","value":"order-event-demo-123"}],
+			"references":[
+			  {"refType":"CHILD_OF","traceID":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","spanID":"2222222222222222"},
+			  {"refType":"FOLLOWS_FROM","traceID":"javascript:alert(1)","spanID":"not-a-span"},
+			  {"refType":"FOLLOWS_FROM","traceID":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","spanID":"3333333333333333"}
+            ]
+          },{
+			"traceID":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"spanID":"4444444444444444",
+			"operationName":"pipeline.hook.after_synthesis.governed-order-response",
+			"startTime":1787845011689174,
+			"duration":7,
+			"tags":[{"key":"span.kind","type":"string","value":"internal"}]
+          }]}]
+        }`)),
+		}, nil
+	})}
+
+	previousURL := jaegerQueryURL
+	previousMock := useMock
+	jaegerQueryURL = "http://jaeger.invalid"
+	useMock = false
+	t.Cleanup(func() {
+		jaegerQueryURL = previousURL
+		jaegerReadClient = previousClient
+		useMock = previousMock
+	})
+
+	view := &UnifiedExecutionView{
+		TraceID:             executionTraceID,
+		TotalDurationMs:     59_343,
+		WallClockDurationMs: 59_343,
+		DurationSource:      "phase_loop_fallback",
+	}
+	enrichUnifiedViewWithTrace(t.Context(), view)
+
+	if view.AsyncTaskID != "order-event-demo-123" {
+		t.Errorf("async_task_id = %q", view.AsyncTaskID)
+	}
+	if view.WallClockDurationMs != 70_677 || view.DurationSource != "jaeger_task.process" {
+		t.Errorf("duration = %d source=%q, want 70677 from task.process", view.WallClockDurationMs, view.DurationSource)
+	}
+	if view.TraceEnrichmentStatus != "available" {
+		t.Errorf("trace_enrichment_status = %q", view.TraceEnrichmentStatus)
+	}
+	if len(view.LinkedTraces) != 1 {
+		t.Fatalf("linked traces = %#v, want one cross-trace FOLLOWS_FROM", view.LinkedTraces)
+	}
+	link := view.LinkedTraces[0]
+	if link.TraceID != triggerTraceID || link.SpanID != "3333333333333333" ||
+		link.Relationship != "FOLLOWS_FROM" || link.SourceOperation != "task.process" {
+		t.Errorf("linked trace = %#v", link)
+	}
+	if len(view.PipelineHooks) != 1 {
+		t.Fatalf("pipeline hooks = %#v, want one trace-backed hook", view.PipelineHooks)
+	}
+	hook := view.PipelineHooks[0]
+	if hook.Phase != "after_synthesis" || hook.HookName != "governed-order-response" ||
+		hook.Status != "completed" || hook.DurationUS != 7 ||
+		hook.SpanID != "4444444444444444" || hook.TraceID != executionTraceID {
+		t.Errorf("pipeline hook = %#v", hook)
+	}
+}
+
+func TestExtractJaegerTraceLinkageSortsAndClassifiesPipelineHooks(t *testing.T) {
+	const traceID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	linkage := extractJaegerTraceLinkage(traceID, []jaegerTraceSpan{
+		{
+			TraceID:       traceID,
+			SpanID:        "2222222222222222",
+			OperationName: "pipeline.hook.after_synthesis.response-governor",
+			StartTime:     2_000_000,
+			Duration:      9,
+		},
+		{
+			TraceID:       traceID,
+			SpanID:        "1111111111111111",
+			OperationName: "pipeline.hook.after_execution.response-governor",
+			StartTime:     1_000_000,
+			Duration:      387,
+			Tags: []jaegerTraceTag{
+				{Key: "otel.status_code", Value: "ERROR"},
+			},
+		},
+		{
+			TraceID:       traceID,
+			SpanID:        "3333333333333333",
+			OperationName: "pipeline.hook.unknown_phase.not-a-framework-phase",
+			StartTime:     3_000_000,
+		},
+	})
+
+	if len(linkage.PipelineHooks) != 2 {
+		t.Fatalf("pipeline hooks = %#v, want two recognized hooks", linkage.PipelineHooks)
+	}
+	first := linkage.PipelineHooks[0]
+	if first.Phase != "after_execution" || first.HookName != "response-governor" ||
+		first.Status != "failed" || first.DurationUS != 387 {
+		t.Errorf("first hook = %#v", first)
+	}
+	second := linkage.PipelineHooks[1]
+	if second.Phase != "after_synthesis" || second.Status != "completed" || second.DurationUS != 9 {
+		t.Errorf("second hook = %#v", second)
+	}
+}
+
+func TestEnrichUnifiedViewWithTraceIsOptional(t *testing.T) {
+	previousURL := jaegerQueryURL
+	previousMock := useMock
+	jaegerQueryURL = ""
+	useMock = false
+	t.Cleanup(func() {
+		jaegerQueryURL = previousURL
+		useMock = previousMock
+	})
+
+	view := &UnifiedExecutionView{TraceID: "cccccccccccccccccccccccccccccccc", WallClockDurationMs: 12}
+	enrichUnifiedViewWithTrace(t.Context(), view)
+	if view.TraceEnrichmentStatus != "unavailable" {
+		t.Errorf("status = %q, want unavailable", view.TraceEnrichmentStatus)
+	}
+	if view.WallClockDurationMs != 12 || len(view.LinkedTraces) != 0 || len(view.PipelineHooks) != 0 || view.AsyncTaskID != "" {
+		t.Errorf("optional enrichment changed base view: %#v", view)
+	}
+}
+
+func TestHandleJaegerTraceRedirectUsesConfiguredBrowserURL(t *testing.T) {
+	previousURL := jaegerUIURL
+	jaegerUIURL = "https://observability.example.com/jaeger"
+	t.Cleanup(func() { jaegerUIURL = previousURL })
+
+	req := httptest.NewRequest(http.MethodGet, "/api/traces/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", nil)
+	rec := httptest.NewRecorder()
+	handleJaegerTraceRedirect(rec, req)
+
+	if rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusTemporaryRedirect)
+	}
+	if location := rec.Header().Get("Location"); location != "https://observability.example.com/jaeger/trace/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Errorf("Location = %q", location)
+	}
+}
+
+func TestHandleJaegerTraceRedirectRejectsInvalidInputs(t *testing.T) {
+	previousURL := jaegerUIURL
+	t.Cleanup(func() { jaegerUIURL = previousURL })
+
+	t.Run("trace ID", func(t *testing.T) {
+		jaegerUIURL = "https://observability.example.com"
+		req := httptest.NewRequest(http.MethodGet, "/api/traces/not-a-trace", nil)
+		rec := httptest.NewRecorder()
+		handleJaegerTraceRedirect(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("UI URL", func(t *testing.T) {
+		jaegerUIURL = "javascript:alert(1)"
+		req := httptest.NewRequest(http.MethodGet, "/api/traces/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", nil)
+		rec := httptest.NewRecorder()
+		handleJaegerTraceRedirect(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+		}
+	})
+}

--- a/examples/registry-viewer-app/k8-deployment.yaml
+++ b/examples/registry-viewer-app/k8-deployment.yaml
@@ -20,6 +20,8 @@ data:
   PORT: "8361"
   APP_ENV: "development"
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318"
+  JAEGER_QUERY_URL: "http://jaeger-query"
+  JAEGER_UI_URL: "http://jaeger.localhost"
   TRUVAG3_VIEWER_MEMORY_DOMAINS: "infrastructure"
   TRUVAG3_SKILLS_REDIS_DB: "9"
 ---
@@ -81,6 +83,16 @@ spec:
             configMapKeyRef:
               name: registry-viewer-config
               key: OTEL_EXPORTER_OTLP_ENDPOINT
+        - name: JAEGER_QUERY_URL
+          valueFrom:
+            configMapKeyRef:
+              name: registry-viewer-config
+              key: JAEGER_QUERY_URL
+        - name: JAEGER_UI_URL
+          valueFrom:
+            configMapKeyRef:
+              name: registry-viewer-config
+              key: JAEGER_UI_URL
         - name: TRUVAG3_VIEWER_MEMORY_DOMAINS
           valueFrom:
             configMapKeyRef:

--- a/examples/registry-viewer-app/main.go
+++ b/examples/registry-viewer-app/main.go
@@ -518,7 +518,7 @@ func init() {
 	flag.BoolVar(&useMock, "mock", true, "Use mock data instead of Redis")
 	flag.StringVar(&redisURL, "redis-url", "", "Redis/Valkey URL (required when -mock=false, or set REDIS_URL env var)")
 	flag.StringVar(&namespace, "namespace", "truvag3", "Redis key namespace")
-	flag.IntVar(&port, "port", 8100, "HTTP server port")
+	flag.IntVar(&port, "port", 8361, "HTTP server port")
 }
 
 // getEnvOrDefault returns environment variable value or default

--- a/examples/registry-viewer-app/main.go
+++ b/examples/registry-viewer-app/main.go
@@ -194,6 +194,7 @@ type RoutingStep struct {
 	Instruction    string                 `json:"instruction,omitempty"`
 	Parameters     map[string]interface{} `json:"parameters,omitempty"`
 	DependsOn      []string               `json:"depends_on,omitempty"`
+	ImplicitDeps   []string               `json:"implicit_deps,omitempty"`
 	Description    string                 `json:"description,omitempty"`
 	ExpectedOutput string                 `json:"expected_output,omitempty"`
 	Metadata       map[string]interface{} `json:"metadata,omitempty"`
@@ -265,7 +266,10 @@ const (
 	viewerGlobalExecutionScanLimit      = 5000
 	viewerDistinctConversationLimit     = 500
 	viewerExecutionHydrationLimit       = 10000
+	viewerExactOwnerHydrationLimit      = 1000
 	viewerConversationMemberReadLimit   = 1000
+	viewerStaleIndexMaintenanceBatch    = 200
+	viewerStaleIndexMaintenanceInterval = 30 * time.Second
 	viewerLLMEnrichmentExecutionLimit   = 200
 	viewerLLMInteractionLimit           = 100
 	viewerLLMInteractionBytesLimit      = 4 * 1024 * 1024
@@ -274,18 +278,20 @@ const (
 
 // StoredExecution contains everything needed for DAG visualization
 type StoredExecution struct {
-	RequestID         string                             `json:"request_id"`
-	OriginalRequestID string                             `json:"original_request_id,omitempty"`
-	TraceID           string                             `json:"trace_id"`
-	AgentName         string                             `json:"agent_name,omitempty"`
-	OriginalRequest   string                             `json:"original_request"`
-	Plan              *RoutingPlan                       `json:"plan"`
-	Result            *ExecutionResult                   `json:"result"`
-	Interrupted       bool                               `json:"interrupted,omitempty"` // True if execution was interrupted for HITL
-	Checkpoint        *HITLCheckpoint                    `json:"checkpoint,omitempty"`  // Checkpoint data if interrupted
-	CreatedAt         time.Time                          `json:"created_at"`
-	Metadata          map[string]string                  `json:"metadata,omitempty"`
-	Skills            *orchestration.SkillExecutionDebug `json:"skills,omitempty"`
+	RequestID           string                             `json:"request_id"`
+	OriginalRequestID   string                             `json:"original_request_id,omitempty"`
+	TraceID             string                             `json:"trace_id"`
+	AgentName           string                             `json:"agent_name,omitempty"`
+	OriginalRequest     string                             `json:"original_request"`
+	Plan                *RoutingPlan                       `json:"plan"`
+	Result              *ExecutionResult                   `json:"result"`
+	Interrupted         bool                               `json:"interrupted,omitempty"` // True if execution was interrupted for HITL
+	Checkpoint          *HITLCheckpoint                    `json:"checkpoint,omitempty"`  // Checkpoint data if interrupted
+	CreatedAt           time.Time                          `json:"created_at"`
+	Metadata            map[string]string                  `json:"metadata,omitempty"`
+	Skills              *orchestration.SkillExecutionDebug `json:"skills,omitempty"`
+	FinalResponse       *string                            `json:"final_response,omitempty"`
+	FinalResponseSource string                             `json:"final_response_source,omitempty"`
 
 	// Multi-phase execution data
 	PhasePlans     []*RoutingPlan `json:"phase_plans,omitempty"`
@@ -304,20 +310,30 @@ type ExecutionResult struct {
 
 // ExecutionSummary is a lightweight version for listing
 type ExecutionSummary struct {
-	RequestID          string            `json:"request_id"`
-	OriginalRequestID  string            `json:"original_request_id,omitempty"`
-	ConversationID     string            `json:"conversation_id,omitempty"`
-	TraceID            string            `json:"trace_id"`
-	AgentName          string            `json:"agent_name,omitempty"`
-	OriginalRequest    string            `json:"original_request"`
-	Success            bool              `json:"success"`
-	Interrupted        bool              `json:"interrupted,omitempty"`
-	StepCount          int               `json:"step_count"`
-	FailedSteps        int               `json:"failed_steps"`
-	TotalDurationMs    int64             `json:"total_duration_ms"`
-	LLMTotalDurationMs int64             `json:"llm_total_duration_ms,omitempty"` // LLM call duration for total time calculation
-	CreatedAt          time.Time         `json:"created_at"`
-	Metadata           map[string]string `json:"metadata,omitempty"`
+	RequestID           string            `json:"request_id"`
+	OriginalRequestID   string            `json:"original_request_id,omitempty"`
+	ConversationID      string            `json:"conversation_id,omitempty"`
+	TraceID             string            `json:"trace_id"`
+	AgentName           string            `json:"agent_name,omitempty"`
+	OriginalRequest     string            `json:"original_request"`
+	Success             bool              `json:"success"`
+	Interrupted         bool              `json:"interrupted,omitempty"`
+	StepCount           int               `json:"step_count"`
+	FailedSteps         int               `json:"failed_steps"`
+	TotalDurationMs     int64             `json:"total_duration_ms"`                // Phase-loop duration; retained for API compatibility.
+	WallClockDurationMs int64             `json:"wall_clock_duration_ms,omitempty"` // Non-additive elapsed-time envelope when available.
+	DurationSource      string            `json:"duration_source,omitempty"`
+	LLMTotalDurationMs  int64             `json:"llm_total_duration_ms,omitempty"` // Aggregate LLM call time; may overlap wall clock.
+	HITLCheckpointID    string            `json:"hitl_checkpoint_id,omitempty"`    // Exact checkpoint identity for lineage-safe HITL joins.
+	RelationStatus      string            `json:"relation_status,omitempty"`
+	MissingOwnerID      string            `json:"missing_owner_id,omitempty"`
+	CreatedAt           time.Time         `json:"created_at"`
+	Metadata            map[string]string `json:"metadata,omitempty"`
+
+	// observedStart/observedEnd are internal inputs for deriving a wall-clock
+	// envelope. They are never serialized.
+	observedStart time.Time
+	observedEnd   time.Time
 }
 
 // ExecutionListResponse is the API response for listing executions
@@ -345,7 +361,7 @@ type DAGNode struct {
 type DAGEdge struct {
 	Source   string `json:"source"`
 	Target   string `json:"target"`
-	EdgeType string `json:"edge_type,omitempty"` // "dependency" (default) or "phase_transition"
+	EdgeType string `json:"edge_type,omitempty"` // dependency, implicit_dependency, or phase_transition
 }
 
 // DAGStatistics contains computed statistics for the DAG
@@ -403,24 +419,32 @@ type ResolutionAnalyticsResponse struct {
 // This provides a "one-stop shop" for debugging and understanding request execution
 type UnifiedExecutionView struct {
 	// Core execution data
-	RequestID         string           `json:"request_id"`
-	OriginalRequestID string           `json:"original_request_id,omitempty"`
-	ConversationID    string           `json:"conversation_id,omitempty"`
-	TraceID           string           `json:"trace_id,omitempty"`
-	AgentName         string           `json:"agent_name,omitempty"`
-	OriginalRequest   string           `json:"original_request"`
-	CreatedAt         time.Time        `json:"created_at"`
-	Success           bool             `json:"success"`
-	TotalDurationMs   int64            `json:"total_duration_ms"`
-	Plan              *RoutingPlan     `json:"plan,omitempty"`
-	Result            *ExecutionResult `json:"result,omitempty"`
-	Interrupted       bool             `json:"interrupted,omitempty"` // True if execution was interrupted for HITL
-	Checkpoint        *HITLCheckpoint  `json:"checkpoint,omitempty"`  // Checkpoint data if interrupted (includes completed_steps, step_results)
+	RequestID             string                  `json:"request_id"`
+	OriginalRequestID     string                  `json:"original_request_id,omitempty"`
+	ConversationID        string                  `json:"conversation_id,omitempty"`
+	TraceID               string                  `json:"trace_id,omitempty"`
+	AsyncTaskID           string                  `json:"async_task_id,omitempty"`
+	LinkedTraces          []LinkedTrace           `json:"linked_traces,omitempty"`
+	PipelineHooks         []PipelineHookExecution `json:"pipeline_hooks,omitempty"`
+	TraceEnrichmentStatus string                  `json:"trace_enrichment_status,omitempty"`
+	AgentName             string                  `json:"agent_name,omitempty"`
+	OriginalRequest       string                  `json:"original_request"`
+	CreatedAt             time.Time               `json:"created_at"`
+	Success               bool                    `json:"success"`
+	TotalDurationMs       int64                   `json:"total_duration_ms"` // Phase-loop duration; retained for compatibility.
+	WallClockDurationMs   int64                   `json:"wall_clock_duration_ms,omitempty"`
+	DurationSource        string                  `json:"duration_source,omitempty"`
+	Plan                  *RoutingPlan            `json:"plan,omitempty"`
+	Result                *ExecutionResult        `json:"result,omitempty"`
+	Interrupted           bool                    `json:"interrupted,omitempty"` // True if execution was interrupted for HITL
+	Checkpoint            *HITLCheckpoint         `json:"checkpoint,omitempty"`  // Checkpoint data if interrupted (includes completed_steps, step_results)
 
 	// Multi-phase execution data
-	PhasePlans     []*RoutingPlan `json:"phase_plans,omitempty"`
-	PhaseCount     int            `json:"phase_count,omitempty"`
-	ForcedTerminal bool           `json:"forced_terminal,omitempty"`
+	PhasePlans          []*RoutingPlan `json:"phase_plans,omitempty"`
+	PhaseCount          int            `json:"phase_count,omitempty"`
+	ForcedTerminal      bool           `json:"forced_terminal,omitempty"`
+	FinalResponse       *string        `json:"final_response,omitempty"`
+	FinalResponseSource string         `json:"final_response_source,omitempty"`
 
 	// Computed DAG structure
 	DAG *DAGResponse `json:"dag,omitempty"`
@@ -432,6 +456,7 @@ type UnifiedExecutionView struct {
 
 	// HITL checkpoints (if any)
 	HITLCheckpoints []HITLCheckpoint `json:"hitl_checkpoints,omitempty"`
+	HITLLifecycle   *HITLLifecycle   `json:"hitl_lifecycle,omitempty"`
 
 	// Metadata for UI
 	HasLLMData  bool `json:"has_llm_data"`
@@ -443,6 +468,30 @@ type UnifiedExecutionView struct {
 	// linking to the completed resume. Empty when no sibling exists or when
 	// this record is not interrupted. (ORCH-022 Layer 4)
 	ResumeSiblingRequestID string `json:"resume_sibling_request_id,omitempty"`
+}
+
+type HITLExecutionLink struct {
+	RequestID   string `json:"request_id"`
+	TraceID     string `json:"trace_id,omitempty"`
+	Role        string `json:"role"` // interrupted or resume
+	Interrupted bool   `json:"interrupted,omitempty"`
+	Success     bool   `json:"success"`
+}
+
+// HITLLifecycle reconciles the immutable interruption snapshot with the
+// checkpoint's current state and the separate execution records created by a
+// resume. The original snapshot is retained rather than overwritten.
+type HITLLifecycle struct {
+	CheckpointID        string              `json:"checkpoint_id,omitempty"`
+	InitialRequestID    string              `json:"initial_request_id"`
+	CurrentRequestID    string              `json:"current_request_id"`
+	IsResume            bool                `json:"is_resume"`
+	SnapshotStatus      string              `json:"snapshot_status,omitempty"`
+	CurrentStatus       string              `json:"current_status,omitempty"`
+	CurrentStatusSource string              `json:"current_status_source,omitempty"`
+	SnapshotCheckpoint  *HITLCheckpoint     `json:"snapshot_checkpoint,omitempty"`
+	CurrentCheckpoint   *HITLCheckpoint     `json:"current_checkpoint,omitempty"`
+	RelatedExecutions   []HITLExecutionLink `json:"related_executions,omitempty"`
 }
 
 // LLMDebugSummary provides a summary of LLM interactions
@@ -612,6 +661,7 @@ func main() {
 	mux.HandleFunc("/api/executions", apiMiddleware(handleExecutionList))
 	mux.HandleFunc("/api/executions/search", apiMiddleware(handleExecutionSearch))
 	mux.HandleFunc("/api/executions/", apiMiddleware(handleExecution)) // Handles both /{id} and /{id}/dag
+	mux.HandleFunc("/api/traces/", withCORS(handleJaegerTraceRedirect))
 	mux.HandleFunc("/api/conversations", apiMiddleware(handleConversationTimeline))
 	mux.HandleFunc("/api/analytics/resolution", apiMiddleware(handleResolutionAnalytics))
 	if !useMock {
@@ -678,7 +728,12 @@ func main() {
 		log.Printf("Redis Namespace: %s", namespace)
 	}
 
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
 }
@@ -735,7 +790,7 @@ func withETag(next http.HandlerFunc) http.HandlerFunc {
 
 		// Compute ETag from FNV-1a hash of the response body (fast, stdlib)
 		h := fnv.New64a()
-		h.Write(body)
+		_, _ = h.Write(body) // hash.Hash.Write never returns an error
 		etag := fmt.Sprintf(`"%x"`, h.Sum64())
 
 		// If client has this version, return 304
@@ -748,7 +803,9 @@ func withETag(next http.HandlerFunc) http.HandlerFunc {
 		// (responseRecorder delegates Header() to the embedded ResponseWriter).
 		w.Header().Set("ETag", etag)
 		w.WriteHeader(rec.statusCode)
-		w.Write(body)
+		if _, err := w.Write(body); err != nil {
+			log.Printf("Failed to write HTTP response: %v", err)
+		}
 	}
 }
 
@@ -783,11 +840,11 @@ func withGzip(next http.HandlerFunc) http.HandlerFunc {
 		gz := gzip.NewWriter(w)
 		gzw := &gzipResponseWriter{ResponseWriter: w, Writer: gz}
 		next(gzw, r)
-		if gzw.wroteBody {
-			gz.Close()
-		} else {
+		if !gzw.wroteBody {
 			gz.Reset(io.Discard)
-			gz.Close()
+		}
+		if err := gz.Close(); err != nil {
+			log.Printf("Failed to finish gzip response: %v", err)
 		}
 	}
 }
@@ -800,11 +857,33 @@ func apiMiddleware(handler http.HandlerFunc) http.HandlerFunc {
 	return withCORS(withGzip(withETag(handler)))
 }
 
+// writeJSON writes a JSON response and records transport failures that occur
+// after a handler has begun writing its response.
+func writeJSON(w http.ResponseWriter, value interface{}) {
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		log.Printf("Failed to encode HTTP response: %v", err)
+	}
+}
+
+// closeHTTPBody closes an outbound HTTP response body without hiding cleanup
+// failures from local diagnostics.
+func closeHTTPBody(body io.Closer) {
+	if err := body.Close(); err != nil {
+		log.Printf("Failed to close outbound HTTP response: %v", err)
+	}
+}
+
+// safeLogText keeps values from external records or request paths on one log
+// line, preventing forged prefixes or entries through CR/LF characters.
+func safeLogText(value string) string {
+	return strings.NewReplacer("\r", `\r`, "\n", `\n`).Replace(value)
+}
+
 // ─── Handlers ────────────────────────────────────────────────────────────────
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	writeJSON(w, map[string]string{"status": "ok"})
 }
 
 func handleServices(w http.ResponseWriter, r *http.Request) {
@@ -849,7 +928,7 @@ func handleServices(w http.ResponseWriter, r *http.Request) {
 		Timestamp:  time.Now(),
 	}
 
-	json.NewEncoder(w).Encode(response)
+	writeJSON(w, response)
 }
 
 // handleSwaggerURLs returns a Swagger UI compatible `urls` array for auto-discovery.
@@ -912,7 +991,7 @@ func handleSwaggerURLs(w http.ResponseWriter, r *http.Request) {
 	// Stable order — Swagger UI preserves the array order in its dropdown.
 	sort.Slice(urls, func(i, j int) bool { return urls[i].Name < urls[j].Name })
 
-	json.NewEncoder(w).Encode(urls)
+	writeJSON(w, urls)
 }
 
 // getMockServices returns mock service data for development
@@ -1054,6 +1133,46 @@ func getMockServices() []ServiceInfo {
 // hitlHTTPClient is the HTTP client used for fan-out calls to agent /hitl/checkpoints endpoints.
 // Uses a 10s timeout to avoid hanging on unresponsive agents.
 var hitlHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+func doHITLGet(ctx context.Context, targetURL string) (*http.Response, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	parsed, err := url.Parse(targetURL)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return nil, fmt.Errorf("invalid HITL service URL")
+	}
+	// The host originates from the framework's service-discovery registry, not
+	// directly from an HTTP request. Scheme and host are validated above. The
+	// viewer intentionally calls registered agents to aggregate HITL state.
+	// #nosec G704 -- registry-owned service URL, validated before use.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	// #nosec G704 -- the request uses the same validated registry-owned URL.
+	return hitlHTTPClient.Do(req)
+}
+
+func doHITLPost(ctx context.Context, targetURL string, body io.Reader) (*http.Response, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	parsed, err := url.Parse(targetURL)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return nil, fmt.Errorf("invalid HITL service URL")
+	}
+	// #nosec G704 -- parsed is a validated framework-owned service URL.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, parsed.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// The destination comes from the framework service registry or a stored
+	// checkpoint created by that registered service, and is validated above.
+	// #nosec G704 -- validated framework-owned service URL.
+	return hitlHTTPClient.Do(req)
+}
 
 // Discovery client singleton. The viewer talks to core.Discovery so the
 // enumeration of registered services is not coupled to a specific backing
@@ -1345,7 +1464,7 @@ func handleLLMDebugList(w http.ResponseWriter, r *http.Request) {
 		Timestamp: time.Now(),
 	}
 
-	json.NewEncoder(w).Encode(response)
+	writeJSON(w, response)
 }
 
 // handleLLMDebugRecord returns a specific LLM debug record by ID
@@ -1397,7 +1516,7 @@ func handleLLMDebugRecord(w http.ResponseWriter, r *http.Request) {
 		record.Interactions = orchestration.DedupeLLMInteractions(record.Interactions)
 	}
 
-	json.NewEncoder(w).Encode(record)
+	writeJSON(w, record)
 }
 
 // ============================================================================
@@ -1470,7 +1589,7 @@ func handleHITLCheckpointList(w http.ResponseWriter, r *http.Request) {
 		Timestamp:   time.Now(),
 	}
 
-	json.NewEncoder(w).Encode(response)
+	writeJSON(w, response)
 }
 
 // handleHITLCheckpoint returns a specific HITL checkpoint by ID
@@ -1507,7 +1626,7 @@ func handleHITLCheckpoint(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	json.NewEncoder(w).Encode(checkpoint)
+	writeJSON(w, checkpoint)
 }
 
 // handleHITLCommand proxies an approve/reject command to the owning agent.
@@ -1572,17 +1691,23 @@ func handleHITLCommand(w http.ResponseWriter, r *http.Request) {
 		"type":          req.CommandType,
 		"feedback":      req.Feedback,
 	}
-	body, _ := json.Marshal(agentCmd)
+	body, err := json.Marshal(agentCmd)
+	if err != nil {
+		http.Error(w, `{"error":"failed to encode command"}`, http.StatusInternalServerError)
+		return
+	}
 
-	resp, err := http.Post(agentAddr+"/hitl/command", "application/json", bytes.NewReader(body))
+	resp, err := doHITLPost(r.Context(), agentAddr+"/hitl/command", bytes.NewReader(body))
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":"failed to reach agent %q: %s"}`, checkpoint.AgentName, err.Error()), http.StatusBadGateway)
 		return
 	}
-	defer resp.Body.Close()
+	defer closeHTTPBody(resp.Body)
 
 	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		log.Printf("Failed to proxy HITL command response: %v", err)
+	}
 }
 
 // handleHITLResume proxies a resume request to the owning agent after approval.
@@ -1628,15 +1753,17 @@ func handleHITLResume(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	resp, err := http.Post(agentAddr+"/hitl/resume/"+url.PathEscape(checkpointID), "application/json", http.NoBody)
+	resp, err := doHITLPost(r.Context(), agentAddr+"/hitl/resume/"+url.PathEscape(checkpointID), http.NoBody)
 	if err != nil {
 		http.Error(w, fmt.Sprintf(`{"error":"failed to reach agent: %s"}`, err.Error()), http.StatusBadGateway)
 		return
 	}
-	defer resp.Body.Close()
+	defer closeHTTPBody(resp.Body)
 
 	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		log.Printf("Failed to proxy HITL resume response: %v", err)
+	}
 }
 
 // getAgentAddress looks up an agent's HTTP address from the service discovery registry.
@@ -1710,7 +1837,7 @@ func handleExecutionList(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	json.NewEncoder(w).Encode(response)
+	writeJSON(w, response)
 }
 
 // ExecutionSearchResponse is the API response for search results
@@ -1760,7 +1887,7 @@ func handleExecutionSearch(w http.ResponseWriter, r *http.Request) {
 		Timestamp:  time.Now(),
 	}
 
-	json.NewEncoder(w).Encode(response)
+	writeJSON(w, response)
 }
 
 // searchMockExecutions searches mock executions by original request content
@@ -1841,15 +1968,16 @@ func handleExecution(w http.ResponseWriter, r *http.Request) {
 
 	if isUnifiedRequest {
 		// Return unified view combining execution, LLM debug, and HITL data
-		unified := buildUnifiedView(execution)
-		json.NewEncoder(w).Encode(unified)
+		unified := buildUnifiedViewWithContext(r.Context(), execution)
+		enrichUnifiedViewWithTrace(r.Context(), unified)
+		writeJSON(w, unified)
 	} else if isDAGRequest {
 		// Return computed DAG structure
 		dag := computeDAG(execution)
-		json.NewEncoder(w).Encode(dag)
+		writeJSON(w, dag)
 	} else {
 		// Return full execution record
-		json.NewEncoder(w).Encode(execution)
+		writeJSON(w, execution)
 	}
 }
 
@@ -1936,83 +2064,162 @@ func normalizeSteps(execution *StoredExecution) (steps []RoutingStep, results ma
 	return steps, results, phaseBreakpoints
 }
 
-// computeDAG builds the DAG structure from a stored execution
-func computeDAG(execution *StoredExecution) *DAGResponse {
-	if execution == nil {
-		return &DAGResponse{
-			Nodes:  []DAGNode{},
-			Edges:  []DAGEdge{},
-			Levels: [][]string{},
-		}
+func topologicalStepLevels(steps []RoutingStep) [][]string {
+	if len(steps) == 0 {
+		return nil
 	}
-
-	// ORCH-022: unified step source + result map via normalizeSteps. Handles
-	// multi-phase records (via PhasePlans), single-phase records (via Plan),
-	// and legacy interrupted records (via Checkpoint.StepResults fallback).
-	allPlanSteps, stepResults, phaseBreakpoints := normalizeSteps(execution)
-
-	if len(allPlanSteps) == 0 {
-		return &DAGResponse{
-			Nodes:  []DAGNode{},
-			Edges:  []DAGEdge{},
-			Levels: [][]string{},
-		}
+	stepIDs := make(map[string]struct{}, len(steps))
+	for _, step := range steps {
+		stepIDs[step.StepID] = struct{}{}
 	}
-
-	// Build adjacency list and in-degree map for topological sort
-	inDegree := make(map[string]int)
-	dependents := make(map[string][]string)
-
-	for _, step := range allPlanSteps {
-		if _, exists := inDegree[step.StepID]; !exists {
-			inDegree[step.StepID] = 0
-		}
+	inDegree := make(map[string]int, len(steps))
+	dependents := make(map[string][]string, len(steps))
+	for _, step := range steps {
+		inDegree[step.StepID] = 0
+	}
+	for _, step := range steps {
+		seenDeps := make(map[string]struct{}, len(step.DependsOn))
 		for _, dep := range step.DependsOn {
+			if _, inPhase := stepIDs[dep]; !inPhase {
+				continue
+			}
+			if _, duplicate := seenDeps[dep]; duplicate {
+				continue
+			}
+			seenDeps[dep] = struct{}{}
 			inDegree[step.StepID]++
 			dependents[dep] = append(dependents[dep], step.StepID)
 		}
 	}
 
-	// Compute levels using BFS (Kahn's algorithm)
-	levels := [][]string{}
-	currentLevel := []string{}
-
-	// Find initial nodes (no dependencies)
-	for _, step := range allPlanSteps {
+	current := make([]string, 0)
+	for _, step := range steps {
 		if inDegree[step.StepID] == 0 {
-			currentLevel = append(currentLevel, step.StepID)
+			current = append(current, step.StepID)
 		}
 	}
-
-	levelMap := make(map[string]int)
-	for len(currentLevel) > 0 {
-		levels = append(levels, currentLevel)
-		levelIdx := len(levels) - 1
-		for _, stepID := range currentLevel {
-			levelMap[stepID] = levelIdx
-		}
-
-		nextLevel := []string{}
-		for _, stepID := range currentLevel {
-			for _, dep := range dependents[stepID] {
-				inDegree[dep]--
-				if inDegree[dep] == 0 {
-					nextLevel = append(nextLevel, dep)
+	levels := make([][]string, 0)
+	visited := make(map[string]struct{}, len(steps))
+	for len(current) > 0 {
+		levels = append(levels, current)
+		next := make([]string, 0)
+		for _, stepID := range current {
+			visited[stepID] = struct{}{}
+			for _, dependent := range dependents[stepID] {
+				inDegree[dependent]--
+				if inDegree[dependent] == 0 {
+					next = append(next, dependent)
 				}
 			}
 		}
-		currentLevel = nextLevel
+		current = next
 	}
 
-	// Build nodes
-	nodes := make([]DAGNode, 0, len(allPlanSteps))
+	// Keep malformed historical plans visible instead of silently dropping
+	// cyclic nodes from the API. Their dependency edges remain available for
+	// diagnosis in a final level.
+	remaining := make([]string, 0)
+	for _, step := range steps {
+		if _, ok := visited[step.StepID]; !ok {
+			remaining = append(remaining, step.StepID)
+		}
+	}
+	if len(remaining) > 0 {
+		levels = append(levels, remaining)
+	}
+	return levels
+}
+
+func phaseStepGroups(allPlanSteps []RoutingStep, phaseBreakpoints []int) [][]RoutingStep {
+	if len(phaseBreakpoints) <= 1 {
+		return [][]RoutingStep{allPlanSteps}
+	}
+	phases := make([][]RoutingStep, 0, len(phaseBreakpoints))
+	for i, start := range phaseBreakpoints {
+		end := len(allPlanSteps)
+		if i+1 < len(phaseBreakpoints) {
+			end = phaseBreakpoints[i+1]
+		}
+		if start < 0 || start > end || end > len(allPlanSteps) {
+			continue
+		}
+		phases = append(phases, allPlanSteps[start:end])
+	}
+	return phases
+}
+
+func phaseRootAndLeafSteps(steps []RoutingStep) (roots, leaves []string) {
+	stepIDs := make(map[string]struct{}, len(steps))
+	for _, step := range steps {
+		stepIDs[step.StepID] = struct{}{}
+	}
+	hasInPhaseDependency := make(map[string]bool, len(steps))
+	dependedOnInPhase := make(map[string]bool, len(steps))
+	for _, step := range steps {
+		for _, dep := range step.DependsOn {
+			if _, ok := stepIDs[dep]; !ok {
+				continue
+			}
+			hasInPhaseDependency[step.StepID] = true
+			dependedOnInPhase[dep] = true
+		}
+	}
+	for _, step := range steps {
+		if !hasInPhaseDependency[step.StepID] {
+			roots = append(roots, step.StepID)
+		}
+		if !dependedOnInPhase[step.StepID] {
+			leaves = append(leaves, step.StepID)
+		}
+	}
+	return roots, leaves
+}
+
+// computeDAG builds a phase-aware DAG from a stored execution. Explicit
+// depends_on edges control scheduling inside each phase. Phase-boundary edges
+// serialize phases, while implicit_deps remain advisory cross-phase data edges.
+func computeDAG(execution *StoredExecution) *DAGResponse {
+	empty := &DAGResponse{Nodes: []DAGNode{}, Edges: []DAGEdge{}, Levels: [][]string{}}
+	if execution == nil {
+		return empty
+	}
+
+	allPlanSteps, stepResults, phaseBreakpoints := normalizeSteps(execution)
+	if len(allPlanSteps) == 0 {
+		return empty
+	}
+	phases := phaseStepGroups(allPlanSteps, phaseBreakpoints)
+
+	levels := make([][]string, 0)
+	levelMap := make(map[string]int, len(allPlanSteps)+len(phases)-1)
+	phaseMap := make(map[string]int, len(allPlanSteps))
+	maxParallelism := 0
+	for phaseIndex, phaseSteps := range phases {
+		for _, phaseLevel := range topologicalStepLevels(phaseSteps) {
+			levelIndex := len(levels)
+			levels = append(levels, phaseLevel)
+			if len(phaseLevel) > maxParallelism {
+				maxParallelism = len(phaseLevel)
+			}
+			for _, stepID := range phaseLevel {
+				levelMap[stepID] = levelIndex
+				phaseMap[stepID] = phaseIndex + 1
+			}
+		}
+		if phaseIndex < len(phases)-1 {
+			boundaryID := fmt.Sprintf("phase_boundary_%d", phaseIndex+1)
+			levelMap[boundaryID] = len(levels)
+			levels = append(levels, []string{boundaryID})
+		}
+	}
+
 	statistics := DAGStatistics{
-		TotalNodes: len(allPlanSteps),
-		Depth:      len(levels),
+		TotalNodes:     len(allPlanSteps) + len(phases) - 1,
+		MaxParallelism: maxParallelism,
+		Depth:          len(levels),
 	}
-
-	// Determine the current step blocked by HITL (if interrupted)
-	var blockedStepID string
+	nodes := make([]DAGNode, 0, statistics.TotalNodes)
+	blockedStepID := ""
 	if execution.Interrupted && execution.Checkpoint != nil && execution.Checkpoint.CurrentStep != nil {
 		blockedStepID = execution.Checkpoint.CurrentStep.StepID
 	}
@@ -2020,27 +2227,24 @@ func computeDAG(execution *StoredExecution) *DAGResponse {
 	for _, step := range allPlanSteps {
 		status := "pending"
 		var durationMs int64
-
 		if result, ok := stepResults[step.StepID]; ok {
-			if result.Success {
+			switch {
+			case result.Success:
 				status = "completed"
 				statistics.CompletedNodes++
-			} else if step.StepID == blockedStepID {
-				// Step is blocked by HITL approval, not failed
+			case step.StepID == blockedStepID:
 				status = "blocked"
-			} else if result.Error != "" {
+			case result.Error != "":
 				status = "failed"
 				statistics.FailedNodes++
-			} else if result.Skipped {
+			case result.Skipped:
 				status = "skipped"
 				statistics.SkippedNodes++
 			}
-			durationMs = result.DurationMs
+			durationMs = stepDurationMilliseconds(result)
 		} else if step.StepID == blockedStepID {
-			// Step has no result yet but is the blocked HITL step
 			status = "blocked"
 		}
-
 		nodes = append(nodes, DAGNode{
 			ID:          step.StepID,
 			Label:       step.AgentName,
@@ -2048,111 +2252,57 @@ func computeDAG(execution *StoredExecution) *DAGResponse {
 			Status:      status,
 			DurationMs:  durationMs,
 			Level:       levelMap[step.StepID],
+			NodeType:    "step",
+			Metadata: map[string]interface{}{
+				"phase_number": phaseMap[step.StepID],
+			},
 		})
 	}
 
-	// Build edges
+	knownSteps := make(map[string]struct{}, len(allPlanSteps))
+	for _, step := range allPlanSteps {
+		knownSteps[step.StepID] = struct{}{}
+	}
 	edges := make([]DAGEdge, 0)
 	for _, step := range allPlanSteps {
 		for _, dep := range step.DependsOn {
-			edges = append(edges, DAGEdge{
-				Source: dep,
-				Target: step.StepID,
-			})
+			edges = append(edges, DAGEdge{Source: dep, Target: step.StepID, EdgeType: "dependency"})
+		}
+		for _, dep := range step.ImplicitDeps {
+			if _, exists := knownSteps[dep]; !exists {
+				continue
+			}
+			edges = append(edges, DAGEdge{Source: dep, Target: step.StepID, EdgeType: "implicit_dependency"})
 		}
 	}
 
-	// For multi-phase: add phase boundary nodes and edges
-	if len(phaseBreakpoints) > 1 {
-		for p := 0; p < len(phaseBreakpoints)-1; p++ {
-			currentPhaseStart := phaseBreakpoints[p]
-			nextPhaseStart := phaseBreakpoints[p+1]
-			var currentPhaseEnd int
-			if p+1 < len(phaseBreakpoints) {
-				currentPhaseEnd = phaseBreakpoints[p+1]
-			} else {
-				currentPhaseEnd = len(allPlanSteps)
-			}
-
-			currentPhaseSteps := allPlanSteps[currentPhaseStart:currentPhaseEnd]
-			var nextPhaseEnd int
-			if p+2 < len(phaseBreakpoints) {
-				nextPhaseEnd = phaseBreakpoints[p+2]
-			} else {
-				nextPhaseEnd = len(allPlanSteps)
-			}
-			nextPhaseSteps := allPlanSteps[nextPhaseStart:nextPhaseEnd]
-
-			// Find leaf steps of current phase (no other step in this phase depends on them)
-			dependedOnInPhase := make(map[string]bool)
-			for _, s := range currentPhaseSteps {
-				for _, dep := range s.DependsOn {
-					dependedOnInPhase[dep] = true
-				}
-			}
-			var leafSteps []string
-			for _, s := range currentPhaseSteps {
-				if !dependedOnInPhase[s.StepID] {
-					leafSteps = append(leafSteps, s.StepID)
-				}
-			}
-
-			// Find root steps of next phase (no depends_on)
-			var rootNextSteps []string
-			for _, s := range nextPhaseSteps {
-				if len(s.DependsOn) == 0 {
-					rootNextSteps = append(rootNextSteps, s.StepID)
-				}
-			}
-
-			// Create phase boundary node
-			boundaryID := fmt.Sprintf("phase_boundary_%d", p+1)
-			note := ""
-			if p < len(execution.PhasePlans) {
-				note = execution.PhasePlans[p].ContinuationNote
-			}
-
-			nodes = append(nodes, DAGNode{
-				ID:       boundaryID,
-				Label:    fmt.Sprintf("Phase %d → %d", p+1, p+2),
-				NodeType: "phase_boundary",
-				Metadata: map[string]interface{}{
-					"continuation_note": note,
-					"phase_number":      p + 1,
-				},
-			})
-
-			// Connect: leaf steps of Phase N → boundary → root steps of Phase N+1
-			for _, stepID := range leafSteps {
-				edges = append(edges, DAGEdge{
-					Source:   stepID,
-					Target:   boundaryID,
-					EdgeType: "phase_transition",
-				})
-			}
-			for _, stepID := range rootNextSteps {
-				edges = append(edges, DAGEdge{
-					Source:   boundaryID,
-					Target:   stepID,
-					EdgeType: "phase_transition",
-				})
-			}
+	for phaseIndex := 0; phaseIndex < len(phases)-1; phaseIndex++ {
+		boundaryID := fmt.Sprintf("phase_boundary_%d", phaseIndex+1)
+		note := ""
+		if phaseIndex < len(execution.PhasePlans) && execution.PhasePlans[phaseIndex] != nil {
+			note = execution.PhasePlans[phaseIndex].ContinuationNote
+		}
+		nodes = append(nodes, DAGNode{
+			ID:       boundaryID,
+			Label:    fmt.Sprintf("Phase %d → %d", phaseIndex+1, phaseIndex+2),
+			Level:    levelMap[boundaryID],
+			NodeType: "phase_boundary",
+			Metadata: map[string]interface{}{
+				"continuation_note": note,
+				"phase_number":      phaseIndex + 1,
+			},
+		})
+		_, currentLeaves := phaseRootAndLeafSteps(phases[phaseIndex])
+		nextRoots, _ := phaseRootAndLeafSteps(phases[phaseIndex+1])
+		for _, stepID := range currentLeaves {
+			edges = append(edges, DAGEdge{Source: stepID, Target: boundaryID, EdgeType: "phase_transition"})
+		}
+		for _, stepID := range nextRoots {
+			edges = append(edges, DAGEdge{Source: boundaryID, Target: stepID, EdgeType: "phase_transition"})
 		}
 	}
 
-	// Calculate max parallelism
-	for _, level := range levels {
-		if len(level) > statistics.MaxParallelism {
-			statistics.MaxParallelism = len(level)
-		}
-	}
-
-	return &DAGResponse{
-		Nodes:      nodes,
-		Edges:      edges,
-		Levels:     levels,
-		Statistics: statistics,
-	}
+	return &DAGResponse{Nodes: nodes, Edges: edges, Levels: levels, Statistics: statistics}
 }
 
 // handleResolutionAnalytics handles GET /api/analytics/resolution
@@ -2251,7 +2401,7 @@ func handleResolutionAnalytics(w http.ResponseWriter, r *http.Request) {
 
 	// Default: JSON response
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(ResolutionAnalyticsResponse{
+	writeJSON(w, ResolutionAnalyticsResponse{
 		Records:    nonNilSlice(records),
 		Summary:    analyticsSummary,
 		ExportedAt: time.Now(),
@@ -2349,15 +2499,18 @@ func writeResolutionCSV(w http.ResponseWriter, records []ResolutionAnalyticsReco
 	defer writer.Flush()
 
 	// Header row
-	writer.Write([]string{
+	if err := writer.Write([]string{
 		"request_id", "step_id", "capability", "agent_name", "success",
 		"auto_wired_count", "micro_resolved_count", "semantic_retry_count", "user_provided_count",
 		"auto_wiring_duration_us", "micro_resolution_duration_ms",
 		"source_data_key_count", "total_params",
-	})
+	}); err != nil {
+		log.Printf("Failed to write resolution CSV header: %v", err)
+		return
+	}
 
 	for _, r := range records {
-		writer.Write([]string{
+		if err := writer.Write([]string{
 			r.RequestID,
 			r.StepID,
 			r.Capability,
@@ -2371,7 +2524,10 @@ func writeResolutionCSV(w http.ResponseWriter, records []ResolutionAnalyticsReco
 			strconv.FormatInt(r.MicroResolvMs, 10),
 			strconv.Itoa(r.SourceKeyCount),
 			strconv.Itoa(r.TotalParams),
-		})
+		}); err != nil {
+			log.Printf("Failed to write resolution CSV row: %v", err)
+			return
+		}
 	}
 }
 
@@ -2405,34 +2561,266 @@ func int64FromMap(m map[string]interface{}, key string) int64 {
 	return 0
 }
 
-// buildUnifiedView combines execution data with LLM debug and HITL checkpoint data
-func buildUnifiedView(execution *StoredExecution) *UnifiedExecutionView {
+func stepDurationMilliseconds(result *StepResult) int64 {
+	if result == nil {
+		return 0
+	}
+	// Live framework records expose Duration as nanoseconds. DurationMs exists
+	// only for older viewer fixtures and remains a backward-compatible fallback.
+	if result.Duration != 0 {
+		return result.Duration / int64(time.Millisecond)
+	}
+	return result.DurationMs
+}
+
+func extendObservationWindow(start, end *time.Time, candidateStart, candidateEnd time.Time) {
+	if candidateStart.IsZero() {
+		return
+	}
+	if candidateEnd.IsZero() || candidateEnd.Before(candidateStart) {
+		candidateEnd = candidateStart
+	}
+	if start.IsZero() || candidateStart.Before(*start) {
+		*start = candidateStart
+	}
+	if end.IsZero() || candidateEnd.After(*end) {
+		*end = candidateEnd
+	}
+}
+
+func stepPlanSource(result *StepResult) string {
+	if result == nil || result.Metadata == nil {
+		return ""
+	}
+	planSource, _ := result.Metadata["plan_source"].(string)
+	return planSource
+}
+
+// resumeObservationBoundary returns the first step that actually ran in this
+// resumed invocation. Resume records also contain restored pre-checkpoint
+// results, whose original timestamps must not expand this invocation's elapsed
+// time to include the operator approval wait.
+func resumeObservationBoundary(execution *StoredExecution) time.Time {
+	if execution == nil || execution.Result == nil || execution.Metadata["resume_checkpoint_id"] == "" {
+		return time.Time{}
+	}
+	var boundary time.Time
+	for i := range execution.Result.Steps {
+		result := &execution.Result.Steps[i]
+		if result.StartTime == nil || stepPlanSource(result) != "hitl_resume" {
+			continue
+		}
+		if boundary.IsZero() || result.StartTime.Before(boundary) {
+			boundary = *result.StartTime
+		}
+	}
+	return boundary
+}
+
+func executionObservationWindow(execution *StoredExecution) (time.Time, time.Time) {
+	var start, end time.Time
+	if execution == nil || execution.Result == nil {
+		return start, end
+	}
+	resumeExecution := execution.Metadata["resume_checkpoint_id"] != ""
+	resumeBoundary := resumeObservationBoundary(execution)
+	for i := range execution.Result.Steps {
+		result := &execution.Result.Steps[i]
+		if result.StartTime == nil {
+			continue
+		}
+		if resumeExecution && (resumeBoundary.IsZero() || result.StartTime.Before(resumeBoundary)) {
+			continue
+		}
+		candidateEnd := *result.StartTime
+		if result.EndTime != nil {
+			candidateEnd = *result.EndTime
+		} else if duration := stepDurationMilliseconds(result); duration > 0 {
+			candidateEnd = candidateEnd.Add(time.Duration(duration) * time.Millisecond)
+		}
+		extendObservationWindow(&start, &end, *result.StartTime, candidateEnd)
+	}
+	return start, end
+}
+
+func extendWindowWithLLMInteractions(start, end time.Time, interactions []orchestration.LLMInteraction) (time.Time, time.Time) {
+	for _, interaction := range interactions {
+		candidateEnd := interaction.Timestamp
+		if interaction.DurationMs > 0 {
+			candidateEnd = candidateEnd.Add(time.Duration(interaction.DurationMs) * time.Millisecond)
+		}
+		extendObservationWindow(&start, &end, interaction.Timestamp, candidateEnd)
+	}
+	return start, end
+}
+
+func observedDurationMilliseconds(start, end time.Time) int64 {
+	if start.IsZero() || end.IsZero() || end.Before(start) {
+		return 0
+	}
+	return end.Sub(start).Milliseconds()
+}
+
+// preferDurationCandidate keeps duration enrichment lower-bound safe. The
+// phase-loop duration includes planning and hooks that a step/LLM timestamp
+// envelope may not observe, so a smaller envelope must never replace it.
+func preferDurationCandidate(current int64, currentSource string, candidate int64, candidateSource string) (int64, string) {
+	if candidate <= current || candidate <= 0 {
+		return current, currentSource
+	}
+	return candidate, candidateSource
+}
+
+func dedupeHITLCheckpoints(checkpoints []HITLCheckpoint) []HITLCheckpoint {
+	if len(checkpoints) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(checkpoints))
+	deduped := make([]HITLCheckpoint, 0, len(checkpoints))
+	for _, checkpoint := range checkpoints {
+		if checkpoint.CheckpointID == "" {
+			continue
+		}
+		if _, duplicate := seen[checkpoint.CheckpointID]; duplicate {
+			continue
+		}
+		seen[checkpoint.CheckpointID] = struct{}{}
+		deduped = append(deduped, checkpoint)
+	}
+	return deduped
+}
+
+func checkpointByID(checkpoints []HITLCheckpoint, checkpointID string) *HITLCheckpoint {
+	for i := range checkpoints {
+		if checkpoints[i].CheckpointID == checkpointID {
+			return &checkpoints[i]
+		}
+	}
+	return nil
+}
+
+func buildHITLLifecycle(execution *StoredExecution, checkpoints []HITLCheckpoint, family []ExecutionSummary) *HITLLifecycle {
 	if execution == nil {
 		return nil
 	}
+	checkpointID := ""
+	if execution.Checkpoint != nil {
+		checkpointID = execution.Checkpoint.CheckpointID
+	}
+	resumeCheckpointID := execution.Metadata["resume_checkpoint_id"]
+	if checkpointID == "" {
+		checkpointID = resumeCheckpointID
+	}
+	if checkpointID == "" && !execution.Interrupted {
+		return nil
+	}
+
+	initialRequestID := execution.OriginalRequestID
+	if initialRequestID == "" {
+		initialRequestID = execution.RequestID
+	}
+	lifecycle := &HITLLifecycle{
+		CheckpointID:       checkpointID,
+		InitialRequestID:   initialRequestID,
+		CurrentRequestID:   execution.RequestID,
+		IsResume:           resumeCheckpointID != "",
+		SnapshotCheckpoint: execution.Checkpoint,
+	}
+	if execution.Checkpoint != nil {
+		lifecycle.SnapshotStatus = execution.Checkpoint.Status
+	}
+	if current := checkpointByID(checkpoints, checkpointID); current != nil {
+		lifecycle.CurrentCheckpoint = current
+		lifecycle.CurrentStatus = current.Status
+		lifecycle.CurrentStatusSource = "agent_checkpoint_api"
+	} else if execution.Checkpoint != nil {
+		lifecycle.CurrentStatus = execution.Checkpoint.Status
+		lifecycle.CurrentStatusSource = "stored_interruption_snapshot"
+	}
+
+	for _, summary := range family {
+		rootID := summary.OriginalRequestID
+		if rootID == "" {
+			rootID = summary.RequestID
+		}
+		if rootID != initialRequestID || summary.RequestID == execution.RequestID {
+			continue
+		}
+		role := ""
+		summaryCheckpointID := summary.HITLCheckpointID
+		if summaryCheckpointID == "" {
+			summaryCheckpointID = summary.Metadata["resume_checkpoint_id"]
+		}
+		switch {
+		case summary.Interrupted && (checkpointID == "" || summaryCheckpointID == checkpointID):
+			role = "interrupted"
+		case summaryCheckpointID != "" && (checkpointID == "" || summaryCheckpointID == checkpointID):
+			role = "resume"
+		}
+		if role == "" {
+			continue
+		}
+		lifecycle.RelatedExecutions = append(lifecycle.RelatedExecutions, HITLExecutionLink{
+			RequestID:   summary.RequestID,
+			TraceID:     summary.TraceID,
+			Role:        role,
+			Interrupted: summary.Interrupted,
+			Success:     summary.Success,
+		})
+	}
+	return lifecycle
+}
+
+// buildUnifiedView combines execution data with LLM debug and HITL checkpoint data
+func buildUnifiedView(execution *StoredExecution) *UnifiedExecutionView {
+	return buildUnifiedViewWithContext(context.Background(), execution)
+}
+
+func buildUnifiedViewWithContext(ctx context.Context, execution *StoredExecution) *UnifiedExecutionView {
+	if execution == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	unified := &UnifiedExecutionView{
-		RequestID:         execution.RequestID,
-		OriginalRequestID: execution.OriginalRequestID,
-		ConversationID:    execution.Metadata[orchestration.MetadataConversationID],
-		TraceID:           execution.TraceID,
-		AgentName:         execution.AgentName,
-		OriginalRequest:   execution.OriginalRequest,
-		CreatedAt:         execution.CreatedAt,
-		Plan:              execution.Plan,
-		Result:            execution.Result,
-		Interrupted:       execution.Interrupted,
-		Checkpoint:        execution.Checkpoint,
-		PhasePlans:        execution.PhasePlans,
-		PhaseCount:        execution.PhaseCount,
-		ForcedTerminal:    execution.ForcedTerminal,
-		Skills:            execution.Skills,
+		RequestID:           execution.RequestID,
+		OriginalRequestID:   execution.OriginalRequestID,
+		ConversationID:      execution.Metadata[orchestration.MetadataConversationID],
+		TraceID:             execution.TraceID,
+		AgentName:           execution.AgentName,
+		OriginalRequest:     execution.OriginalRequest,
+		CreatedAt:           execution.CreatedAt,
+		Plan:                execution.Plan,
+		Result:              execution.Result,
+		Interrupted:         execution.Interrupted,
+		Checkpoint:          execution.Checkpoint,
+		PhasePlans:          execution.PhasePlans,
+		PhaseCount:          execution.PhaseCount,
+		ForcedTerminal:      execution.ForcedTerminal,
+		Skills:              execution.Skills,
+		FinalResponse:       execution.FinalResponse,
+		FinalResponseSource: execution.FinalResponseSource,
 	}
 
 	// Compute success and duration from result
 	if execution.Result != nil {
 		unified.Success = execution.Result.Success
 		unified.TotalDurationMs = execution.Result.TotalDuration / 1_000_000 // ns to ms
+		unified.WallClockDurationMs = unified.TotalDurationMs
+		if unified.WallClockDurationMs > 0 {
+			unified.DurationSource = "phase_loop_fallback"
+		}
+	}
+	observedStart, observedEnd := executionObservationWindow(execution)
+	if observed := observedDurationMilliseconds(observedStart, observedEnd); observed > 0 {
+		unified.WallClockDurationMs, unified.DurationSource = preferDurationCandidate(
+			unified.WallClockDurationMs,
+			unified.DurationSource,
+			observed,
+			"step_time_envelope",
+		)
 	}
 
 	// Compute DAG structure
@@ -2444,9 +2832,9 @@ func buildUnifiedView(execution *StoredExecution) *UnifiedExecutionView {
 		var llmRecord *orchestration.LLMDebugRecord
 		var err error
 		if storeErr == nil {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			llmCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
-			llmRecord, err = store.GetRecord(ctx, execution.RequestID)
+			llmRecord, err = store.GetRecord(llmCtx, execution.RequestID)
 		}
 		if err == nil && llmRecord != nil {
 			if unified.TraceID == "" {
@@ -2466,6 +2854,19 @@ func buildUnifiedView(execution *StoredExecution) *UnifiedExecutionView {
 			deduped := orchestration.DedupeLLMInteractions(llmRecord.Interactions)
 			unified.LLMInteractions = deduped
 			unified.HasLLMData = len(deduped) > 0
+			observedStart, observedEnd = extendWindowWithLLMInteractions(
+				observedStart,
+				observedEnd,
+				deduped,
+			)
+			if observed := observedDurationMilliseconds(observedStart, observedEnd); observed > 0 {
+				unified.WallClockDurationMs, unified.DurationSource = preferDurationCandidate(
+					unified.WallClockDurationMs,
+					unified.DurationSource,
+					observed,
+					"llm_and_step_time_envelope",
+				)
+			}
 
 			// Build summary from the deduped view
 			if len(deduped) > 0 {
@@ -2486,21 +2887,23 @@ func buildUnifiedView(execution *StoredExecution) *UnifiedExecutionView {
 				unified.LLMDebugSummary = summary
 			}
 		} else if err != nil && !strings.Contains(err.Error(), "not found") {
-			log.Printf("Warning: failed to fetch LLM debug data for %s: %v", execution.RequestID, err)
+			// #nosec G706 -- every external value is normalized by safeLogText.
+			log.Printf("Warning: failed to fetch LLM debug data for %s: %s", safeLogText(execution.RequestID), safeLogText(err.Error()))
 		}
 
 		// Fetch HITL checkpoints by request ID
-		checkpoints, err := getHITLCheckpointsByRequestID(execution.RequestID)
+		checkpoints, err := getAgentHITLCheckpointsByRequestID(ctx, execution.RequestID)
 		if err == nil && len(checkpoints) > 0 {
 			unified.HITLCheckpoints = checkpoints
 			unified.HasHITLData = true
 		} else if err != nil {
-			log.Printf("Warning: failed to fetch HITL checkpoints for %s: %v", execution.RequestID, err)
+			// #nosec G706 -- every external value is normalized by safeLogText.
+			log.Printf("Warning: failed to fetch HITL checkpoints for %s: %s", safeLogText(execution.RequestID), safeLogText(err.Error()))
 		}
 
 		// Also check by original_request_id if different (for resumed HITL conversations)
 		if execution.OriginalRequestID != "" && execution.OriginalRequestID != execution.RequestID {
-			moreCheckpoints, err := getHITLCheckpointsByRequestID(execution.OriginalRequestID)
+			moreCheckpoints, err := getAgentHITLCheckpointsByRequestID(ctx, execution.OriginalRequestID)
 			if err == nil && len(moreCheckpoints) > 0 {
 				unified.HITLCheckpoints = append(unified.HITLCheckpoints, moreCheckpoints...)
 				unified.HasHITLData = true
@@ -2508,68 +2911,41 @@ func buildUnifiedView(execution *StoredExecution) *UnifiedExecutionView {
 		}
 	}
 
-	// ORCH-022 Layer 4: surface a pointer to a completed resume sibling when this
-	// record is interrupted. The UI renders a banner linking to the resume.
-	// Canonical "is interrupted" signal is execution.Interrupted; also flag
-	// has-HITL-data when the stored record carries an embedded checkpoint.
+	unified.HITLCheckpoints = dedupeHITLCheckpoints(unified.HITLCheckpoints)
+	checkpointID := execution.Metadata["resume_checkpoint_id"]
 	if execution.Checkpoint != nil {
-		unified.HasHITLData = true
+		checkpointID = execution.Checkpoint.CheckpointID
 	}
-	if execution.Interrupted && execution.OriginalRequestID != "" {
-		if sibling := findCompletedResumeSibling(execution); sibling != "" {
-			unified.ResumeSiblingRequestID = sibling
+	if !useMock && checkpointID != "" && checkpointByID(unified.HITLCheckpoints, checkpointID) == nil {
+		if current, err := getAgentHITLCheckpoint(ctx, checkpointID); err == nil && current != nil {
+			unified.HITLCheckpoints = append(unified.HITLCheckpoints, *current)
+		}
+	}
+
+	var family []ExecutionSummary
+	if !useMock && (execution.Interrupted || checkpointID != "") {
+		if page, err := getRedisExecutionSummaries(resumeSiblingSearchDepth, ""); err == nil && page != nil {
+			family = page.Summaries
+		}
+	}
+	unified.HITLLifecycle = buildHITLLifecycle(execution, unified.HITLCheckpoints, family)
+	if unified.HITLLifecycle != nil {
+		unified.HasHITLData = true
+		for _, related := range unified.HITLLifecycle.RelatedExecutions {
+			if related.Role == "resume" {
+				unified.ResumeSiblingRequestID = related.RequestID
+				break
+			}
 		}
 	}
 
 	return unified
 }
 
-// resumeSiblingSearchDepth bounds the findCompletedResumeSibling scan. Named
-// constant so the limitation is discoverable by grep rather than buried as a
-// magic number at the call site.
+// resumeSiblingSearchDepth bounds the best-effort family scan used to link
+// interruption and resume records. A future indexed lineage lookup can replace
+// this bounded scan without changing the unified API shape.
 const resumeSiblingSearchDepth = 200
-
-// findCompletedResumeSibling searches recent executions for a non-interrupted
-// record sharing the same original_request_id. Returns the sibling's request_id
-// or empty string when none exists.
-//
-// Scope and limits (Layer 4 UX banner, not load-bearing):
-//   - Only fires when the current execution is interrupted AND has a non-empty
-//     original_request_id (cheap early-out on the common case).
-//   - Scans the most recent resumeSiblingSearchDepth executions. Older siblings
-//     (e.g. an approval that pended for weeks) may not be found; the banner
-//     is best-effort.
-//   - No memoization or indexed lookup. Each unified-view load of an interrupted
-//     record issues one Redis pipeline fetch. Acceptable at current scale; if
-//     viewer load becomes a concern, add a short-TTL cache keyed by
-//     original_request_id or push an explicit index.
-func findCompletedResumeSibling(execution *StoredExecution) string {
-	if useMock || execution == nil || execution.OriginalRequestID == "" {
-		return ""
-	}
-	page, err := getRedisExecutionSummaries(resumeSiblingSearchDepth, "")
-	if err != nil || page == nil {
-		return ""
-	}
-	for _, s := range page.Summaries {
-		if s.RequestID == execution.RequestID {
-			continue
-		}
-		if s.OriginalRequestID != execution.OriginalRequestID {
-			continue
-		}
-		if !s.Interrupted {
-			return s.RequestID
-		}
-	}
-	return ""
-}
-
-// getHITLCheckpointsByRequestID finds all HITL checkpoints for a given request ID.
-// Delegates to the HTTP fan-out helper (RC3-Backend).
-func getHITLCheckpointsByRequestID(requestID string) ([]HITLCheckpoint, error) {
-	return getAgentHITLCheckpointsByRequestID(context.Background(), requestID)
-}
 
 // getRedisExecutionSummaries fetches recent execution summaries from Redis
 // executionPage holds a page of summaries with cursor for pagination.
@@ -2701,23 +3077,28 @@ func deserializeExecution(data []byte) (*StoredExecution, error) {
 	var jsonData []byte
 
 	// Check compression flag (first byte)
-	if data[0] == 1 {
+	switch data[0] {
+	case 1:
 		// Gzip compressed
 		reader, err := gzip.NewReader(bytes.NewReader(data[1:]))
 		if err != nil {
 			return nil, fmt.Errorf("gzip reader failed: %w", err)
 		}
-		defer reader.Close()
+		defer func() {
+			if closeErr := reader.Close(); closeErr != nil {
+				log.Printf("Failed to close gzip reader: %v", closeErr)
+			}
+		}()
 
 		var buf bytes.Buffer
 		if _, err := buf.ReadFrom(reader); err != nil {
 			return nil, fmt.Errorf("gzip decompress failed: %w", err)
 		}
 		jsonData = buf.Bytes()
-	} else if data[0] == 0 {
+	case 0:
 		// Raw JSON (skip flag byte)
 		jsonData = data[1:]
-	} else {
+	default:
 		// Legacy format (no flag byte, raw JSON)
 		jsonData = data
 	}
@@ -2972,7 +3353,7 @@ func getAgentHITLCheckpointSummaries(ctx context.Context) ([]HITLCheckpointSumma
 			continue
 		}
 		agentURL := fmt.Sprintf("http://%s:%d", svc.Address, svc.Port)
-		resp, err := hitlHTTPClient.Get(agentURL + "/hitl/checkpoints")
+		resp, err := doHITLGet(ctx, agentURL+"/hitl/checkpoints")
 		if err != nil {
 			log.Printf("Warning: could not reach agent %s for HITL checkpoints: %v", svc.Name, err)
 			continue
@@ -2981,7 +3362,7 @@ func getAgentHITLCheckpointSummaries(ctx context.Context) ([]HITLCheckpointSumma
 			Checkpoints []HITLCheckpoint `json:"checkpoints"`
 		}
 		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
-		resp.Body.Close()
+		closeHTTPBody(resp.Body)
 		if decodeErr != nil {
 			log.Printf("Warning: failed to decode HITL checkpoints from agent %s: %v", svc.Name, decodeErr)
 			continue
@@ -3014,21 +3395,21 @@ func getAgentHITLCheckpoint(ctx context.Context, checkpointID string) (*HITLChec
 			continue
 		}
 		agentURL := fmt.Sprintf("http://%s:%d", svc.Address, svc.Port)
-		resp, err := hitlHTTPClient.Get(agentURL + "/hitl/checkpoints/" + url.PathEscape(checkpointID))
+		resp, err := doHITLGet(ctx, agentURL+"/hitl/checkpoints/"+url.PathEscape(checkpointID))
 		if err != nil {
 			continue
 		}
 		if resp.StatusCode == http.StatusNotFound {
-			resp.Body.Close()
+			closeHTTPBody(resp.Body)
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
-			resp.Body.Close()
+			closeHTTPBody(resp.Body)
 			continue
 		}
 		var cp HITLCheckpoint
 		decodeErr := json.NewDecoder(resp.Body).Decode(&cp)
-		resp.Body.Close()
+		closeHTTPBody(resp.Body)
 		if decodeErr != nil {
 			continue
 		}
@@ -3065,11 +3446,11 @@ func getAgentHITLCheckpointsByRequestID(ctx context.Context, requestID string) (
 		}
 		g.Go(func() error {
 			agentURL := fmt.Sprintf("http://%s:%d", svc.Address, svc.Port)
-			resp, err := hitlHTTPClient.Get(agentURL + "/hitl/checkpoints?request_id=" + url.QueryEscape(requestID))
+			resp, err := doHITLGet(ctx, agentURL+"/hitl/checkpoints?request_id="+url.QueryEscape(requestID))
 			if err != nil {
 				return nil // swallow per-agent failures, same as the sequential implementation
 			}
-			defer resp.Body.Close()
+			defer closeHTTPBody(resp.Body)
 			if resp.StatusCode != http.StatusOK {
 				return nil
 			}
@@ -3739,7 +4120,8 @@ func initMemoryClients(factory MemoryBackendFactory, domains []string) {
 	for _, domain := range domains {
 		backends, err := factory(domain)
 		if err != nil {
-			log.Printf("[WARN] Memory: failed to init backends for domain %q: %v", domain, err)
+			// #nosec G706 -- every external value is normalized by safeLogText.
+			log.Printf("[WARN] Memory: failed to init backends for domain %q: %s", safeLogText(domain), safeLogText(err.Error()))
 			continue
 		}
 		built[domain] = &domainMemory{
@@ -3748,7 +4130,8 @@ func initMemoryClients(factory MemoryBackendFactory, domains []string) {
 			digest:      backends.Digest,
 			activity:    backends.Activity,
 		}
-		log.Printf("[INFO] Memory: initialized domain %q", domain)
+		// #nosec G706 -- the external value is normalized by safeLogText.
+		log.Printf("[INFO] Memory: initialized domain %q", safeLogText(domain))
 	}
 	// Only promote to the package-level map if we successfully built at
 	// least one domain — otherwise keep memoryDomains nil so getMemoryDomain
@@ -3851,7 +4234,7 @@ func handleMemoryDomains(w http.ResponseWriter, r *http.Request) {
 		"knowledge":      false, // Phase 2
 	}
 
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	writeJSON(w, map[string]interface{}{
 		"domains":  domains,
 		"backends": backends,
 	})
@@ -3881,7 +4264,7 @@ func handleMemoryEvents(w http.ResponseWriter, r *http.Request) {
 		for i, e := range events {
 			jsonEvents[i] = agentEventToJSON(e)
 		}
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		writeJSON(w, map[string]interface{}{
 			"events":      jsonEvents,
 			"total_count": len(jsonEvents),
 			"domain":      domain,
@@ -3912,7 +4295,8 @@ func handleMemoryEvents(w http.ResponseWriter, r *http.Request) {
 
 	events, err := dm.episodic.QueryEvents(ctx, domain, filter)
 	if err != nil {
-		log.Printf("[ERROR] Memory: QueryEvents failed for domain %q: %v", domain, err)
+		// #nosec G706 -- every external value is normalized by safeLogText.
+		log.Printf("[ERROR] Memory: QueryEvents failed for domain %q: %s", safeLogText(domain), safeLogText(err.Error()))
 		http.Error(w, `{"error":"query_failed","message":"Failed to query episodic events"}`, http.StatusInternalServerError)
 		return
 	}
@@ -3922,7 +4306,7 @@ func handleMemoryEvents(w http.ResponseWriter, r *http.Request) {
 		jsonEvents[i] = agentEventToJSON(e)
 	}
 
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	writeJSON(w, map[string]interface{}{
 		"events":      jsonEvents,
 		"total_count": len(jsonEvents),
 		"domain":      domain,
@@ -3957,7 +4341,7 @@ func handleMemoryEventsRecent(w http.ResponseWriter, r *http.Request) {
 		for i, e := range events {
 			jsonEvents[i] = agentEventToJSON(e)
 		}
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		writeJSON(w, map[string]interface{}{
 			"events":      jsonEvents,
 			"total_count": len(jsonEvents),
 			"domain":      domain,
@@ -3977,7 +4361,8 @@ func handleMemoryEventsRecent(w http.ResponseWriter, r *http.Request) {
 
 	events, err := dm.episodic.QueryRecentEvents(ctx, domain, time.Now().Add(-since), limit)
 	if err != nil {
-		log.Printf("[ERROR] Memory: QueryRecentEvents failed for domain %q: %v", domain, err)
+		// #nosec G706 -- every external value is normalized by safeLogText.
+		log.Printf("[ERROR] Memory: QueryRecentEvents failed for domain %q: %s", safeLogText(domain), safeLogText(err.Error()))
 		http.Error(w, `{"error":"query_failed","message":"Failed to query recent events"}`, http.StatusInternalServerError)
 		return
 	}
@@ -3987,7 +4372,7 @@ func handleMemoryEventsRecent(w http.ResponseWriter, r *http.Request) {
 		jsonEvents[i] = agentEventToJSON(e)
 	}
 
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	writeJSON(w, map[string]interface{}{
 		"events":      jsonEvents,
 		"total_count": len(jsonEvents),
 		"domain":      domain,
@@ -4002,7 +4387,7 @@ func handleMemoryInvestigations(w http.ResponseWriter, r *http.Request) {
 
 	if useMock {
 		investigations := getMockMemoryInvestigations(domain)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		writeJSON(w, map[string]interface{}{
 			"investigations": investigations,
 			"total_count":    len(investigations),
 		})
@@ -4031,7 +4416,8 @@ func handleMemoryInvestigations(w http.ResponseWriter, r *http.Request) {
 		}
 		claims, err := dm.coordinator.GetActiveInvestigations(ctx)
 		if err != nil {
-			log.Printf("[WARN] Memory: GetActiveInvestigations failed for domain %q: %v", d, err)
+			// #nosec G706 -- every external value is normalized by safeLogText.
+			log.Printf("[WARN] Memory: GetActiveInvestigations failed for domain %q: %s", safeLogText(d), safeLogText(err.Error()))
 			continue
 		}
 		for entityID, holder := range claims {
@@ -4047,7 +4433,7 @@ func handleMemoryInvestigations(w http.ResponseWriter, r *http.Request) {
 		results = []investigation{}
 	}
 
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	writeJSON(w, map[string]interface{}{
 		"investigations": results,
 		"total_count":    len(results),
 	})
@@ -4063,7 +4449,7 @@ func handleMemoryDigest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if useMock {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		writeJSON(w, map[string]interface{}{
 			"domain":    domain,
 			"digest":    getMockMemoryDigest(domain),
 			"available": true,
@@ -4082,8 +4468,9 @@ func handleMemoryDigest(w http.ResponseWriter, r *http.Request) {
 
 	data, err := dm.digest.GetDigest(ctx, domain)
 	if err != nil {
-		log.Printf("[WARN] Memory: GetDigest failed for domain %q: %v", domain, err)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		// #nosec G706 -- every external value is normalized by safeLogText.
+		log.Printf("[WARN] Memory: GetDigest failed for domain %q: %s", safeLogText(domain), safeLogText(err.Error()))
+		writeJSON(w, map[string]interface{}{
 			"domain":    domain,
 			"digest":    "",
 			"available": false,
@@ -4093,7 +4480,7 @@ func handleMemoryDigest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(data) == 0 {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		writeJSON(w, map[string]interface{}{
 			"domain":    domain,
 			"digest":    "",
 			"available": false,
@@ -4112,8 +4499,10 @@ func handleMemoryDigest(w http.ResponseWriter, r *http.Request) {
 	if err := json.Unmarshal(data, &digestData); err == nil && digestData.Content != "" {
 		// Re-marshal the raw data with indentation for the raw view
 		var rawPretty interface{}
-		json.Unmarshal(data, &rawPretty)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		if err := json.Unmarshal(data, &rawPretty); err != nil {
+			rawPretty = string(data)
+		}
+		writeJSON(w, map[string]interface{}{
 			"domain":       domain,
 			"digest":       digestData.Content,
 			"generated_at": digestData.GeneratedAt,
@@ -4122,7 +4511,7 @@ func handleMemoryDigest(w http.ResponseWriter, r *http.Request) {
 		})
 	} else {
 		// Fallback: treat raw bytes as plain text digest
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		writeJSON(w, map[string]interface{}{
 			"domain":    domain,
 			"digest":    string(data),
 			"available": true,
@@ -4141,7 +4530,7 @@ func handleMemoryActivities(w http.ResponseWriter, r *http.Request) {
 
 	if useMock {
 		activities := getMockMemoryActivities(domain)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		writeJSON(w, map[string]interface{}{
 			"activities":  activities,
 			"domain":      domain,
 			"total_count": len(activities),
@@ -4160,7 +4549,8 @@ func handleMemoryActivities(w http.ResponseWriter, r *http.Request) {
 
 	signals, err := dm.activity.GetDomainActivities(ctx, domain)
 	if err != nil {
-		log.Printf("[WARN] Memory: GetDomainActivities failed for domain %q: %v", domain, err)
+		// #nosec G706 -- every external value is normalized by safeLogText.
+		log.Printf("[WARN] Memory: GetDomainActivities failed for domain %q: %s", safeLogText(domain), safeLogText(err.Error()))
 		signals = nil
 	}
 
@@ -4186,7 +4576,7 @@ func handleMemoryActivities(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	writeJSON(w, map[string]interface{}{
 		"activities":  results,
 		"domain":      domain,
 		"total_count": len(results),

--- a/examples/registry-viewer-app/orch_022_viewer_test.go
+++ b/examples/registry-viewer-app/orch_022_viewer_test.go
@@ -36,6 +36,86 @@ func TestBuildUnifiedViewPreservesSkillExecutionDebug(t *testing.T) {
 	}
 }
 
+func TestBuildUnifiedViewPreservesGovernedFinalResponse(t *testing.T) {
+	previousMock := useMock
+	useMock = true
+	t.Cleanup(func() { useMock = previousMock })
+
+	governed := "Governed order recovery outcome: recovered"
+	view := buildUnifiedView(&StoredExecution{
+		RequestID:           "request-with-governed-response",
+		FinalResponse:       &governed,
+		FinalResponseSource: "after_synthesis_hooks",
+	})
+	if view == nil || view.FinalResponse == nil || *view.FinalResponse != governed {
+		t.Fatalf("final response = %#v", view)
+	}
+	if view.FinalResponseSource != "after_synthesis_hooks" {
+		t.Errorf("final response source = %q", view.FinalResponseSource)
+	}
+}
+
+func TestSummarizeExecutionDoesNotReplacePhaseLoopWithSmallerStepEnvelope(t *testing.T) {
+	started := time.Date(2026, 8, 21, 3, 39, 57, 0, time.UTC)
+	ended := started.Add(55 * time.Second)
+	execution := &StoredExecution{
+		RequestID: "duration-lower-bound",
+		Result: &ExecutionResult{
+			TotalDuration: int64(183 * time.Second),
+			Steps: []StepResult{{
+				StepID: "step-1", Success: true, StartTime: &started, EndTime: &ended,
+			}},
+		},
+	}
+
+	summary := summarizeExecution(execution)
+	if summary.WallClockDurationMs != 183_000 {
+		t.Fatalf("wall clock = %d, want phase-loop lower bound 183000", summary.WallClockDurationMs)
+	}
+	if summary.DurationSource != "phase_loop_fallback" {
+		t.Fatalf("duration source = %q, want phase_loop_fallback", summary.DurationSource)
+	}
+}
+
+func TestResumeObservationWindowExcludesRestoredStepsAndIncludesLaterResumePhases(t *testing.T) {
+	historicalStart := time.Date(2026, 8, 27, 15, 34, 36, 0, time.UTC)
+	historicalEnd := historicalStart.Add(50 * time.Second)
+	resumeStart := historicalStart.Add(111 * time.Second)
+	resumeEnd := resumeStart.Add(2 * time.Second)
+	continuationStart := resumeEnd.Add(time.Second)
+	continuationEnd := continuationStart.Add(4 * time.Second)
+	execution := &StoredExecution{
+		RequestID: "resume-duration",
+		Metadata:  map[string]string{"resume_checkpoint_id": "cp-duration"},
+		Result: &ExecutionResult{
+			TotalDuration: int64(5 * time.Second),
+			Steps: []StepResult{
+				{
+					StepID: "restored", Success: true, StartTime: &historicalStart, EndTime: &historicalEnd,
+					Metadata: map[string]interface{}{"plan_source": "continuation_generation"},
+				},
+				{
+					StepID: "resumed", Success: true, StartTime: &resumeStart, EndTime: &resumeEnd,
+					Metadata: map[string]interface{}{"plan_source": "hitl_resume"},
+				},
+				{
+					StepID: "continued", Success: true, StartTime: &continuationStart, EndTime: &continuationEnd,
+					Metadata: map[string]interface{}{"plan_source": "continuation_generation"},
+				},
+			},
+		},
+	}
+
+	start, end := executionObservationWindow(execution)
+	if !start.Equal(resumeStart) || !end.Equal(continuationEnd) {
+		t.Fatalf("resume window = %s to %s, want %s to %s", start, end, resumeStart, continuationEnd)
+	}
+	summary := summarizeExecution(execution)
+	if summary.WallClockDurationMs != 7_000 || summary.DurationSource != "step_time_envelope" {
+		t.Fatalf("resume duration = %d source=%q, want 7000 step_time_envelope", summary.WallClockDurationMs, summary.DurationSource)
+	}
+}
+
 func TestNormalizeSteps_MultiPhasePostFix(t *testing.T) {
 	t0 := time.Now()
 	exec := &StoredExecution{
@@ -304,5 +384,174 @@ func TestComputeDAG_InterruptedRecord_Legacy(t *testing.T) {
 	}
 	if step3.Status != "blocked" {
 		t.Errorf("step-3 status = %q, want blocked (Checkpoint.CurrentStep match)", step3.Status)
+	}
+}
+
+func TestComputeDAG_LiveDurationAndPhaseAwareTopology(t *testing.T) {
+	exec := &StoredExecution{
+		PhasePlans: []*RoutingPlan{
+			{PhaseNumber: 1, Steps: []RoutingStep{{StepID: "step-1"}, {StepID: "step-2"}}},
+			{PhaseNumber: 2, Steps: []RoutingStep{{StepID: "step-3"}}},
+			{PhaseNumber: 3, Steps: []RoutingStep{
+				{StepID: "step-4"},
+				{StepID: "step-5"},
+				{StepID: "step-6", DependsOn: []string{"step-4", "step-5"}},
+			}},
+			{PhaseNumber: 4, Steps: []RoutingStep{
+				{StepID: "step-7", ImplicitDeps: []string{"step-6"}},
+				{StepID: "step-8", DependsOn: []string{"step-7"}},
+				{StepID: "step-9", DependsOn: []string{"step-7", "step-8"}},
+			}},
+		},
+		Result: &ExecutionResult{Success: true, Steps: []StepResult{
+			{StepID: "step-1", Success: true},
+			{StepID: "step-2", Success: true},
+			{StepID: "step-3", Success: true},
+			{StepID: "step-4", Success: true},
+			{StepID: "step-5", Success: true},
+			{StepID: "step-6", Success: true, Duration: 6_918_398_341},
+			{StepID: "step-7", Success: true},
+			{StepID: "step-8", Success: true},
+			{StepID: "step-9", Success: true},
+		}},
+	}
+
+	dag := computeDAG(exec)
+	wantLevels := [][]string{
+		{"step-1", "step-2"},
+		{"phase_boundary_1"},
+		{"step-3"},
+		{"phase_boundary_2"},
+		{"step-4", "step-5"},
+		{"step-6"},
+		{"phase_boundary_3"},
+		{"step-7"},
+		{"step-8"},
+		{"step-9"},
+	}
+	if len(dag.Levels) != len(wantLevels) {
+		t.Fatalf("levels = %v, want %v", dag.Levels, wantLevels)
+	}
+	for i := range wantLevels {
+		if len(dag.Levels[i]) != len(wantLevels[i]) {
+			t.Fatalf("level %d = %v, want %v", i, dag.Levels[i], wantLevels[i])
+		}
+		for j := range wantLevels[i] {
+			if dag.Levels[i][j] != wantLevels[i][j] {
+				t.Fatalf("level %d = %v, want %v", i, dag.Levels[i], wantLevels[i])
+			}
+		}
+	}
+	if dag.Statistics.MaxParallelism != 2 {
+		t.Errorf("max_parallelism = %d, want 2", dag.Statistics.MaxParallelism)
+	}
+	if dag.Statistics.TotalNodes != len(dag.Nodes) || len(dag.Nodes) != 12 {
+		t.Errorf("total_nodes = %d, node count = %d, want both 12", dag.Statistics.TotalNodes, len(dag.Nodes))
+	}
+	if dag.Statistics.Depth != 10 {
+		t.Errorf("depth = %d, want 10 including three sequencing boundaries", dag.Statistics.Depth)
+	}
+
+	var step6 *DAGNode
+	implicitEdgeFound := false
+	for i := range dag.Nodes {
+		if dag.Nodes[i].ID == "step-6" {
+			step6 = &dag.Nodes[i]
+		}
+	}
+	for _, edge := range dag.Edges {
+		if edge.Source == "step-6" && edge.Target == "step-7" && edge.EdgeType == "implicit_dependency" {
+			implicitEdgeFound = true
+		}
+	}
+	if step6 == nil || step6.DurationMs != 6918 {
+		t.Fatalf("step-6 = %#v, want duration_ms=6918 from live nanoseconds", step6)
+	}
+	if !implicitEdgeFound {
+		t.Fatal("missing implicit_dependency edge step-6 -> step-7")
+	}
+}
+
+func TestObservedDurationUsesElapsedEnvelopeNotDurationSum(t *testing.T) {
+	start := time.Date(2026, 8, 21, 22, 0, 0, 0, time.UTC)
+	end := start.Add(70_677 * time.Millisecond)
+	if got := observedDurationMilliseconds(start, end); got != 70_677 {
+		t.Fatalf("observed duration = %dms, want 70677ms", got)
+	}
+	if got := primaryExecutionDurationMs(ExecutionSummary{
+		TotalDurationMs:     59_343,
+		WallClockDurationMs: 70_677,
+		LLMTotalDurationMs:  70_555,
+	}); got != 70_677 {
+		t.Fatalf("primary duration = %dms, want wall clock 70677ms", got)
+	}
+}
+
+func TestBuildHITLLifecycleReconcilesSnapshotAndCurrentCheckpoint(t *testing.T) {
+	initial := &StoredExecution{
+		RequestID:         "initial-request",
+		OriginalRequestID: "initial-request",
+		Interrupted:       true,
+		Checkpoint: &HITLCheckpoint{
+			CheckpointID: "checkpoint-1",
+			Status:       "pending",
+		},
+	}
+	current := []HITLCheckpoint{{CheckpointID: "checkpoint-1", Status: "completed"}}
+	family := []ExecutionSummary{{
+		RequestID:         "resume-request",
+		OriginalRequestID: "initial-request",
+		TraceID:           "resume-trace",
+		Success:           true,
+		HITLCheckpointID:  "checkpoint-1",
+		Metadata:          map[string]string{"resume_checkpoint_id": "checkpoint-1"},
+	}}
+
+	lifecycle := buildHITLLifecycle(initial, current, family)
+	if lifecycle == nil {
+		t.Fatal("lifecycle is nil")
+	}
+	if lifecycle.SnapshotStatus != "pending" || lifecycle.CurrentStatus != "completed" {
+		t.Errorf("snapshot=%q current=%q", lifecycle.SnapshotStatus, lifecycle.CurrentStatus)
+	}
+	if lifecycle.CurrentStatusSource != "agent_checkpoint_api" || lifecycle.CurrentCheckpoint == nil {
+		t.Errorf("current checkpoint source/payload = %#v", lifecycle)
+	}
+	if len(lifecycle.RelatedExecutions) != 1 || lifecycle.RelatedExecutions[0].Role != "resume" ||
+		lifecycle.RelatedExecutions[0].RequestID != "resume-request" {
+		t.Errorf("related executions = %#v", lifecycle.RelatedExecutions)
+	}
+}
+
+func TestBuildHITLLifecycleMarksResumeAndLinksBackToInitial(t *testing.T) {
+	resume := &StoredExecution{
+		RequestID:         "resume-request",
+		OriginalRequestID: "initial-request",
+		Metadata:          map[string]string{"resume_checkpoint_id": "checkpoint-1"},
+	}
+	current := []HITLCheckpoint{{CheckpointID: "checkpoint-1", Status: "aborted"}}
+	family := []ExecutionSummary{{
+		RequestID:         "initial-request",
+		OriginalRequestID: "initial-request",
+		TraceID:           "initial-trace",
+		Interrupted:       true,
+		HITLCheckpointID:  "checkpoint-1",
+	}, {
+		RequestID:         "other-interruption",
+		OriginalRequestID: "initial-request",
+		Interrupted:       true,
+		HITLCheckpointID:  "checkpoint-2",
+	}}
+
+	lifecycle := buildHITLLifecycle(resume, current, family)
+	if lifecycle == nil || !lifecycle.IsResume || lifecycle.CheckpointID != "checkpoint-1" {
+		t.Fatalf("resume lifecycle = %#v", lifecycle)
+	}
+	if lifecycle.InitialRequestID != "initial-request" || lifecycle.CurrentStatus != "aborted" {
+		t.Errorf("resume lifecycle = %#v", lifecycle)
+	}
+	if len(lifecycle.RelatedExecutions) != 1 || lifecycle.RelatedExecutions[0].Role != "interrupted" ||
+		lifecycle.RelatedExecutions[0].RequestID != "initial-request" {
+		t.Errorf("related executions = %#v", lifecycle.RelatedExecutions)
 	}
 }

--- a/examples/registry-viewer-app/redis_storage_provider.go
+++ b/examples/registry-viewer-app/redis_storage_provider.go
@@ -2,19 +2,48 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/truvaagents/truva-g3/orchestration"
 )
 
-// RedisStorageProvider implements the StorageProvider interface using Redis.
+var providerExtendMinimumTTLScript = redis.NewScript(`
+local current = redis.call("PTTL", KEYS[1])
+local requested = tonumber(ARGV[1])
+if current == -2 or current == -1 or current >= requested then
+	return current
+end
+redis.call("PEXPIRE", KEYS[1], requested)
+return current
+`)
+
+var providerSetWithMinimumTTLScript = redis.NewScript(`
+local previous = redis.call("PTTL", KEYS[1])
+redis.call("SET", KEYS[1], ARGV[1])
+if previous == -1 then
+	return previous
+end
+local requested = tonumber(ARGV[2])
+local selected = requested
+if previous >= 0 and previous > selected then
+	selected = previous
+end
+redis.call("PEXPIRE", KEYS[1], selected)
+return previous
+`)
+
+// RedisStorageProvider implements the required ExecutionStorageProvider and
+// optional IndexTTLManager interfaces using Redis.
 // This is an application-level implementation that the orchestration module
 // accepts through dependency injection.
 type RedisStorageProvider struct {
 	client *redis.Client
 }
 
-// NewRedisStorageProvider creates a new Redis-backed StorageProvider.
+// NewRedisStorageProvider creates a Redis-backed execution storage provider.
 func NewRedisStorageProvider(client *redis.Client) *RedisStorageProvider {
 	return &RedisStorageProvider{
 		client: client,
@@ -36,6 +65,67 @@ func (r *RedisStorageProvider) Get(ctx context.Context, key string) (string, err
 // Set stores a value with TTL. Use 0 for no expiration.
 func (r *RedisStorageProvider) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
 	return r.client.Set(ctx, key, value, ttl).Err()
+}
+
+// ExtendKeyTTL implements orchestration.KeyTTLManager without creating a
+// missing key, shortening a longer lifetime, or expiring a persistent key.
+func (r *RedisStorageProvider) ExtendKeyTTL(
+	ctx context.Context,
+	key string,
+	minTTL time.Duration,
+) error {
+	milliseconds, err := providerTTLMilliseconds(minTTL)
+	if err != nil {
+		return err
+	}
+	return providerExtendMinimumTTLScript.Run(
+		ctx,
+		r.client,
+		[]string{key},
+		strconv.FormatInt(milliseconds, 10),
+	).Err()
+}
+
+// SetKeyWithMinimumTTL atomically writes a value while preserving a longer or
+// persistent lifetime already attached to the key.
+func (r *RedisStorageProvider) SetKeyWithMinimumTTL(
+	ctx context.Context,
+	key string,
+	value string,
+	minTTL time.Duration,
+) error {
+	milliseconds, err := providerTTLMilliseconds(minTTL)
+	if err != nil {
+		return err
+	}
+	return providerSetWithMinimumTTLScript.Run(
+		ctx,
+		r.client,
+		[]string{key},
+		value,
+		strconv.FormatInt(milliseconds, 10),
+	).Err()
+}
+
+// ExtendIndexTTL implements orchestration.IndexTTLManager with the same
+// atomic minimum-lifetime semantics as ordinary keys.
+func (r *RedisStorageProvider) ExtendIndexTTL(
+	ctx context.Context,
+	key string,
+	minTTL time.Duration,
+) error {
+	return r.ExtendKeyTTL(ctx, key, minTTL)
+}
+
+func providerTTLMilliseconds(ttl time.Duration) (int64, error) {
+	if ttl <= 0 {
+		return 0, fmt.Errorf("duration must be positive")
+	}
+	milliseconds := ttl.Milliseconds()
+	if milliseconds <= 0 {
+		milliseconds = 1
+	}
+	return milliseconds, nil
 }
 
 // Del deletes one or more keys.
@@ -84,3 +174,8 @@ func (r *RedisStorageProvider) RemoveFromIndex(ctx context.Context, key string, 
 	}
 	return r.client.ZRem(ctx, key, args...).Err()
 }
+
+var _ orchestration.StorageProvider = (*RedisStorageProvider)(nil)
+var _ orchestration.KeyTTLManager = (*RedisStorageProvider)(nil)
+var _ orchestration.ExecutionStorageProvider = (*RedisStorageProvider)(nil)
+var _ orchestration.IndexTTLManager = (*RedisStorageProvider)(nil)

--- a/examples/registry-viewer-app/setup.sh
+++ b/examples/registry-viewer-app/setup.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 # setup.sh - Setup and deployment script for registry-viewer-app
-# This is a standalone app that visualizes the TruvaG3 Redis service registry
-# No infrastructure setup required - just build, deploy, and run
+# This independently deployable app visualizes TruvaG3 runtime data. Its source
+# imports framework modules from the repository; setup.sh builds them together.
+# No infrastructure setup is performed here: build, deploy, and run the app
+# after shared infrastructure is available.
 
 set -e
 
@@ -130,7 +132,7 @@ build_app() {
 
     cd "$SCRIPT_DIR"
 
-    # Disable Go workspace to build standalone
+    # Build this module through the local framework replacements in go.mod.
     export GOWORK=off
 
     # Download dependencies
@@ -325,9 +327,9 @@ run_local() {
     echo ""
 
     if [ "$1" = "redis" ]; then
-        ./registry-viewer -mock=false -redis-url="${REDIS_URL:-redis://localhost:6379}"
+        ./registry-viewer -port="$APP_PORT" -mock=false -redis-url="${REDIS_URL:-redis://localhost:6379}"
     else
-        ./registry-viewer -mock=true
+        ./registry-viewer -port="$APP_PORT" -mock=true
     fi
 }
 

--- a/examples/registry-viewer-app/setup.sh
+++ b/examples/registry-viewer-app/setup.sh
@@ -234,6 +234,8 @@ deploy_k8s() {
         --from-literal=PORT="${APP_PORT}" \
         --from-literal=APP_ENV="${APP_ENV:-development}" \
         --from-literal=OTEL_EXPORTER_OTLP_ENDPOINT="${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4318}" \
+        --from-literal=JAEGER_QUERY_URL="${JAEGER_QUERY_URL:-http://jaeger-query}" \
+        --from-literal=JAEGER_UI_URL="${JAEGER_UI_URL:-http://jaeger.localhost}" \
         --from-literal=TRUVAG3_VIEWER_MEMORY_DOMAINS="${TRUVAG3_VIEWER_MEMORY_DOMAINS:-infrastructure}" \
         --from-literal=TRUVAG3_SKILLS_REDIS_DB="${TRUVAG3_SKILLS_REDIS_DB:-9}" \
         --dry-run=client -o yaml | kubectl apply -f -
@@ -504,6 +506,8 @@ Environment Variables:
                     Default: Extracted from ../k8-deployment/redis.yaml
                     (service name + port from Redis Service definition)
   REDIS_NAMESPACE   Redis key namespace (default: truvag3)
+  JAEGER_QUERY_URL  Jaeger Query base URL (default: http://jaeger-query)
+  JAEGER_UI_URL     Browser-facing Jaeger UI base URL (default: http://jaeger.localhost)
   DOCKER_NO_CACHE   Set to 'true' to build Docker with --no-cache
 
 Redis Configuration:

--- a/examples/registry-viewer-app/static/css/layout.css
+++ b/examples/registry-viewer-app/static/css/layout.css
@@ -2010,6 +2010,64 @@ tr.expandable td:nth-child(2)::before {
     color: var(--accent-teal);
     font-weight: 500;
 }
+
+/* HITL checkpoint details: neutral dark glass keeps nested content distinct
+   from status-tinted checkpoint cards without competing with status color. */
+.hitl-context-panel {
+    --hitl-context-accent: rgba(100, 210, 255, 0.72);
+    position: relative;
+    margin-top: 12px;
+    padding: 14px 16px;
+    background: linear-gradient(135deg, rgba(4, 8, 14, 0.82) 0%, rgba(12, 17, 25, 0.68) 100%);
+    backdrop-filter: blur(12px) saturate(150%);
+    -webkit-backdrop-filter: blur(12px) saturate(150%);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 12px;
+    box-shadow:
+        0 8px 24px rgba(0, 0, 0, 0.28),
+        inset 0 1px 0 rgba(255, 255, 255, 0.08),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.18);
+}
+.hitl-context-panel-decision {
+    --hitl-context-accent: rgba(255, 179, 64, 0.78);
+}
+.hitl-context-panel-step {
+    --hitl-context-accent: rgba(100, 210, 255, 0.78);
+}
+.hitl-context-title {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding-bottom: 10px;
+    margin-bottom: 11px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.1px;
+}
+.hitl-context-title::before {
+    content: '';
+    width: 7px;
+    height: 7px;
+    flex: 0 0 7px;
+    border-radius: 50%;
+    background: var(--hitl-context-accent);
+    box-shadow: 0 0 8px var(--hitl-context-accent);
+}
+.hitl-context-grid {
+    margin-bottom: 0;
+}
+.hitl-context-grid .dag-step-label {
+    color: var(--text-muted);
+}
+.hitl-context-grid .dag-step-value {
+    color: var(--text-primary);
+    line-height: 1.5;
+}
+.hitl-context-grid .dag-step-value.highlight {
+    color: var(--accent-teal);
+}
 .instruction-collapsible { width: 100%; }
 .instruction-text {
     white-space: pre-wrap;
@@ -2249,6 +2307,19 @@ tr.expandable td:nth-child(2)::before {
     border: 1px solid rgba(255, 255, 255, 0.08);
     font-size: 11px;
 }
+.dag-viz-meta-item.dag-viz-trace-link,
+.dag-viz-meta-item.dag-viz-trace-link:visited {
+    background: rgba(10, 132, 255, 0.2);
+    border-color: rgba(100, 210, 255, 0.5);
+    color: #f2f8ff;
+    text-decoration: none;
+}
+.dag-viz-meta-item.dag-viz-trace-link:hover,
+.dag-viz-meta-item.dag-viz-trace-link:focus-visible {
+    background: rgba(10, 132, 255, 0.34);
+    border-color: rgba(142, 220, 255, 0.8);
+    color: #ffffff;
+}
 .dag-viz-meta-item.success {
     background: rgba(50, 215, 75, 0.15);
     border-color: rgba(50, 215, 75, 0.4);
@@ -2375,6 +2446,12 @@ tr.expandable td:nth-child(2)::before {
     border: 2px dashed rgba(100, 210, 255, 0.6);
     box-shadow: 0 0 8px rgba(100, 210, 255, 0.4), 0 0 16px rgba(100, 210, 255, 0.15);
     color: rgba(100, 210, 255, 0.6);
+}
+.dag-legend-dot.implicit-dependency {
+    background: rgba(182, 133, 244, 0.15);
+    border: 2px dotted rgba(182, 133, 244, 0.75);
+    box-shadow: 0 0 8px rgba(182, 133, 244, 0.4), 0 0 16px rgba(182, 133, 244, 0.15);
+    color: rgba(182, 133, 244, 0.7);
 }
 .dag-phase-divider {
     background: linear-gradient(135deg, rgba(25, 25, 35, 0.6) 0%, rgba(15, 15, 22, 0.6) 100%);

--- a/examples/registry-viewer-app/static/js/utils/dag-graph.js
+++ b/examples/registry-viewer-app/static/js/utils/dag-graph.js
@@ -1,0 +1,161 @@
+/**
+ * Remove graph edges whose endpoints are not present in the rendered node set.
+ *
+ * HITL resume records can legitimately retain implicit data-provenance links to
+ * steps stored on the interrupted parent execution. Those parent steps are not
+ * nodes in the resume record's own DAG. Cytoscape rejects any such dangling
+ * edge and otherwise leaves the whole canvas blank, so callers must validate
+ * the graph boundary before handing elements to the renderer.
+ */
+export function filterRenderableEdges(nodes, edges) {
+    const nodeIDs = new Set(
+        (nodes || [])
+            .map(node => node?.data?.id)
+            .filter(id => typeof id === 'string' && id !== '')
+    );
+    const renderable = [];
+    const omitted = [];
+
+    (edges || []).forEach(edge => {
+        const source = edge?.data?.source;
+        const target = edge?.data?.target;
+        if (nodeIDs.has(source) && nodeIDs.has(target)) {
+            renderable.push(edge);
+        } else {
+            omitted.push(edge);
+        }
+    });
+
+    return { renderable, omitted };
+}
+
+/**
+ * Keep step-scoped interactions only when their parent step is part of the
+ * graph currently being rendered. A HITL resume can carry debug interactions
+ * from its interrupted parent execution; those remain available in the LLM
+ * Calls tab but must not appear as disconnected nodes in the resume DAG.
+ */
+export function filterInteractionsWithRenderedParent(interactions, stepIDs) {
+    const renderedStepIDs = stepIDs instanceof Set ? stepIDs : new Set(stepIDs || []);
+    return (interactions || []).filter(interaction =>
+        renderedStepIDs.has(interaction?.step_id)
+    );
+}
+
+/**
+ * A relationship branch is meaningful only when its owner is present in the
+ * rendered execution group. Orphan rows retain lineage text for audit, but a
+ * branch glyph or connector would falsely imply a visible parent.
+ */
+export function hasVisibleRelationOwner(execution, orphan = false) {
+    if (orphan) return false;
+    return execution?.relation_status !== 'owner_unavailable' &&
+        execution?.relation_status !== 'owner_unknown';
+}
+
+/**
+ * Count the distinct steps completed before a HITL resume. These steps belong
+ * to the same logical workflow, so the resume must continue their visible
+ * numbering instead of restarting at one.
+ */
+export function hitlContinuationStepOffset(execution) {
+    const lifecycle = execution?.hitl_lifecycle;
+    if (!lifecycle?.is_resume) return 0;
+
+    const completedSteps = lifecycle.current_checkpoint?.completed_steps;
+    let stepIDs = [];
+
+    if (Array.isArray(completedSteps)) {
+        stepIDs = completedSteps.map(step => step?.step_id);
+    } else if (completedSteps && typeof completedSteps === 'object') {
+        stepIDs = Object.keys(completedSteps);
+    }
+
+    return new Set(stepIDs.filter(Boolean)).size;
+}
+
+/**
+ * Step IDs are opaque identifiers, not display ordinals. Number a normal
+ * execution from one, and continue after the completed pre-interruption steps
+ * for a HITL resume.
+ */
+export function executionDisplayStepNumber(index, execution) {
+    if (!Number.isInteger(index) || index < 0) return null;
+    return hitlContinuationStepOffset(execution) + index + 1;
+}
+
+const preExecutionHookPhases = new Set(['before_planning', 'after_planning']);
+const postExecutionHookPhases = new Set(['after_execution', 'after_synthesis']);
+
+export function isPreExecutionHook(hook) {
+    return preExecutionHookPhases.has(hook?.phase);
+}
+
+export function isPostExecutionHook(hook) {
+    return postExecutionHookPhases.has(hook?.phase);
+}
+
+/**
+ * Trace spans wrap hook implementations. Some framework hooks already expose
+ * their internal operations as richer LLM-debug nodes. Suppress only those
+ * wrapper nodes in Full Flow so the graph does not imply duplicate execution;
+ * the Pre/Post tabs still show both the hook invocation and its operations.
+ */
+export function pipelineHookHasDetailedInteractions(hook, interactions) {
+    const name = hook?.hook_name || '';
+    const calls = interactions || [];
+
+    if (name === 'user-memory-enrichment') {
+        return calls.some(call =>
+            call?.type?.startsWith('user_memory_recall_') ||
+            call?.type === 'user_memory_enrichment_injected'
+        );
+    }
+    if (name === 'user-memory-extraction') {
+        return calls.some(call =>
+            call?.type?.startsWith('user_memory_') &&
+            !call?.type?.startsWith('user_memory_recall_') &&
+            call?.type !== 'user_memory_enrichment_injected'
+        );
+    }
+    if (name === 'memory-enrichment') {
+        return calls.some(call =>
+            call?.type === 'activity_compaction' ||
+            call?.type === 'activity_compaction_incremental'
+        );
+    }
+    if (name === 'memory-record') {
+        return calls.some(call => call?.type === 'event_summarization');
+    }
+    return false;
+}
+
+/**
+ * Associate AfterPlanning spans with the latest phase plan created before the
+ * span began. The trace schema does not carry phase_number on hook spans, but
+ * both timestamps are authoritative and preserve the actual iterative order.
+ * Hooks that cannot be placed safely remain tab-visible and are omitted from
+ * Full Flow instead of being attached to a guessed phase.
+ */
+export function assignAfterPlanningHooksToPhases(hooks, phasePlans) {
+    const plans = phasePlans || [];
+    const assignments = plans.map(() => []);
+    const planTimes = plans.map(plan => Date.parse(plan?.created_at || ''));
+
+    (hooks || []).forEach(hook => {
+        const hookTime = Date.parse(hook?.started_at || '');
+        if (!Number.isFinite(hookTime)) return;
+
+        let bestIndex = -1;
+        let bestTime = -Infinity;
+        planTimes.forEach((planTime, index) => {
+            if (Number.isFinite(planTime) && planTime <= hookTime && planTime > bestTime) {
+                bestIndex = index;
+                bestTime = planTime;
+            }
+        });
+        if (bestIndex >= 0) assignments[bestIndex].push(hook);
+    });
+
+    return assignments;
+}

--- a/examples/registry-viewer-app/static/js/views/dag.js
+++ b/examples/registry-viewer-app/static/js/views/dag.js
@@ -32,6 +32,16 @@ import {
     isPhaseClosingType,
     getPhaseNumber,
 } from '../llm-types.js';
+import {
+    assignAfterPlanningHooksToPhases,
+    executionDisplayStepNumber,
+    filterInteractionsWithRenderedParent,
+    filterRenderableEdges,
+    hasVisibleRelationOwner,
+    isPostExecutionHook,
+    isPreExecutionHook,
+    pipelineHookHasDetailedInteractions,
+} from '../utils/dag-graph.js';
 
 // ---------------------------------------------------------------------------
 // Module-level state
@@ -89,6 +99,17 @@ function escapeHtmlAttribute(value) {
     return escapeHtml(String(value ?? '')).replace(/"/g, '&quot;');
 }
 
+// The framework's phase-loop time and aggregate LLM call time overlap. The
+// viewer must never add them. Prefer the backend's elapsed-time envelope and
+// retain total_duration_ms only as a compatibility fallback for older rows.
+function primaryDurationMs(execution) {
+    return execution?.wall_clock_duration_ms || execution?.total_duration_ms || 0;
+}
+
+function jaegerTraceURL(traceID) {
+    return `/api/traces/${encodeURIComponent(traceID || '')}`;
+}
+
 // ---------------------------------------------------------------------------
 // Hook-phase classification
 // ---------------------------------------------------------------------------
@@ -118,6 +139,76 @@ function classifyInteractions(interactions) {
         ? (i) => !i.hook_phase
         : (i) => !isPreHook(i) && !isPostHook(i);
     return { isPreHook, isPostHook, isOrchestrationCall };
+}
+
+function pipelineHookPhaseLabel(phase) {
+    const labels = {
+        before_planning: 'BeforePlanning',
+        after_planning: 'AfterPlanning',
+        after_execution: 'AfterExecution',
+        after_synthesis: 'AfterSynthesis',
+    };
+    return labels[phase] || String(phase || 'Unknown').replaceAll('_', ' ');
+}
+
+function formatPipelineHookDuration(durationUS) {
+    const microseconds = Number(durationUS) || 0;
+    if (microseconds < 1000) return `${microseconds}µs`;
+    const milliseconds = microseconds / 1000;
+    return milliseconds < 10 ? `${milliseconds.toFixed(2)}ms` : formatDuration(Math.round(milliseconds));
+}
+
+function pipelineHookNodeData(hook, id) {
+    const phase = pipelineHookPhaseLabel(hook.phase);
+    return {
+        id,
+        label: `🪝 ${phase}\n${hook.hook_name}`,
+        nodeType: 'pipeline_hook',
+        hookName: hook.hook_name || 'unknown',
+        hookPhase: hook.phase || '',
+        operationName: hook.operation_name || '',
+        hookStatus: hook.status || 'completed',
+        durationUS: hook.duration_us || 0,
+        traceID: hook.trace_id || selected?.trace_id || '',
+        spanID: hook.span_id || '',
+        startedAt: hook.started_at || '',
+    };
+}
+
+function renderPipelineHookObservations(hooks) {
+    if (!hooks?.length) return '';
+    return `
+        <section style="margin-bottom: 20px;">
+            <div style="font-size: 14px; font-weight: 600; color: #64d2ff; margin-bottom: 10px; display: flex; align-items: center; gap: 8px;">
+                🪝 Pipeline hook executions
+                <span style="font-size: 11px; font-weight: 400; color: var(--text-muted);">${hooks.length} trace-backed invocation${hooks.length === 1 ? '' : 's'}</span>
+            </div>
+            ${hooks.map(hook => {
+                const failed = hook.status === 'failed';
+                const statusColor = failed ? 'var(--accent-red)' : 'var(--accent-green)';
+                return `
+                    <div class="dag-step-card" style="margin-bottom: 8px; border-left: 3px solid ${statusColor};">
+                        <div class="dag-step-header">
+                            <div class="dag-step-title">
+                                <span style="font-weight: 700; color: var(--text-primary);">${escapeHtml(hook.hook_name || 'unknown hook')}</span>
+                                <span class="dag-step-id">${escapeHtml(pipelineHookPhaseLabel(hook.phase))}</span>
+                            </div>
+                            <span style="color: ${statusColor}; font-size: 11px; font-weight: 700;">${failed ? '✗ Failed' : '✓ Completed'}</span>
+                        </div>
+                        <div class="dag-step-body">
+                            <div class="dag-step-info">
+                                <span class="dag-step-label">Duration</span>
+                                <span class="dag-step-value">${formatPipelineHookDuration(hook.duration_us)}</span>
+                                <span class="dag-step-label">Evidence</span>
+                                <span class="dag-step-value" style="color: var(--accent-teal);">Jaeger pipeline span</span>
+                                <span class="dag-step-label">Operation</span>
+                                <span class="dag-step-value dag-mono">${escapeHtml(hook.operation_name || '')}</span>
+                                ${hook.span_id ? `<span class="dag-step-label">Span ID</span><span class="dag-step-value dag-mono">${escapeHtml(hook.span_id)}</span>` : ''}
+                            </div>
+                        </div>
+                    </div>`;
+            }).join('')}
+        </section>`;
 }
 
 // ---------------------------------------------------------------------------
@@ -424,13 +515,11 @@ function handleDagDetailContentClick(e) {
         toggleHITLSection(hitlHeader.dataset.toggleHitl, hitlHeader.dataset.hitlSection);
         return;
     }
-    // ORCH-022 Layer 4: navigate to the completed resume sibling when the
-    // banner link is clicked. Reuses the same selection path the list click
-    // uses so load/cache behavior is identical.
-    const resumeSibling = e.target.closest('[data-resume-sibling]');
-    if (resumeSibling) {
+    // Navigate between immutable interruption and resume execution records.
+    const hitlExecution = e.target.closest('[data-hitl-execution], [data-resume-sibling]');
+    if (hitlExecution) {
         e.preventDefault();
-        const targetID = resumeSibling.dataset.resumeSibling;
+        const targetID = hitlExecution.dataset.hitlExecution || hitlExecution.dataset.resumeSibling;
         if (targetID) {
             selectExecution(targetID);
         }
@@ -839,7 +928,8 @@ function renderServerExecutionGroups(groups) {
                 (group.orphans || []).forEach(orphan => {
                     rows.push(renderGroupedExecutionRow(orphan, {
                         related: true,
-                        relationLabel: 'Related record',
+                        relationLabel: orphanRelationLabel(orphan),
+                        orphan: true,
                     }));
                 });
                 return;
@@ -865,7 +955,7 @@ function renderServerExecutionGroups(groups) {
             (group.orphans || []).forEach(orphan => {
                 rows.push(renderGroupedExecutionRow(orphan, {
                     related: true,
-                    relationLabel: 'Unattached related record',
+                    relationLabel: orphanRelationLabel(orphan),
                     orphan: true,
                 }));
             });
@@ -883,6 +973,16 @@ function renderServerExecutionGroups(groups) {
     }
 }
 
+function orphanRelationLabel(execution) {
+    if (execution?.relation_status === 'owner_unavailable') {
+        return 'Parent execution unavailable';
+    }
+    if (execution?.relation_status === 'owner_unknown') {
+        return 'Parent relationship incomplete';
+    }
+    return 'Unattached related record';
+}
+
 function renderConversationGroupHeader(group, expanded) {
     const turns = group.turns || [];
     const anchor = turns[0]?.execution || group.orphans?.[0] || {};
@@ -891,9 +991,7 @@ function renderConversationGroupHeader(group, expanded) {
         (group.orphans || []).length,
     );
     const visibleExecutions = flattenGroupedExecutions([group]);
-    const totalDuration =
-        (anchor.total_duration_ms || 0) +
-        (anchor.llm_total_duration_ms || 0);
+    const totalDuration = primaryDurationMs(anchor);
     const successful = visibleExecutions.every(item => item.success);
     const interrupted = visibleExecutions.some(item => item.interrupted);
     const statusClass = interrupted ? 'interrupted' : (successful ? 'success' : 'error');
@@ -954,18 +1052,19 @@ function renderGroupedExecutionRow(exec, options = {}) {
         llmCallCount = 0,
         historyStatus = '',
     } = options;
+    const renderRelationBranch = related && hasVisibleRelationOwner(exec, orphan);
     const isSelected = selected?.request_id === exec.request_id;
     const rowClasses = [
         isSelected ? 'selected' : '',
         conversationTurn ? 'dag-conversation-turn-row' : '',
-        related ? 'child-row dag-related-execution-row' : '',
+        renderRelationBranch ? 'child-row dag-related-execution-row' : '',
         orphan ? 'dag-orphan-execution-row' : '',
     ].filter(Boolean).join(' ');
     const requestID = exec.request_id || '';
     const originalRequestID = exec.original_request_id || requestID;
     const statusClass = exec.interrupted ? 'interrupted' : (exec.success ? 'success' : 'error');
     const statusLabel = exec.interrupted ? '⏸ Interrupted' : (exec.success ? '✓ Success' : '✗ Failed');
-    const duration = (exec.total_duration_ms || 0) + (exec.llm_total_duration_ms || 0);
+    const duration = primaryDurationMs(exec);
 
     return `
         <tr class="${rowClasses}"
@@ -976,7 +1075,7 @@ function renderGroupedExecutionRow(exec, options = {}) {
             </td>
             <td>
                 <div class="dag-execution-title-row">
-                    ${related ? '<span class="child-indicator">↳</span>' : (conversationTurn ? '<span class="dag-turn-dot" aria-hidden="true"></span>' : '')}
+                    ${renderRelationBranch ? '<span class="child-indicator">↳</span>' : (conversationTurn ? '<span class="dag-turn-dot" aria-hidden="true"></span>' : '')}
                     <div class="dag-execution-title">
                         ${relationLabel ? `<span class="dag-relation-label">${escapeHtml(relationLabel)}</span>` : ''}
                         <div class="service-name">${escapeHtml(truncateText(exec.original_request || 'Unknown request', related ? 48 : 58))}</div>
@@ -985,6 +1084,7 @@ function renderGroupedExecutionRow(exec, options = {}) {
                         ${exec.metadata?.resume_checkpoint_id ? '<span class="hitl-resume-badge dag-hitl-resume">HITL Resume</span>' : ''}
                         ${llmCallCount ? `<span class="dag-row-meta">${llmCallCount} LLM call${llmCallCount === 1 ? '' : 's'}</span>` : ''}
                         ${historyStatus ? `<span class="dag-row-meta">${escapeHtml(historyStatus)}</span>` : ''}
+                        ${exec.missing_owner_id ? `<span class="dag-row-meta">Parent: ${escapeHtml(exec.missing_owner_id)}</span>` : ''}
                     </div>
                 </div>
             </td>
@@ -1022,8 +1122,8 @@ function renderLegacyExecutionList() {
                 valB = (b.original_request || '').toLowerCase();
                 break;
             case 'total_duration_ms':
-                valA = (a.total_duration_ms || 0) + (a.llm_total_duration_ms || 0);
-                valB = (b.total_duration_ms || 0) + (b.llm_total_duration_ms || 0);
+                valA = primaryDurationMs(a);
+                valB = primaryDurationMs(b);
                 break;
             case 'created_at':
             default:
@@ -1094,8 +1194,8 @@ function renderLegacyExecutionList() {
                     valB = (b.parent.original_request || '').toLowerCase();
                     break;
                 case 'total_duration_ms':
-                    valA = (a.parent.total_duration_ms || 0) + (a.parent.llm_total_duration_ms || 0);
-                    valB = (b.parent.total_duration_ms || 0) + (b.parent.llm_total_duration_ms || 0);
+                    valA = primaryDurationMs(a.parent);
+                    valB = primaryDurationMs(b.parent);
                     break;
                 case 'created_at':
                 default:
@@ -1126,8 +1226,8 @@ function renderLegacyExecutionList() {
                 valB = (b.parent.original_request || '').toLowerCase();
                 break;
             case 'total_duration_ms':
-                valA = (a.parent.total_duration_ms || 0) + (a.parent.llm_total_duration_ms || 0);
-                valB = (b.parent.total_duration_ms || 0) + (b.parent.llm_total_duration_ms || 0);
+                valA = primaryDurationMs(a.parent);
+                valB = primaryDurationMs(b.parent);
                 break;
             case 'created_at':
             default:
@@ -1179,7 +1279,7 @@ function renderLegacyExecutionList() {
             </td>
             <td>
                 <span style="font-family: 'SF Mono', monospace; font-size: 12px;">
-                    ${formatDuration((exec.total_duration_ms || 0) + (exec.llm_total_duration_ms || 0))}
+                    ${formatDuration(primaryDurationMs(exec))}
                 </span>
             </td>
             <td>
@@ -1353,7 +1453,7 @@ function renderConversationTimeline(timeline, selectedRequestID = selected?.requ
         cards.push(`
             <section class="dag-timeline-orphans">
                 <h3>Unattached related records</h3>
-                <p>These executions carry the conversation ID, but their top-level owner was not available.</p>
+                <p>These executions reference a parent that could not be attached. Each card shows whether the parent was confirmed unavailable or the lookup was incomplete.</p>
                 ${(timeline.orphans || []).map(orphan =>
                     renderTimelineRelatedExecution(orphan, selectedRequestID, true)
                 ).join('')}
@@ -1375,8 +1475,7 @@ function renderTimelineTurn(turn, index, totalTurns, selectedRequestID) {
     const statusLabel = execution.interrupted
         ? '⏸ Interrupted'
         : (execution.success ? '✓ Success' : '✗ Failed');
-    const duration = (execution.total_duration_ms || 0) +
-        (execution.llm_total_duration_ms || 0);
+    const duration = primaryDurationMs(execution);
 
     return `
         <article class="dag-timeline-card ${containsSelected ? 'contains-current' : ''} ${execution.request_id === selectedRequestID ? 'current' : ''}" ${containsSelected ? 'aria-current="true"' : ''}>
@@ -1428,11 +1527,11 @@ function renderTimelineTurn(turn, index, totalTurns, selectedRequestID) {
 
 function renderTimelineRelatedExecution(execution, selectedRequestID, orphan = false) {
     const current = execution.request_id === selectedRequestID;
-    const duration = (execution.total_duration_ms || 0) +
-        (execution.llm_total_duration_ms || 0);
+    const duration = primaryDurationMs(execution);
     const relation = orphan
-        ? 'Unattached'
+        ? orphanRelationLabel(execution)
         : (execution.metadata?.resume_checkpoint_id ? 'HITL resume' : 'Delegated / related');
+    const renderRelationBranch = hasVisibleRelationOwner(execution, orphan);
     return `
         <div
             class="dag-timeline-related ${current ? 'current' : ''}"
@@ -1442,7 +1541,7 @@ function renderTimelineRelatedExecution(execution, selectedRequestID, orphan = f
             aria-label="View DAG for ${escapeHtmlAttribute(relation.toLowerCase())} execution: ${escapeHtmlAttribute(truncateText(execution.original_request || 'Unknown request', 90))}"
             ${current ? 'aria-current="true"' : ''}
         >
-            <span class="dag-related-branch" aria-hidden="true">↳</span>
+            ${renderRelationBranch ? '<span class="dag-related-branch" aria-hidden="true">↳</span>' : ''}
             <div>
                 <span class="dag-relation-label">${relation}</span>
                 <div>${escapeHtml(truncateText(execution.original_request || 'Unknown request', 72))}</div>
@@ -1454,6 +1553,7 @@ function renderTimelineRelatedExecution(execution, selectedRequestID, orphan = f
                     <span class="${execution.success ? 'dag-success-text' : 'dag-error-text'}">${execution.interrupted ? 'Interrupted' : (execution.success ? 'Success' : 'Failed')}</span>
                 </div>
                 <div class="dag-timeline-request-id">${escapeHtml(execution.request_id || '')}</div>
+                ${execution.missing_owner_id ? `<div class="dag-timeline-request-id">Parent: ${escapeHtml(execution.missing_owner_id)}</div>` : ''}
             </div>
             <span class="dag-view-dag-btn" aria-hidden="true">
                 ${current ? 'Viewing DAG' : 'View DAG'}
@@ -1586,11 +1686,16 @@ function updateDetailTabs() {
         hitlTab.style.display = selected?.has_hitl_data ? 'block' : 'none';
     }
 
-    // Pre/Post tabs visible when hook interactions exist for the respective phase.
+    // LLM-debug interactions describe hook-internal operations. Jaeger-backed
+    // pipeline_hooks prove deterministic hook invocations that make no LLM
+    // call. Either source must make the respective tab visible.
     const interactions = selected?.llm_interactions || [];
+    const pipelineHooks = selected?.pipeline_hooks || [];
     const { isPreHook, isPostHook } = classifyInteractions(interactions);
-    const hasPreHooks = interactions.some(isPreHook);
-    const hasPostHooks = interactions.some(isPostHook);
+    const hasPreHooks = interactions.some(isPreHook) || pipelineHooks.some(isPreExecutionHook);
+    const hasPostHooks = interactions.some(isPostHook) ||
+        pipelineHooks.some(isPostExecutionHook) ||
+        typeof selected?.final_response === 'string';
 
     if (preTab) {
         preTab.style.display = hasPreHooks ? 'block' : 'none';
@@ -1998,17 +2103,24 @@ function renderDAGVisualization(container) {
     const stepCount = selected.plan?.steps?.length || 0;
     const hasLLM = selected.has_llm_data;
     const hasHITL = selected.has_hitl_data;
+    const hasPipelineHooks = (selected.pipeline_hooks || []).length > 0;
     const llmCallCount = selected.llm_interactions?.length || 0;
+    const hasImplicitDeps = (selected.plan?.steps || []).some(step =>
+        (step.implicit_deps || []).length > 0
+    );
 
-    // Compute total duration: executor time (tool calls) + LLM time (AI calls)
-    // These are additive because executor handles tool invocations, LLM handles AI planning/synthesis
-    const executorDurationMs = selected.total_duration_ms || 0;
+    // Elapsed time and aggregate LLM call time are separate diagnostics. LLM
+    // calls occur inside the elapsed interval, so they are not additive.
+    const totalDurationMs = primaryDurationMs(selected);
     const llmDurationMs = selected.llm_debug_summary?.total_duration_ms || 0;
-    const totalDurationMs = executorDurationMs + llmDurationMs;
 
     // Check if we can show Full Flow (has LLM or HITL data)
-    const canShowFullFlow = hasLLM || hasHITL;
+    const canShowFullFlow = hasLLM || hasHITL || hasPipelineHooks;
     const agentName = selected.agent_name || 'orchestrator';
+    // Keep one direct observability affordance without filling the header with
+    // separate processing/submission trace pills. Prefer the execution's own
+    // processing trace and use a linked trace only as a legacy fallback.
+    const traceID = selected.trace_id || selected.linked_traces?.[0]?.trace_id;
 
     container.innerHTML = `
         <div class="dag-viz-container">
@@ -2017,11 +2129,11 @@ function renderDAGVisualization(container) {
                 <div class="dag-viz-meta">
                     ${agentName !== 'orchestrator' ? `<span class="dag-viz-meta-item" style="color: var(--accent-purple);">🤖 ${escapeHtml(agentName)}</span>` : ''}
                     <span class="dag-viz-meta-item">ID: ${(selected.request_id || '').substring(0, 20)}...</span>
-                    ${selected.trace_id ? `<span class="dag-viz-meta-item">Trace: ${selected.trace_id.substring(0, 16)}...</span>` : ''}
+                    ${traceID ? `<a class="dag-viz-meta-item dag-viz-trace-link" href="${jaegerTraceURL(traceID)}" target="_blank" rel="noopener noreferrer" title="Open execution trace ${escapeHtmlAttribute(traceID)} in Jaeger">Trace</a>` : ''}
                     <span class="dag-viz-meta-item">${stepCount} step${stepCount !== 1 ? 's' : ''}</span>
-                    <span class="dag-viz-meta-item">⏱️ Total: ${formatDuration(totalDurationMs)}</span>
+                    <span class="dag-viz-meta-item" title="${escapeHtmlAttribute(selected.duration_source || 'legacy execution duration')}">⏱️ Elapsed: ${formatDuration(totalDurationMs)}</span>
                     <span class="dag-viz-meta-item ${selected.interrupted ? 'interrupted' : (selected.success ? 'success' : 'error')}">${selected.interrupted ? '⏸ Interrupted' : (selected.success ? '✓ Success' : '✗ Failed')}</span>
-                    ${hasLLM ? `<span class="dag-viz-meta-item" style="color: var(--accent-blue);">💭 ${llmCallCount} LLM calls</span>` : ''}
+                    ${hasLLM ? `<span class="dag-viz-meta-item" style="color: var(--accent-blue);">💭 ${llmCallCount} LLM calls · aggregate ${formatDuration(llmDurationMs)}</span>` : ''}
                     ${hasHITL && !selected.interrupted ? `<span class="dag-viz-meta-item" style="color: var(--accent-orange);">⏸️ HITL</span>` : ''}
                     ${selected.phase_count > 1 ? `<span class="dag-viz-meta-item" style="color: var(--accent-teal);">🔄 ${selected.phase_count} Phases</span>` : ''}
                     ${selected.forced_terminal ? `<span class="dag-viz-meta-item" style="color: var(--accent-orange);">⚠ Forced Terminal</span>` : ''}
@@ -2047,12 +2159,6 @@ function renderDAGVisualization(container) {
                     } catch(e) { return ''; }
                 })()}
             </div>
-            ${selected.interrupted && selected.resume_sibling_request_id ? `
-            <div class="dag-resume-sibling-banner" style="margin: 8px 0 12px 0; padding: 10px 14px; background: rgba(46, 204, 113, 0.10); border: 1px solid rgba(46, 204, 113, 0.35); border-radius: 8px; font-size: 12px; color: #2ecc71; display: flex; align-items: center; gap: 8px;">
-                <span>⏩</span>
-                <span>This execution was interrupted for approval. A completed resume exists:</span>
-                <a href="#" data-resume-sibling="${escapeHtml(selected.resume_sibling_request_id)}" style="color: #2ecc71; text-decoration: underline;">${escapeHtml((selected.resume_sibling_request_id || '').substring(0, 28))}…</a>
-            </div>` : ''}
             <div id="dagContainer" class="dag-viz-canvas"></div>
             <div id="dagLegend" class="dag-viz-legend">
                 ${viewMode === 'full' ? `
@@ -2065,6 +2171,10 @@ function renderDAGVisualization(container) {
                     <span class="dag-legend-dot llm-call"></span>
                     <span>LLM Call</span>
                 </div>
+                ${hasPipelineHooks ? `<div class="dag-legend-item" title="Trace-backed deterministic pipeline hook">
+                    <span class="dag-legend-dot" style="background: #64d2ff;"></span>
+                    <span>Hook</span>
+                </div>` : ''}
                 <div class="dag-legend-item">
                     <span class="dag-legend-dot" style="background: #a064f0;"></span>
                     <span>Agent LLM</span>
@@ -2122,6 +2232,11 @@ function renderDAGVisualization(container) {
                     <span class="dag-legend-dot phase-boundary"></span>
                     <span>Phase →</span>
                 </div>` : ''}
+                ${hasImplicitDeps ? `
+                <div class="dag-legend-item" title="Shows that a step uses results from an earlier phase; this does not control execution order">
+                    <span class="dag-legend-dot implicit-dependency"></span>
+                    <span>Earlier-step results</span>
+                </div>` : ''}
                 ` : `
                 <!-- Steps Only Legend -->
                 <div class="dag-legend-item">
@@ -2168,6 +2283,11 @@ function renderDAGVisualization(container) {
                 <div class="dag-legend-item" title="Phase boundary between iterative planning phases">
                     <span class="dag-legend-dot phase-boundary"></span>
                     <span>Phase →</span>
+                </div>` : ''}
+                ${hasImplicitDeps ? `
+                <div class="dag-legend-item" title="Shows that a step uses results from an earlier phase; this does not control execution order">
+                    <span class="dag-legend-dot implicit-dependency"></span>
+                    <span>Earlier-step results</span>
                 </div>` : ''}
                 `}
             </div>
@@ -2295,6 +2415,28 @@ function computeStepLevels(steps) {
     return levels;
 }
 
+function computeExecutionStepLevels(execution) {
+    const phasePlans = execution?.phase_plans || [];
+    if (phasePlans.length <= 1) {
+        return computeStepLevels(execution?.plan?.steps || []);
+    }
+
+    const levels = [];
+    phasePlans.forEach((phase, phaseIndex) => {
+        const phaseSteps = phase.steps || [];
+        const phaseStepIDs = new Set(phaseSteps.map(step => step.step_id));
+        const scopedSteps = phaseSteps.map(step => ({
+            ...step,
+            depends_on: (step.depends_on || []).filter(dep => phaseStepIDs.has(dep)),
+        }));
+        levels.push(...computeStepLevels(scopedSteps));
+        if (phaseIndex < phasePlans.length - 1) {
+            levels.push([`phase_boundary_${phaseIndex + 1}`]);
+        }
+    });
+    return levels;
+}
+
 // Update the DAG legend with parallelism statistics
 function updateDAGLegend(depth, maxParallelism) {
     const legendContainer = document.querySelector('.dag-viz-legend');
@@ -2383,8 +2525,9 @@ function initCytoscape() {
     // Track the current step (blocked by HITL) for proper status display
     const currentStepId = selected.checkpoint?.current_step?.step_id;
 
-    // Compute levels using topological sort for parallelism info
-    const levels = computeStepLevels(selected.plan.steps);
+    // Phase boundaries serialize iterative plans. Including those boundaries
+    // prevents steps from different phases appearing at the same level.
+    const levels = computeExecutionStepLevels(selected);
     const maxParallelism = Math.max(...levels.map(l => l.length), 0);
 
     // Update legend with parallelism info (only for steps view)
@@ -2401,6 +2544,9 @@ function initCytoscape() {
         const agentName = selected.agent_name || 'orchestrator';
         const llmInteractions = selected.llm_interactions || [];
         const checkpoints = selected.hitl_checkpoints || [];
+        const traceOnlyPipelineHooks = (selected.pipeline_hooks || []).filter(hook =>
+            !pipelineHookHasDetailedInteractions(hook, llmInteractions)
+        );
 
         // 1. Orchestrator node (root)
         nodes.push({
@@ -2418,6 +2564,13 @@ function initCytoscape() {
         const phasePlans = selected.phase_plans || [];
         const llmByPhase = groupLLMCallsByPhase(llmInteractions);
         const fullFlowLevels = computeStepLevels(allPlanSteps);
+        const hookPlacementPlans = phasePlans.length > 0
+            ? phasePlans
+            : (selected.plan ? [selected.plan] : []);
+        const afterPlanningByPhase = assignAfterPlanningHooksToPhases(
+            traceOnlyPipelineHooks.filter(hook => hook.phase === 'after_planning'),
+            hookPlacementPlans
+        );
 
         // HITL plan-approval checkpoints (before_plan_execution) are attached
         // after Phase 1 planning LLM calls.
@@ -2428,6 +2581,30 @@ function initCytoscape() {
         let previousPhaseExitNode = 'orchestrator';
         let globalLLMIndex = 0;
         let memoryLLMIndex = 0;
+        let pipelineHookIndex = 0;
+
+        const appendPipelineHookChain = (hooks, sourceNodeIDs) => {
+            const sources = Array.isArray(sourceNodeIDs) ? sourceNodeIDs : [sourceNodeIDs];
+            let previousNodeID = '';
+            hooks.forEach((hook, index) => {
+                const nodeId = `pipeline_hook_${pipelineHookIndex++}`;
+                nodes.push({ data: pipelineHookNodeData(hook, nodeId) });
+                if (index === 0) {
+                    sources.filter(Boolean).forEach(source => {
+                        edges.push({ data: { source, target: nodeId, edgeType: 'pipeline_hook' } });
+                    });
+                } else {
+                    edges.push({ data: { source: previousNodeID, target: nodeId, edgeType: 'pipeline_hook' } });
+                }
+                previousNodeID = nodeId;
+            });
+            return previousNodeID || sources[0] || '';
+        };
+
+        const beforePlanningHooks = traceOnlyPipelineHooks.filter(hook => hook.phase === 'before_planning');
+        if (beforePlanningHooks.length > 0) {
+            previousPhaseExitNode = appendPipelineHookChain(beforePlanningHooks, previousPhaseExitNode);
+        }
 
         // Pre-planning conversation-history and memory-hook calls
         const compactionCalls = llmInteractions.filter(i =>
@@ -2516,6 +2693,19 @@ function initCytoscape() {
                     lastLLMNodeInPhase = nodeId;
                 });
 
+                // Trace-backed AfterPlanning hooks run after the phase plan is
+                // generated and before any approval checkpoint or step from
+                // that phase. Timestamp association avoids inventing a phase
+                // number that the current trace span schema does not carry.
+                const phaseHookIndex = phasePlans.length > 0 ? phaseIdx : 0;
+                const phaseAfterPlanningHooks = afterPlanningByPhase[phaseHookIndex] || [];
+                if (phaseAfterPlanningHooks.length > 0) {
+                    lastLLMNodeInPhase = appendPipelineHookChain(
+                        phaseAfterPlanningHooks,
+                        lastLLMNodeInPhase
+                    );
+                }
+
                 // 2b. HITL plan-approval checkpoint (Phase 1 only)
                 if (phaseIdx === 0 && planCheckpoints.length > 0) {
                     planCheckpoints.forEach((cp, idx) => {
@@ -2578,6 +2768,7 @@ function initCytoscape() {
                             parallelCount: parallelCount,
                             isParallel: parallelCount > 1,
                             dependsOn: step.depends_on || [],
+                            implicitDeps: step.implicit_deps || [],
                             hasAutoIncludes: (result?.metadata?.template_auto_includes?.length > 0),
                             trimmed: !!wasTrimmedFull
                         }
@@ -2601,6 +2792,15 @@ function initCytoscape() {
                                 }
                             });
                         }
+                    });
+                    (step.implicit_deps || []).forEach(dep => {
+                        edges.push({
+                            data: {
+                                source: dep,
+                                target: step.step_id,
+                                edgeType: 'implicit_dependency'
+                            }
+                        });
                     });
                 });
 
@@ -2653,7 +2853,11 @@ function initCytoscape() {
                 const source = idx === 0 ? previousPhaseExitNode : `llm_plan_${idx - 1}`;
                 edges.push({ data: { source, target: nodeId } });
             });
-            const lastPlanNode = planningCalls.length > 0 ? `llm_plan_${planningCalls.length - 1}` : previousPhaseExitNode;
+            let lastPlanNode = planningCalls.length > 0 ? `llm_plan_${planningCalls.length - 1}` : previousPhaseExitNode;
+            const fallbackAfterPlanningHooks = afterPlanningByPhase[0] || [];
+            if (fallbackAfterPlanningHooks.length > 0) {
+                lastPlanNode = appendPipelineHookChain(fallbackAfterPlanningHooks, lastPlanNode);
+            }
             planCheckpoints.forEach((cp, idx) => {
                 const nodeId = `checkpoint_plan_${idx}`;
                 const statusLabel = cp.status === 'approved' ? '✓' : cp.status === 'pending' ? '⏳' : '✗';
@@ -2707,6 +2911,7 @@ function initCytoscape() {
                         parallelCount: parallelCount,
                         isParallel: parallelCount > 1,
                         dependsOn: step.depends_on || [],
+                        implicitDeps: step.implicit_deps || [],
                         hasAutoIncludes: (result?.metadata?.template_auto_includes?.length > 0),
                         trimmed: !!wasTrimmedFull
                     }
@@ -2724,6 +2929,15 @@ function initCytoscape() {
                             source: dep,
                             target: step.step_id,
                             edgeType: depFailed ? 'failed' : undefined
+                        }
+                    });
+                });
+                (step.implicit_deps || []).forEach(dep => {
+                    edges.push({
+                        data: {
+                            source: dep,
+                            target: step.step_id,
+                            edgeType: 'implicit_dependency'
                         }
                     });
                 });
@@ -2795,8 +3009,11 @@ function initCytoscape() {
 
         // 4c. Step-specific LLM calls (micro_resolution and semantic_retry WITH step_id)
         // These are parameter resolution calls associated with specific execution steps
-        const stepSpecificLLMCalls = llmInteractions.filter(i =>
-            ['micro_resolution', 'semantic_retry', 'error_analysis', 'result_distillation', 'hallucination_detection'].includes(i.type) && i.step_id
+        const stepSpecificLLMCalls = filterInteractionsWithRenderedParent(
+            llmInteractions.filter(i =>
+                ['micro_resolution', 'semantic_retry', 'error_analysis', 'result_distillation', 'hallucination_detection'].includes(i.type) && i.step_id
+            ),
+            stepIds
         );
         stepSpecificLLMCalls.forEach((call, idx) => {
             const nodeId = `llm_step_${idx}`;
@@ -2895,6 +3112,19 @@ function initCytoscape() {
             return previousPhaseExitNode;
         })();
 
+        // Deterministic AfterExecution hooks do not necessarily emit an LLM
+        // interaction. Place their trace-backed nodes after the terminal step
+        // leaves and before synthesis. Hooks whose internal activity already
+        // has richer graph nodes were filtered above.
+        const afterExecutionHooks = traceOnlyPipelineHooks.filter(hook => hook.phase === 'after_execution');
+        let afterExecutionHookExit = '';
+        if (afterExecutionHooks.length > 0) {
+            const sources = leafSteps.length > 0
+                ? leafSteps.map(step => step.step_id)
+                : [lastPlanningNodeId];
+            afterExecutionHookExit = appendPipelineHookChain(afterExecutionHooks, sources);
+        }
+
         // 5c. Post-execution memory hook LLM calls (event summarization)
         let eventSumIndex = 0;
         const eventSumCalls = llmInteractions.filter(i =>
@@ -2912,7 +3142,9 @@ function initCytoscape() {
                     })
                 });
                 if (idx === 0) {
-                    if (leafSteps.length > 0) {
+                    if (afterExecutionHookExit) {
+                        edges.push({ data: { source: afterExecutionHookExit, target: nodeId, edgeType: 'memory_llm' } });
+                    } else if (leafSteps.length > 0) {
                         leafSteps.forEach(step => {
                             const result = stepResults[step.step_id];
                             const isFailed = result && !result.success;
@@ -2960,6 +3192,8 @@ function initCytoscape() {
                     if (eventSumNodes.length > 0) {
                         // Chain from last event summarization node
                         edges.push({ data: { source: eventSumNodes[eventSumNodes.length - 1], target: nodeId } });
+                    } else if (afterExecutionHookExit) {
+                        edges.push({ data: { source: afterExecutionHookExit, target: nodeId, edgeType: 'pipeline_hook' } });
                     } else if (leafSteps.length > 0) {
                         // Connect leaf steps directly to synthesis
                         leafSteps.forEach(step => {
@@ -2995,10 +3229,22 @@ function initCytoscape() {
         //   4. Last planning node (ORCH-018 clarification short-circuit edge case
         //      where synthesis was somehow skipped — defensive)
         //   5. Orchestrator root (fully degenerate trace)
-        const responseSource = synthesisCalls.length > 0 ? `llm_synth_${synthesisCalls.length - 1}` :
+        let responseSource = synthesisCalls.length > 0 ? `llm_synth_${synthesisCalls.length - 1}` :
             (eventSumNodes.length > 0 ? eventSumNodes[eventSumNodes.length - 1] :
+            (afterExecutionHookExit ? afterExecutionHookExit :
             (leafSteps.length > 0 ? leafSteps[0].step_id :
-            (lastPlanningNodeId !== 'orchestrator' ? lastPlanningNodeId : 'orchestrator')));
+            (lastPlanningNodeId !== 'orchestrator' ? lastPlanningNodeId : 'orchestrator'))));
+
+        // AfterSynthesis hooks run after the model draft and before the
+        // terminal application response. This is the key trace-only path for
+        // deterministic response-governance hooks used by domain applications.
+        const afterSynthesisHooks = traceOnlyPipelineHooks.filter(hook => hook.phase === 'after_synthesis');
+        if (afterSynthesisHooks.length > 0) {
+            const hookSources = synthesisCalls.length > 0 || eventSumNodes.length > 0 || afterExecutionHookExit
+                ? [responseSource]
+                : (leafSteps.length > 0 ? leafSteps.map(step => step.step_id) : [responseSource]);
+            responseSource = appendPipelineHookChain(afterSynthesisHooks, hookSources);
+        }
         const successLabel = selected.success ? '✓ Complete' : (selected.interrupted ? '⏸ Paused (HITL)' : '✗ Failed');
         nodes.push({
             data: {
@@ -3009,7 +3255,7 @@ function initCytoscape() {
                 interrupted: selected.interrupted ? 'true' : 'false'
             }
         });
-        if (synthesisCalls.length > 0 || eventSumNodes.length > 0) {
+        if (synthesisCalls.length > 0 || eventSumNodes.length > 0 || afterExecutionHookExit || afterSynthesisHooks.length > 0) {
             edges.push({ data: { source: responseSource, target: 'response' } });
         } else if (leafSteps.length > 0) {
             // No synthesis or event summarization - connect leaf steps directly to response
@@ -3098,6 +3344,7 @@ function initCytoscape() {
                     parallelCount: parallelCount,
                     isParallel: isParallel,
                     dependsOn: step.depends_on || [],
+                    implicitDeps: step.implicit_deps || [],
                     hasAutoIncludes: (result?.metadata?.template_auto_includes?.length > 0)
                 }
             };
@@ -3114,6 +3361,15 @@ function initCytoscape() {
                         source: dep,
                         target: step.step_id,
                         edgeType: depFailed ? 'failed' : undefined
+                    }
+                });
+            });
+            (step.implicit_deps || []).forEach(dep => {
+                edges.push({
+                    data: {
+                        source: dep,
+                        target: step.step_id,
+                        edgeType: 'implicit_dependency'
                     }
                 });
             });
@@ -3169,6 +3425,20 @@ function initCytoscape() {
                 });
             }
         }
+    }
+
+    // Cytoscape rejects the entire graph when even one edge references a node
+    // outside the current execution. This can happen legitimately on a HITL
+    // resume when an implicit provenance dependency points to a step stored on
+    // the interrupted parent record. Keep the current record renderable while
+    // retaining a diagnostic for malformed or cross-record edges.
+    const filteredEdges = filterRenderableEdges(nodes, edges);
+    edges = filteredEdges.renderable;
+    if (filteredEdges.omitted.length > 0) {
+        console.warn(
+            `Omitted ${filteredEdges.omitted.length} DAG edge(s) whose endpoints are not present in this execution`,
+            filteredEdges.omitted.map(edge => edge.data)
+        );
     }
 
     // Create Cytoscape instance with premium dark styling
@@ -3506,6 +3776,32 @@ function initCytoscape() {
                 }
             },
             {
+                // Trace-backed framework pipeline hook. This remains visible
+                // even when the hook is deterministic and emits no LLM record.
+                selector: 'node[nodeType="pipeline_hook"]',
+                style: {
+                    'shape': 'round-rectangle',
+                    'width': '220px',
+                    'height': '58px',
+                    'background-color': '#112c35',
+                    'border-color': '#64d2ff',
+                    'border-width': '2px',
+                    'border-style': 'dashed',
+                    'color': '#b9eaff',
+                    'font-size': '10px',
+                    'text-wrap': 'wrap',
+                    'text-max-width': '200px'
+                }
+            },
+            {
+                selector: 'node[nodeType="pipeline_hook"][hookStatus="failed"]',
+                style: {
+                    'background-color': '#3d1717',
+                    'border-color': '#ff6b6b',
+                    'color': '#ffd0d0'
+                }
+            },
+            {
                 // HITL Checkpoint - default orange diamond style (plan approval)
                 selector: 'node[nodeType="checkpoint"]',
                 style: {
@@ -3695,6 +3991,32 @@ function initCytoscape() {
                 }
             },
             {
+                // Cross-phase data provenance. This is advisory and does not
+                // express scheduler ordering inside a phase.
+                selector: 'edge[edgeType="implicit_dependency"]',
+                style: {
+                    'line-color': '#b685f4',
+                    'target-arrow-color': '#b685f4',
+                    'target-arrow-shape': 'triangle',
+                    'line-style': 'dotted',
+                    'width': 2,
+                    'opacity': 0.85,
+                    'curve-style': 'bezier'
+                }
+            },
+            {
+                selector: 'edge[edgeType="pipeline_hook"]',
+                style: {
+                    'line-color': '#64d2ff',
+                    'target-arrow-color': '#64d2ff',
+                    'target-arrow-shape': 'triangle',
+                    'line-style': 'dashed',
+                    'width': 2,
+                    'opacity': 0.8,
+                    'curve-style': 'bezier'
+                }
+            },
+            {
                 // Phase transition edge (dashed teal)
                 selector: 'edge[edgeType="phase_transition"]',
                 style: {
@@ -3743,7 +4065,7 @@ function initCytoscape() {
             return;
         }
         // Handle different node types in full flow mode
-        if (nodeType === 'orchestrator' || nodeType === 'llm_call' || nodeType === 'llm_step' || nodeType === 'agent_llm' || nodeType === 'memory_llm' || nodeType === 'checkpoint' || nodeType === 'response' || nodeType === 'phase_boundary') {
+        if (nodeType === 'orchestrator' || nodeType === 'llm_call' || nodeType === 'llm_step' || nodeType === 'agent_llm' || nodeType === 'memory_llm' || nodeType === 'pipeline_hook' || nodeType === 'checkpoint' || nodeType === 'response' || nodeType === 'phase_boundary') {
             showFullFlowNodePopup(node, nodeData);
         } else {
             // Step node - use existing logic
@@ -4008,6 +4330,32 @@ function showFullFlowNodePopup(node, nodeData) {
             `;
             break;
         }
+        case 'pipeline_hook': {
+            const hookFailed = nodeData.hookStatus === 'failed';
+            const hookTraceID = nodeData.traceID || selected?.trace_id || '';
+            title = `🪝 ${pipelineHookPhaseLabel(nodeData.hookPhase)}`;
+            color = hookFailed ? 'var(--accent-red)' : '#64d2ff';
+            content = `
+                <div style="margin-top: 10px;">
+                    <div style="font-size: 11px; color: var(--text-muted);">Hook</div>
+                    <div style="font-weight: 600; color: var(--text-primary);">${escapeHtml(nodeData.hookName || 'unknown')}</div>
+                </div>
+                <div style="margin-top: 10px;">
+                    <div style="font-size: 11px; color: var(--text-muted);">Status</div>
+                    <div style="font-weight: 600; color: ${hookFailed ? 'var(--accent-red)' : 'var(--accent-green)'};">${hookFailed ? 'FAILED' : 'COMPLETED'}</div>
+                </div>
+                <div style="margin-top: 10px;">
+                    <div style="font-size: 11px; color: var(--text-muted);">Duration</div>
+                    <div>${formatPipelineHookDuration(nodeData.durationUS)}</div>
+                </div>
+                <div style="margin-top: 10px;">
+                    <div style="font-size: 11px; color: var(--text-muted);">Trace evidence</div>
+                    <div style="font-family: 'SF Mono', monospace; font-size: 11px; overflow-wrap: anywhere;">${escapeHtml(nodeData.operationName || '')}</div>
+                    ${nodeData.spanID ? `<div style="font-family: 'SF Mono', monospace; font-size: 10px; color: var(--text-muted); margin-top: 4px;">Span ${escapeHtml(nodeData.spanID)}</div>` : ''}
+                    ${hookTraceID ? `<a href="${jaegerTraceURL(hookTraceID)}" target="_blank" rel="noopener noreferrer" style="display: inline-block; margin-top: 7px; color: #9bdcff;">Open trace ↗</a>` : ''}
+                </div>`;
+            break;
+        }
         case 'llm_step':
             // Step-specific LLM call attached to a parent step
             const stepLlmType = nodeData.llmType || 'unknown';
@@ -4237,15 +4585,14 @@ function showFullFlowNodePopup(node, nodeData) {
             color = 'var(--accent-teal)';
             const success = nodeData.success;
             const resultColor = success ? 'var(--accent-green)' : 'var(--accent-red)';
-            // Compute total duration: executor time + LLM time
-            const responseTotalDuration = (selected.total_duration_ms || 0) + (selected.llm_debug_summary?.total_duration_ms || 0);
+            const responseTotalDuration = primaryDurationMs(selected);
             content = `
                 <div style="margin-top: 10px;">
                     <div style="font-size: 11px; color: var(--text-muted);">Status</div>
                     <div style="color: ${resultColor}; font-weight: 600;">${success ? 'SUCCESS' : 'FAILED'}</div>
                 </div>
                 <div style="margin-top: 10px;">
-                    <div style="font-size: 11px; color: var(--text-muted);">Total Duration</div>
+                    <div style="font-size: 11px; color: var(--text-muted);">Elapsed Duration</div>
                     <div>${formatDuration(responseTotalDuration)}</div>
                 </div>
             `;
@@ -4262,6 +4609,7 @@ function showFullFlowNodePopup(node, nodeData) {
             const stepLevel = nodeData.level || 1;
             const stepParallel = nodeData.parallelCount || 1;
             const stepDeps = nodeData.dependsOn || [];
+            const stepImplicitDeps = nodeData.implicitDeps || [];
             content = `
                 <div style="margin-top: 10px;">
                     <div style="font-size: 11px; color: var(--text-muted);">Status</div>
@@ -4284,7 +4632,13 @@ function showFullFlowNodePopup(node, nodeData) {
                 ${stepDeps.length > 0 ? `
                 <div style="margin-top: 10px;">
                     <div style="font-size: 11px; color: var(--text-muted);">Depends On</div>
-                    <div style="font-family: 'SF Mono', monospace; font-size: 10px;">${stepDeps.join(', ')}</div>
+                    <div style="font-family: 'SF Mono', monospace; font-size: 10px;">${stepDeps.map(escapeHtml).join(', ')}</div>
+                </div>` : ''}
+                ${stepImplicitDeps.length > 0 ? `
+                <div style="margin-top: 10px;">
+                    <div style="font-size: 11px; color: var(--text-muted);">Prior-phase Data</div>
+                    <div style="font-family: 'SF Mono', monospace; font-size: 10px; color: #b685f4;">${stepImplicitDeps.map(escapeHtml).join(', ')}</div>
+                    <div style="font-size: 10px; color: var(--text-muted); margin-top: 3px;">Provenance only; this does not schedule the step.</div>
                 </div>` : ''}
                 ${nodeData.instruction ? `
                 <div style="margin-top: 10px;">
@@ -4390,6 +4744,11 @@ function showNodePopup(node, step, result) {
     const parallelCount = nodeData.parallelCount || 1;
     const isParallel = nodeData.isParallel || false;
     const dependsOn = nodeData.dependsOn || step.depends_on || [];
+    const implicitDeps = nodeData.implicitDeps || step.implicit_deps || [];
+    const stepIndex = (selected.plan?.steps || []).findIndex(candidate =>
+        candidate.step_id === step.step_id
+    );
+    const displayStepNumber = executionDisplayStepNumber(stepIndex, selected);
     // Get capability from metadata (where orchestration stores it)
     const capability = step.metadata?.capability || result?.metadata?.capability || step.capability || step.agent_name || '';
 
@@ -4429,9 +4788,10 @@ function showNodePopup(node, step, result) {
 
         <!-- Execution Flow Info -->
         <div style="display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 12px;">
-            <span style="padding: 4px 10px; border-radius: 8px; font-size: 10px; background: rgba(10, 132, 255, 0.15); color: var(--accent-blue); font-family: 'SF Mono', 'Monaco', monospace;">
-                ${step.step_id}
-            </span>
+            ${displayStepNumber !== null ? `
+            <span style="padding: 4px 10px; border-radius: 8px; font-size: 10px; font-weight: 700; background: rgba(50, 215, 75, 0.15); color: var(--accent-green);">
+                Step ${displayStepNumber}
+            </span>` : ''}
             <span style="padding: 4px 10px; border-radius: 8px; font-size: 10px; background: rgba(100, 210, 255, 0.15); color: var(--accent-teal);">
                 Level ${level}
             </span>
@@ -4453,12 +4813,25 @@ function showNodePopup(node, step, result) {
                     ○ Root step
                 </span>
             `}
+            ${implicitDeps.length > 0 ? `
+                <span style="padding: 4px 10px; border-radius: 8px; font-size: 10px; background: rgba(182, 133, 244, 0.12); color: #b685f4;">
+                    ⇠ ${implicitDeps.length} prior-phase data
+                </span>
+            ` : ''}
         </div>
 
         ${dependsOn.length > 0 ? `
             <div style="margin-bottom: 12px; padding: 8px 10px; background: rgba(0,0,0,0.2); border-radius: 8px; font-size: 11px;">
                 <span style="color: var(--text-muted);">Depends on:</span>
                 <span style="color: var(--text-secondary); margin-left: 6px;">${dependsOn.join(', ')}</span>
+            </div>
+        ` : ''}
+
+        ${implicitDeps.length > 0 ? `
+            <div style="margin-bottom: 12px; padding: 8px 10px; background: rgba(182, 133, 244, 0.08); border-left: 2px dotted #b685f4; border-radius: 8px; font-size: 11px;">
+                <span style="color: #b685f4; font-weight: 600;">Uses results from earlier steps:</span>
+                <span style="color: var(--text-secondary); margin-left: 6px;">${implicitDeps.join(', ')}</span>
+                <div style="color: var(--text-muted); margin-top: 4px;">Data lineage only; this does not control execution order.</div>
             </div>
         ` : ''}
 
@@ -4471,9 +4844,9 @@ function showNodePopup(node, step, result) {
                 <span>${formatDuration(result.duration_ms || (result.duration ? Math.round(result.duration / 1000000) : 0))}</span>
                 <span>${result.attempts || 1} attempt${(result.attempts || 1) > 1 ? 's' : ''}</span>
             </div>
-            ${result.error ? `
+            ${result.error && !result.success ? `
                 <div style="margin-top: 10px; padding: 10px 12px; background: rgba(255, 107, 107, 0.1); border-radius: 8px; border: 1px solid rgba(255, 107, 107, 0.2); color: var(--accent-red); font-size: 11px;">
-                    ${result.error}
+                    ${escapeHtml(result.error)}
                 </div>
             ` : ''}
         ` : '<div style="color: var(--text-muted); font-style: italic;">Not executed yet</div>'}
@@ -4889,8 +5262,9 @@ function renderStepDetails(container) {
                 const capability = step.metadata?.capability || result?.metadata?.capability || result?.capability || step.capability || step.capability_name || step.agent_name || 'N/A';
                 const agentName = step.agent_name || result?.agent_name || 'N/A';
                 const dependsOn = step.depends_on || [];
+                const implicitDeps = step.implicit_deps || [];
                 const usedBy = usedByMap[step.step_id] || [];
-                const hasDependencies = dependsOn.length > 0 || usedBy.length > 0;
+                const hasDependencies = dependsOn.length > 0 || implicitDeps.length > 0 || usedBy.length > 0;
 
                 // Timing data from orchestration/interfaces.go StepResult
                 const durationMs = getDurationMs(result);
@@ -4909,7 +5283,7 @@ function renderStepDetails(container) {
                     <div class="dag-step-card ${status}">
                         <div class="dag-step-header">
                             <div class="dag-step-title">
-                                <span class="dag-step-number" style="${stepNumColors[status]} padding: 4px 12px; border-radius: 8px; font-weight: 700; font-size: 12px;">Step ${parseInt(step.step_id.replace(/\D/g, '')) || (idx + 1)}</span>
+                                <span class="dag-step-number" style="${stepNumColors[status]} padding: 4px 12px; border-radius: 8px; font-weight: 700; font-size: 12px;">Step ${executionDisplayStepNumber(idx, selected)}</span>
                                 <span class="dag-step-id">${step.step_id}</span>
                             </div>
                             <div style="display: flex; align-items: center; gap: 12px;">
@@ -4947,6 +5321,14 @@ function renderStepDetails(container) {
                                             <span class="dag-step-depends-label">⬅ Waits for:</span>
                                             <div class="dag-step-depends-list">
                                                 ${dependsOn.map(dep => `<span class="dag-step-depends-item">${dep}</span>`).join('')}
+                                            </div>
+                                        </div>
+                                    ` : ''}
+                                    ${implicitDeps.length > 0 ? `
+                                        <div class="dag-step-depends-row">
+                                            <span class="dag-step-depends-label" style="color: #b685f4;">⇠ Uses earlier results:</span>
+                                            <div class="dag-step-depends-list">
+                                                ${implicitDeps.map(dep => `<span class="dag-step-depends-item" title="Data lineage only; this does not control execution order">${dep}</span>`).join('')}
                                             </div>
                                         </div>
                                     ` : ''}
@@ -5010,9 +5392,9 @@ function renderStepDetails(container) {
                                     `).join('')}
                                 </div>
                             ` : ''}
-                            ${result?.error ? `
+                            ${result?.error && !result?.success ? `
                                 <div class="dag-step-error">
-                                    <strong>Error:</strong> ${result.error}
+                                    <strong>Error:</strong> ${escapeHtml(result.error)}
                                 </div>
                             ` : ''}
                             ${result?.response ? `
@@ -5086,15 +5468,16 @@ function toggleLLMInteraction(idx, type) {
 }
 
 // ---------------------------------------------------------------------------
-// Pre-Execution tab — BeforePlanning hook steps
+// Pre-Execution tab — BeforePlanning / AfterPlanning hooks and their activity
 // ---------------------------------------------------------------------------
 
 function renderPreExecution(container) {
     const interactions = selected?.llm_interactions || [];
     const { isPreHook } = classifyInteractions(interactions);
     const preSteps = interactions.filter(isPreHook);
+    const pipelineHooks = (selected?.pipeline_hooks || []).filter(isPreExecutionHook);
 
-    if (preSteps.length === 0) {
+    if (preSteps.length === 0 && pipelineHooks.length === 0) {
         container.innerHTML = `
             <div class="empty-detail">
                 <div class="empty-detail-icon">🔄</div>
@@ -5121,8 +5504,9 @@ function renderPreExecution(container) {
 
     let html = `<div style="overflow-y: auto; height: 100%; padding: 16px;">`;
     html += `<div style="margin-bottom: 16px; font-size: 13px; color: var(--text-muted);">
-        ${preSteps.length} steps | ${formatDuration(totalDuration)} total | Runs before planning
+        ${pipelineHooks.length} hook invocation${pipelineHooks.length === 1 ? '' : 's'} | ${preSteps.length} recorded operation${preSteps.length === 1 ? '' : 's'} | ${formatDuration(totalDuration)} aggregate operation time | Runs before step execution
     </div>`;
+    html += renderPipelineHookObservations(pipelineHooks);
 
     // User memory enrichment section
     if (userMemorySteps.length > 0) {
@@ -5198,15 +5582,17 @@ function renderPreExecution(container) {
 }
 
 // ---------------------------------------------------------------------------
-// Post-Execution tab — AfterSynthesis hook steps
+// Post-Execution tab — AfterExecution / AfterSynthesis hooks and their activity
 // ---------------------------------------------------------------------------
 
 function renderPostExecution(container) {
     const interactions = selected?.llm_interactions || [];
     const { isPostHook } = classifyInteractions(interactions);
     const postSteps = interactions.filter(isPostHook);
+    const pipelineHooks = (selected?.pipeline_hooks || []).filter(isPostExecutionHook);
+    const governedResponsePanel = renderGovernedResponsePanel(interactions);
 
-    if (postSteps.length === 0) {
+    if (postSteps.length === 0 && pipelineHooks.length === 0 && !governedResponsePanel) {
         container.innerHTML = `
             <div class="empty-detail">
                 <div class="empty-detail-icon">🔄</div>
@@ -5228,8 +5614,10 @@ function renderPostExecution(container) {
 
     let html = `<div style="overflow-y: auto; height: 100%; padding: 16px;">`;
     html += `<div style="margin-bottom: 16px; font-size: 13px; color: var(--text-muted);">
-        ${postSteps.length} steps | ${formatDuration(totalDuration)} total | ${llmCount} LLM calls | Runs after synthesis
+        ${pipelineHooks.length} hook invocation${pipelineHooks.length === 1 ? '' : 's'} | ${postSteps.length} recorded operation${postSteps.length === 1 ? '' : 's'} | ${llmCount} LLM call${llmCount === 1 ? '' : 's'} | ${formatDuration(totalDuration)} aggregate operation time
     </div>`;
+    html += renderPipelineHookObservations(pipelineHooks);
+    html += governedResponsePanel;
 
     // User memory extraction section
     if (userMemorySteps.length > 0) {
@@ -5343,7 +5731,13 @@ function renderSingleLLMCard(interaction, idx, displayNum, displayLabel) {
     const config = getLLMCardConfig(interaction.type);
     const _r = config.rgb;
     const category = interaction.category || 'llm';
-    const typeLabel = config.label || interaction.type || 'Unknown';
+    const isStreamingSynthesis = interaction.type === 'synthesis_streaming';
+    const isSynthesis = interaction.type === 'synthesis' || isStreamingSynthesis;
+    const typeLabel = isStreamingSynthesis
+        ? 'LLM synthesis output streamed to client'
+        : interaction.type === 'synthesis'
+            ? 'Pre-hook LLM synthesis output'
+        : (config.label || interaction.type || 'Unknown');
     const shownNum = displayNum != null ? displayNum : (idx + 1);
     // Prefer the globally-annotated label (stamped by annotateCallLabels)
     // so popup and card suffixes always match. Falls back to the base
@@ -5455,7 +5849,7 @@ function renderSingleLLMCard(interaction, idx, displayNum, displayLabel) {
                 ${promptSections}
                 <div class="dag-step-response" style="background: rgba(0, 0, 0, 0.15); border-radius: 12px; margin-top: 8px; overflow: hidden;">
                     <div class="dag-step-response-header" data-toggle-llm="${idx}" data-llm-type="response" style="background: rgba(255, 255, 255, 0.03); border-bottom: 1px solid rgba(255, 255, 255, 0.06);">
-                        <span><span class="expand-arrow" id="llm-response-arrow-${idx}">▶</span> View Response</span>
+                        <span><span class="expand-arrow" id="llm-response-arrow-${idx}">▶</span> ${isStreamingSynthesis ? 'View Streamed Output' : isSynthesis ? 'View Pre-hook Output' : 'View Response'}</span>
                         <span style="display: flex; align-items: center; gap: 8px;">
                             <button class="copy-inline-btn" data-copy-llm="${idx}" data-copy-type="response">Copy</button>
                             <span style="color: var(--text-muted); font-size: 10px;">${(interaction.completion_tokens || 0).toLocaleString()} tokens</span>
@@ -5469,12 +5863,45 @@ function renderSingleLLMCard(interaction, idx, displayNum, displayLabel) {
     `;
 }
 
+function renderGovernedResponsePanel(interactions) {
+    const synthesisOutputs = (interactions || []).filter(interaction =>
+        interaction.type === 'synthesis' || interaction.type === 'synthesis_streaming'
+    );
+    const latestSynthesis = synthesisOutputs.at(-1);
+    const latestOutput = latestSynthesis?.response || '';
+    const isStreamingSynthesis = latestSynthesis?.type === 'synthesis_streaming';
+    const governedResponse = selected?.final_response;
+    if (typeof governedResponse !== 'string') {
+        return '';
+    }
+    const governedDiffers = governedResponse !== latestOutput;
+    return `
+        <div class="dag-step-card" style="margin-bottom: 20px; background: linear-gradient(135deg, rgba(50, 215, 75, 0.16), rgba(182, 133, 244, 0.08)); border: 2px solid rgba(50, 215, 75, 0.45);">
+            <div class="dag-step-header">
+                <div class="dag-step-title">
+                    <span style="font-size: 15px; font-weight: 700; color: var(--accent-green);">✓ Post-hook application response</span>
+                    <span class="dag-step-id">${escapeHtml((selected.final_response_source || 'post-hook application output').replaceAll('_', ' '))}</span>
+                </div>
+            </div>
+            <div class="dag-step-body">
+                <div style="font-size: 11px; color: var(--text-muted); line-height: 1.5; margin-bottom: 10px;">
+                    This terminal response was captured after application AfterSynthesis hooks.${isStreamingSynthesis ? ' The streaming synthesis card below also preserves the output already emitted to the client.' : ' The synthesis card below preserves the model output from before those hooks.'}
+                </div>
+                ${governedDiffers ? `<div style="margin-bottom: 10px; color: var(--accent-orange); font-size: 11px; font-weight: 600;">${isStreamingSynthesis ? 'The stored post-hook response differs from the output streamed to the client.' : 'The application changed the pre-hook synthesis output.'}</div>` : ''}
+                <pre style="white-space: pre-wrap; overflow-wrap: anywhere; max-height: 320px; overflow: auto; padding: 12px; background: rgba(0,0,0,0.24); border-radius: 8px; color: var(--text-primary);">${escapeHtml(governedResponse)}</pre>
+            </div>
+        </div>`;
+}
+
 function renderLLMCalls(container) {
-    if (!selected?.llm_interactions?.length) {
+    const allInteractions = selected?.llm_interactions || [];
+    if (allInteractions.length === 0) {
         container.innerHTML = `
-            <div class="empty-detail">
-                <div class="empty-detail-icon">🤖</div>
-                <div>No LLM calls recorded for this execution</div>
+            <div style="overflow-y: auto; height: 100%; padding: 16px;">
+                <div class="empty-detail">
+                    <div class="empty-detail-icon">🤖</div>
+                    <div>No LLM calls recorded for this execution</div>
+                </div>
             </div>`;
         return;
     }
@@ -5483,14 +5910,16 @@ function renderLLMCalls(container) {
     // tiered selection, etc.). Hook interactions route to the Pre-Execution /
     // Post-Execution tabs. classifyInteractions handles both new agents
     // (hook_phase-aware) and legacy agents (type-string fallback) uniformly.
-    const { isOrchestrationCall } = classifyInteractions(selected.llm_interactions);
-    const interactions = selected.llm_interactions.filter(isOrchestrationCall);
+    const { isOrchestrationCall } = classifyInteractions(allInteractions);
+    const interactions = allInteractions.filter(isOrchestrationCall);
 
     if (interactions.length === 0) {
         container.innerHTML = `
-            <div class="empty-detail">
-                <div class="empty-detail-icon">🤖</div>
-                <div>No orchestration LLM calls for this execution<br><span style="font-size: 12px; color: var(--text-muted);">Hook calls are shown in the Pre-Execution and Post-Execution tabs</span></div>
+            <div style="overflow-y: auto; height: 100%; padding: 16px;">
+                <div class="empty-detail">
+                    <div class="empty-detail-icon">🤖</div>
+                    <div>No orchestration LLM calls for this execution<br><span style="font-size: 12px; color: var(--text-muted);">Hook calls are shown in the Pre-Execution and Post-Execution tabs</span></div>
+                </div>
             </div>`;
         return;
     }
@@ -5531,14 +5960,14 @@ function renderLLMCalls(container) {
                         <span class="dag-step-value" style="color: var(--accent-teal);">${orchTotalTokensIn.toLocaleString()}</span>
                         <span class="dag-step-label">Output Tokens</span>
                         <span class="dag-step-value" style="color: var(--accent-purple);">${orchTotalTokensOut.toLocaleString()}</span>
-                        <span class="dag-step-label">Total Duration</span>
+                        <span class="dag-step-label">Aggregate Call Time</span>
                         <span class="dag-step-value">${formatDuration(orchTotalDurationMs)}</span>
                     </div>
                     ${providerEntries.length > 0 ? `
                         <div style="margin-top: 12px; display: flex; gap: 12px; flex-wrap: wrap;">
                             ${providerEntries.map(([provider, count]) => `
                                 <span style="padding: 6px 14px; border-radius: 20px; font-size: 11px; font-weight: 600; background: linear-gradient(135deg, rgba(10, 132, 255, 0.25), rgba(10, 132, 255, 0.1)); border: 1px solid rgba(10, 132, 255, 0.3); color: var(--accent-blue);">
-                                    ${provider}: ${count} call${count > 1 ? 's' : ''}
+                                    ${escapeHtml(provider)}: ${count} call${count > 1 ? 's' : ''}
                                 </span>
                             `).join('')}
                         </div>
@@ -5686,7 +6115,8 @@ function toggleHITLSection(checkpointId, section) {
 }
 
 function renderHITLCheckpoints(container) {
-    if (!selected?.hitl_checkpoints?.length) {
+    const lifecycle = selected?.hitl_lifecycle;
+    if (!lifecycle && !selected?.hitl_checkpoints?.length) {
         container.innerHTML = `
             <div class="empty-detail">
                 <div class="empty-detail-icon">🛑</div>
@@ -5695,41 +6125,83 @@ function renderHITLCheckpoints(container) {
         return;
     }
 
-    const checkpoints = selected.hitl_checkpoints;
+    const checkpoints = selected.hitl_checkpoints || [];
+    const lifecyclePanel = lifecycle ? `
+        <div class="dag-step-card" style="border-color: rgba(182, 133, 244, 0.45); margin-bottom: 16px;">
+            <div class="dag-step-header">
+                <div class="dag-step-title">
+                    <span class="dag-step-number" style="color: #b685f4;">Lifecycle</span>
+                    <span class="dag-step-id">${lifecycle.is_resume ? 'Resume execution' : 'Interruption execution'}</span>
+                </div>
+            </div>
+            <div class="dag-step-body">
+                <div class="dag-step-info">
+                    <span class="dag-step-label">Checkpoint ID</span>
+                    <span class="dag-step-value dag-mono">${escapeHtml(lifecycle.checkpoint_id || 'Unavailable')}</span>
+                    <span class="dag-step-label">Initial request</span>
+                    <span class="dag-step-value dag-mono">${escapeHtml(lifecycle.initial_request_id || 'Unavailable')}</span>
+                    ${lifecycle.snapshot_status ? `<span class="dag-step-label">Stored snapshot</span><span class="dag-step-value">${escapeHtml(lifecycle.snapshot_status)}</span>` : ''}
+                    <span class="dag-step-label">Current status</span>
+                    <span class="dag-step-value" style="color: #b685f4;">${escapeHtml(lifecycle.current_status || 'Unavailable')}</span>
+                    ${lifecycle.current_status_source ? `<span class="dag-step-label">Status source</span><span class="dag-step-value">${escapeHtml(lifecycle.current_status_source.replaceAll('_', ' '))}</span>` : ''}
+                </div>
+                ${lifecycle.snapshot_status && lifecycle.current_status && lifecycle.snapshot_status !== lifecycle.current_status ? `
+                    <div style="margin-top: 12px; padding: 10px 12px; background: rgba(182, 133, 244, 0.08); border-left: 3px solid #b685f4; border-radius: 6px;">
+                        The stored interruption remains <strong>${escapeHtml(lifecycle.snapshot_status)}</strong> as historical evidence. The live checkpoint is now <strong>${escapeHtml(lifecycle.current_status)}</strong>.
+                    </div>
+                ` : ''}
+                ${(lifecycle.related_executions || []).length ? `
+                    <div style="margin-top: 12px; display: flex; gap: 8px; flex-wrap: wrap;">
+                        ${(lifecycle.related_executions || []).map(link => `<a href="#" data-hitl-execution="${escapeHtmlAttribute(link.request_id)}" class="dag-viz-meta-item" style="color: #b685f4;">Open ${escapeHtml(link.role)} execution ↗</a>`).join('')}
+                    </div>
+                ` : ''}
+            </div>
+        </div>` : '';
 
     container.innerHTML = `
         <div style="overflow-y: auto; height: 100%; padding: 16px;">
-            ${checkpoints.map((checkpoint, idx) => {
+            ${lifecyclePanel}
+            ${checkpoints.length === 0 ? '<div class="empty-detail">The lifecycle is known, but the current checkpoint payload is unavailable.</div>' : checkpoints.map((checkpoint, idx) => {
+                const normalizedStatus = String(checkpoint.status || 'unknown').toLowerCase();
                 const statusColors = {
                     'pending': 'rgba(255, 179, 64, 0.2)',
                     'approved': 'rgba(50, 215, 75, 0.2)',
+                    'completed': 'rgba(50, 215, 75, 0.2)',
                     'rejected': 'rgba(255, 107, 107, 0.2)',
+                    'aborted': 'rgba(255, 107, 107, 0.2)',
                     'expired': 'rgba(128, 128, 128, 0.2)'
                 };
-                const bgColor = statusColors[checkpoint.status] || 'rgba(255, 255, 255, 0.08)';
+                const bgColor = statusColors[normalizedStatus] || 'rgba(255, 255, 255, 0.08)';
+                const successfulStatus = normalizedStatus === 'approved' || normalizedStatus === 'completed';
+                const failedStatus = normalizedStatus === 'rejected' || normalizedStatus === 'aborted';
+                const statusClass = successfulStatus ? 'completed' : failedStatus ? 'failed' : 'pending';
+                const statusIcon = successfulStatus ? '✓' : failedStatus ? '✗' : normalizedStatus === 'expired' ? '⊘' : '◐';
+                const statusLabel = normalizedStatus === 'unknown'
+                    ? 'Unknown'
+                    : normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1);
+                const checkpointID = String(checkpoint.checkpoint_id || `checkpoint-${idx + 1}`);
+                const checkpointIDAttr = escapeHtmlAttribute(checkpointID);
 
                 return `
                     <div class="dag-step-card" style="background: linear-gradient(135deg, ${bgColor} 0%, rgba(255, 255, 255, 0.02) 100%);">
                         <div class="dag-step-header">
                             <div class="dag-step-title">
                                 <span class="dag-step-number">#${idx + 1}</span>
-                                <span class="dag-step-id">${checkpoint.interrupt_point || 'Checkpoint'}</span>
+                                <span class="dag-step-id">${escapeHtml(checkpoint.interrupt_point || 'Checkpoint')}</span>
                             </div>
                             <div style="display: flex; align-items: center; gap: 12px;">
-                                <span class="dag-step-status ${checkpoint.status === 'approved' ? 'completed' : checkpoint.status === 'rejected' ? 'failed' : 'pending'}">
-                                    ${checkpoint.status === 'approved' ? '✓ Approved' :
-                                      checkpoint.status === 'rejected' ? '✗ Rejected' :
-                                      checkpoint.status === 'expired' ? '⊘ Expired' : '◐ Pending'}
+                                <span class="dag-step-status ${statusClass}">
+                                    ${statusIcon} ${escapeHtml(statusLabel)}
                                 </span>
                             </div>
                         </div>
                         <div class="dag-step-body">
                             <div class="dag-step-info">
                                 <span class="dag-step-label">Checkpoint ID</span>
-                                <span class="dag-step-value" style="font-family: 'SF Mono', monospace; font-size: 11px;">${checkpoint.checkpoint_id}</span>
+                                <span class="dag-step-value" style="font-family: 'SF Mono', monospace; font-size: 11px;">${escapeHtml(checkpointID)}</span>
                                 ${checkpoint.agent_name ? `
                                     <span class="dag-step-label">Agent</span>
-                                    <span class="dag-step-value highlight">${checkpoint.agent_name}</span>
+                                    <span class="dag-step-value highlight">${escapeHtml(checkpoint.agent_name)}</span>
                                 ` : ''}
                                 <span class="dag-step-label">Created</span>
                                 <span class="dag-step-value">${new Date(checkpoint.created_at).toLocaleString()}</span>
@@ -5737,47 +6209,47 @@ function renderHITLCheckpoints(container) {
                                 <span class="dag-step-value">${new Date(checkpoint.expires_at).toLocaleString()}</span>
                             </div>
                             ${checkpoint.decision ? `
-                                <div style="margin-top: 12px; padding: 12px; background: rgba(0,0,0,0.2); border-radius: 8px;">
-                                    <div style="font-weight: 500; margin-bottom: 8px; color: var(--text-primary);">Decision Context</div>
-                                    <div class="dag-step-info">
+                                <div class="hitl-context-panel hitl-context-panel-decision">
+                                    <div class="hitl-context-title">Decision Context</div>
+                                    <div class="dag-step-info hitl-context-grid">
                                         <span class="dag-step-label">Reason</span>
-                                        <span class="dag-step-value">${checkpoint.decision.reason || 'N/A'}</span>
+                                        <span class="dag-step-value">${escapeHtml(checkpoint.decision.reason || 'N/A')}</span>
                                         <span class="dag-step-label">Priority</span>
-                                        <span class="dag-step-value">${checkpoint.decision.priority || 'N/A'}</span>
+                                        <span class="dag-step-value">${escapeHtml(checkpoint.decision.priority || 'N/A')}</span>
                                         ${checkpoint.decision.message ? `
                                             <span class="dag-step-label">Message</span>
-                                            <span class="dag-step-value" style="grid-column: span 3;">${checkpoint.decision.message}</span>
+                                            <span class="dag-step-value">${escapeHtml(checkpoint.decision.message)}</span>
                                         ` : ''}
                                     </div>
                                 </div>
                             ` : ''}
                             ${checkpoint.current_step ? `
-                                <div style="margin-top: 12px; padding: 12px; background: rgba(0,0,0,0.2); border-radius: 8px;">
-                                    <div style="font-weight: 500; margin-bottom: 8px; color: var(--text-primary);">Current Step</div>
-                                    <div class="dag-step-info">
+                                <div class="hitl-context-panel hitl-context-panel-step">
+                                    <div class="hitl-context-title">Current Step</div>
+                                    <div class="dag-step-info hitl-context-grid">
                                         <span class="dag-step-label">Step ID</span>
-                                        <span class="dag-step-value">${checkpoint.current_step.step_id || 'N/A'}</span>
+                                        <span class="dag-step-value">${escapeHtml(checkpoint.current_step.step_id || 'N/A')}</span>
                                         <span class="dag-step-label">Capability</span>
-                                        <span class="dag-step-value highlight">${checkpoint.current_step.capability || 'N/A'}</span>
+                                        <span class="dag-step-value highlight">${escapeHtml(checkpoint.current_step.capability || 'N/A')}</span>
                                     </div>
                                 </div>
                             ` : ''}
                             ${checkpoint.resolved_parameters ? `
                                 <div class="dag-step-response">
-                                    <div class="dag-step-response-header" data-toggle-hitl="${checkpoint.checkpoint_id}" data-hitl-section="params">
-                                        <span><span class="expand-arrow" id="hitl-params-arrow-${checkpoint.checkpoint_id}">▶</span> Resolved Parameters</span>
+                                    <div class="dag-step-response-header" data-toggle-hitl="${checkpointIDAttr}" data-hitl-section="params">
+                                        <span><span class="expand-arrow" id="hitl-params-arrow-${checkpointIDAttr}">▶</span> Resolved Parameters</span>
                                     </div>
-                                    <div id="hitl-params-${checkpoint.checkpoint_id}" class="dag-step-response-content" style="display: none;">
+                                    <div id="hitl-params-${checkpointIDAttr}" class="dag-step-response-content" style="display: none;">
                                         ${formatResponseJson(checkpoint.resolved_parameters)}
                                     </div>
                                 </div>
                             ` : ''}
                             ${checkpoint.plan ? `
                                 <div class="dag-step-response">
-                                    <div class="dag-step-response-header" data-toggle-hitl="${checkpoint.checkpoint_id}" data-hitl-section="plan">
-                                        <span><span class="expand-arrow" id="hitl-plan-arrow-${checkpoint.checkpoint_id}">▶</span> Execution Plan (${checkpoint.plan.steps?.length || 0} steps)</span>
+                                    <div class="dag-step-response-header" data-toggle-hitl="${checkpointIDAttr}" data-hitl-section="plan">
+                                        <span><span class="expand-arrow" id="hitl-plan-arrow-${checkpointIDAttr}">▶</span> Execution Plan (${checkpoint.plan.steps?.length || 0} steps)</span>
                                     </div>
-                                    <div id="hitl-plan-${checkpoint.checkpoint_id}" class="dag-step-response-content" style="display: none;">
+                                    <div id="hitl-plan-${checkpointIDAttr}" class="dag-step-response-content" style="display: none;">
                                         ${formatResponseJson(checkpoint.plan)}
                                     </div>
                                 </div>

--- a/examples/registry-viewer-app/tests/dag-graph.test.mjs
+++ b/examples/registry-viewer-app/tests/dag-graph.test.mjs
@@ -1,0 +1,208 @@
+// DAG renderer boundary tests.
+//
+// Run: node tests/dag-graph.test.mjs
+
+import {
+    assignAfterPlanningHooksToPhases,
+    executionDisplayStepNumber,
+    filterInteractionsWithRenderedParent,
+    filterRenderableEdges,
+    hasVisibleRelationOwner,
+    hitlContinuationStepOffset,
+    isPostExecutionHook,
+    isPreExecutionHook,
+    pipelineHookHasDetailedInteractions,
+} from '../static/js/utils/dag-graph.js';
+
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`  ✓ ${name}`);
+    } catch (error) {
+        failed += 1;
+        console.error(`  ✗ ${name}`);
+        console.error(`    ${error.message}`);
+    }
+}
+
+function assertDeepEqual(actual, expected, message) {
+    const actualJSON = JSON.stringify(actual);
+    const expectedJSON = JSON.stringify(expected);
+    if (actualJSON !== expectedJSON) {
+        throw new Error(`${message || 'expected equality'} — got ${actualJSON}, want ${expectedJSON}`);
+    }
+}
+
+console.log('dag-graph.test.mjs');
+
+test('omits a HITL resume provenance edge whose parent step is outside the graph', () => {
+    const nodes = [
+        { data: { id: 'step-10-governed-execute' } },
+        { data: { id: 'step-10-governed-verify' } },
+        { data: { id: 'step-10-governed-notify' } },
+    ];
+    const validDependency = {
+        data: {
+            source: 'step-10-governed-execute',
+            target: 'step-10-governed-verify',
+            edgeType: 'dependency',
+        },
+    };
+    const crossExecutionProvenance = {
+        data: {
+            source: 'step-10',
+            target: 'step-10-governed-execute',
+            edgeType: 'implicit_dependency',
+        },
+    };
+
+    const result = filterRenderableEdges(
+        nodes,
+        [validDependency, crossExecutionProvenance]
+    );
+
+    assertDeepEqual(result.renderable, [validDependency]);
+    assertDeepEqual(result.omitted, [crossExecutionProvenance]);
+});
+
+test('preserves edges when both endpoints are rendered', () => {
+    const nodes = [
+        { data: { id: 'a' } },
+        { data: { id: 'b' } },
+    ];
+    const edge = { data: { source: 'a', target: 'b' } };
+
+    const result = filterRenderableEdges(nodes, [edge]);
+
+    assertDeepEqual(result.renderable, [edge]);
+    assertDeepEqual(result.omitted, []);
+});
+
+test('omits carried step-scoped LLM calls whose parent belongs to another execution', () => {
+    const interactions = [
+        { type: 'micro_resolution', step_id: 'step-10-governed-notify' },
+        { type: 'result_distillation', step_id: 'step-4' },
+        { type: 'synthesis' },
+    ];
+
+    const result = filterInteractionsWithRenderedParent(
+        interactions,
+        new Set([
+            'step-10-governed-execute',
+            'step-10-governed-verify',
+            'step-10-governed-notify',
+        ])
+    );
+
+    assertDeepEqual(result, [interactions[0]]);
+});
+
+test('renders a relationship branch only when the owner is visible', () => {
+    assertDeepEqual(hasVisibleRelationOwner({}, false), true);
+    assertDeepEqual(
+        hasVisibleRelationOwner({ relation_status: 'owner_unavailable' }, true),
+        false
+    );
+    assertDeepEqual(
+        hasVisibleRelationOwner({ relation_status: 'owner_unknown' }, true),
+        false
+    );
+    assertDeepEqual(hasVisibleRelationOwner({}, true), false);
+});
+
+test('uses unique numbers when normal-execution step IDs share a numeric prefix', () => {
+    const steps = [
+        { step_id: 'step-10-governed-execute' },
+        { step_id: 'step-10-governed-verify' },
+        { step_id: 'step-10-governed-notify' },
+    ];
+
+    assertDeepEqual(
+        steps.map((_, index) => executionDisplayStepNumber(index, {})),
+        [1, 2, 3]
+    );
+    assertDeepEqual(executionDisplayStepNumber(-1, {}), null);
+});
+
+test('continues HITL resume numbering after distinct completed steps', () => {
+    const execution = {
+        hitl_lifecycle: {
+            is_resume: true,
+            current_checkpoint: {
+                completed_steps: [
+                    { step_id: 'step-1' },
+                    { step_id: 'step-2' },
+                    { step_id: 'step-2' },
+                    { step_id: 'step-3' },
+                ],
+            },
+        },
+    };
+
+    assertDeepEqual(hitlContinuationStepOffset(execution), 3);
+    assertDeepEqual(
+        [0, 1, 2].map(index => executionDisplayStepNumber(index, execution)),
+        [4, 5, 6]
+    );
+});
+
+test('classifies trace-backed hooks into pre- and post-execution stages', () => {
+    assertDeepEqual(isPreExecutionHook({ phase: 'before_planning' }), true);
+    assertDeepEqual(isPreExecutionHook({ phase: 'after_planning' }), true);
+    assertDeepEqual(isPostExecutionHook({ phase: 'after_execution' }), true);
+    assertDeepEqual(isPostExecutionHook({ phase: 'after_synthesis' }), true);
+    assertDeepEqual(isPostExecutionHook({ phase: 'after_planning' }), false);
+});
+
+test('suppresses only trace wrappers with richer Full Flow interaction nodes', () => {
+    const interactions = [
+        { type: 'user_memory_recall_identity' },
+        { type: 'user_memory_extraction' },
+    ];
+
+    assertDeepEqual(
+        pipelineHookHasDetailedInteractions(
+            { hook_name: 'user-memory-enrichment' },
+            interactions
+        ),
+        true
+    );
+    assertDeepEqual(
+        pipelineHookHasDetailedInteractions(
+            { hook_name: 'governed-order-response' },
+            interactions
+        ),
+        false
+    );
+});
+
+test('places AfterPlanning spans after the phase whose plan preceded them', () => {
+    const phases = [
+        { created_at: '2026-08-27T15:34:36.900Z' },
+        { created_at: '2026-08-27T15:34:47.500Z' },
+    ];
+    const hooks = [
+        { hook_name: 'guard', started_at: '2026-08-27T15:34:47.600Z' },
+        { hook_name: 'guard', started_at: '2026-08-27T15:34:36.950Z' },
+        { hook_name: 'unplaced' },
+    ];
+
+    assertDeepEqual(
+        assignAfterPlanningHooksToPhases(hooks, phases).map(items =>
+            items.map(item => item.started_at)
+        ),
+        [
+            ['2026-08-27T15:34:36.950Z'],
+            ['2026-08-27T15:34:47.600Z'],
+        ]
+    );
+});
+
+if (failed > 0) {
+    console.error(`\n${failed} test(s) failed`);
+    process.exit(1);
+}
+
+console.log('\nAll tests passed.');

--- a/go.work.sum
+++ b/go.work.sum
@@ -514,6 +514,7 @@ golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/orchestration/ARCHITECTURE.md
+++ b/orchestration/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # TruvaG3 Orchestration Module Architecture
 
-**Version**: 1.4
+**Version**: 1.9
 **Purpose**: Comprehensive architectural documentation for the orchestration module
 **Audience**: Core contributors, module developers, system architects, LLM-based coding agents
 
@@ -1607,7 +1607,8 @@ The orchestration module includes a debug store that captures complete LLM reque
 │                                                                  │
 │  Alternative Writer (no orchestration import needed):            │
 │  └── telemetry.RedisLLMCallRecorder — write-only Redis recorder  │
-│      for standalone agents. Same Redis DB 7 format.              │
+│      for standalone agents. Same Redis DB 7 format and atomic    │
+│      minimum-retention rules.                                     │
 │                                                                  │
 │  Three-Layer Resilience:                                         │
 │  ├── Layer 1: Built-in retry (3 attempts, 50ms backoff)         │
@@ -1620,9 +1621,24 @@ The orchestration module includes a debug store that captures complete LLM reque
 **Key Design Decisions:**
 - **Disabled by default**: Must explicitly enable via `TRUVAG3_LLM_DEBUG_ENABLED=true`
 - **Dedicated Redis DB**: Uses `core.RedisDBLLMDebug` (DB 7) to isolate debug data
-- **TTL-based cleanup**: 24h for success, 168h (7 days) for errors
+- **TTL-based cleanup**: 24h for success and 168h (7 days) for errors;
+  final execution outcome and lineage promotion may retain the current and
+  root records longer
 - **Async recording**: Uses goroutines with WaitGroup for non-blocking capture
 - **Graceful fallback**: Never fails orchestration if debug store fails
+- **Payload fidelity**: Built-in stores preserve application and model
+  payloads without framework-inferred redaction. Sanitization, access control,
+  encryption, and retention policy for sensitive workloads belong to the
+  adopter, as required by the root framework design principles. The legacy
+  executor and skills error transformations documented below occur before
+  storage and remain pending a separate audit; they are not part of the store
+  contract or precedent for new paths
+- **Atomic minimum retention**: Both Redis writers preserve a longer or
+  persistent lifetime in the same atomic operation that appends an interaction
+- **Late-writer retention floor**: Final execution recording stores a small,
+  non-displayable retention-floor key. Orchestrator and standalone-agent
+  writers consult that key atomically, so a write that starts later or in a
+  different pod still receives the required audit lifetime
 
 The store name is historical: it now carries both true LLM calls and selected non-LLM hook interactions when they materially improve production debugging. Examples include `conversation_history_prepare` (`Category: "logic"`), `user_memory_similarity_search` (`Category: "vector_db"`), and persistence-policy decisions (`Category: "logic"`). The registry viewer uses `HookPhase` plus `Category` to route these uniformly into LLM Debug, Pre-Execution, and Post-Execution views.
 
@@ -1636,10 +1652,20 @@ record field sets remain unchanged.
 `ExecutionStore` keeps its minimal required method set.
 `ConversationExecutionLister` is a separate optional capability discovered by
 type assertion. `NoOpExecutionStore` intentionally does not advertise it.
-Similarly, `StorageProvider` remains backend-neutral and unchanged;
-`IndexTTLManager` is an optional capability for providers that can extend a
-sorted index TTL without shortening it. A provider without that capability
-remains supported and relies on bounded lazy stale-member cleanup.
+`StorageProvider` remains the backend-neutral base storage contract.
+`KeyTTLManager` separately defines atomic minimum-retention operations on
+ordinary values. Its two operations
+extend an existing key without creating it, and rewrite a value while
+preserving the larger of its prior remaining lifetime and the requested
+minimum. Neither operation may shorten a longer lifetime or make a persistent
+key expiring.
+
+`ExecutionStorageProvider` composes `StorageProvider` and `KeyTTLManager` and
+is the compile-time requirement for the provider-backed execution store. This
+makes lineage promotion and TTL-preserving rewrites correctness invariants,
+not optional backend behavior. `IndexTTLManager` remains optional because a
+conversation index is only an accelerator; providers without index-TTL support
+rely on bounded lazy stale-member cleanup.
 
 Both the provider-backed store and direct Redis store:
 
@@ -1657,6 +1683,56 @@ returned records. `ConversationIndexScanLimit` defaults to 5000 and bounds
 work when stale entries are encountered. Explicit positive config values win;
 otherwise environment values are normalized by the factory and invalid or
 non-positive values fall back to defaults.
+
+#### Lineage-aware debug retention
+
+Execution and LLM-debug evidence are retained as one audit lineage rather than
+as unrelated records. The shared execution-retention selector applies these
+rules:
+
+- a successful execution receives the configured normal TTL;
+- a failed execution receives the configured error TTL; and
+- an interrupted execution receives at least the maximum of normal TTL, error
+  TTL, and the checkpoint's remaining approval lifetime.
+
+Each execution `Store` also attempts to persist a small retention-link record
+containing only its trace ID, conversation ID, and related-root ID. Normal TTL
+extension reads this projection instead of decompressing and unmarshalling the
+full execution payload. A projection-write failure after the authoritative
+record succeeds is a sanitized warning, not a false `Store` failure; indexing
+continues, and later extension falls back to the full record when the projection
+is absent. Direct Redis extends the execution, link, trace mapping, and optional
+conversation index in one Lua operation inside the store's retry/circuit-
+breaker boundary. `ExtendTTL` follows related-root links recursively with a
+cycle guard, so an investigation extension on a retained descendant promotes
+the complete available lineage. Promotion never creates a missing execution
+and never fails the business request. A missing requested execution returns the
+typed `ErrExecutionRecordNotFound`; a missing later ancestor ends successful
+available-chain traversal. Expected absence is surfaced only after an injected
+breaker operation succeeds, so it cannot count against storage health; other
+failures remain inside resilience handling and are sanitized at logging
+boundaries. `Store`, `Update`, and `SetMetadata` use atomic rewrite operations
+to avoid undoing a prior promotion. Direct Redis `Update` replaces its
+authoritative record and retention projection together through one MSET-backed
+Lua operation. Non-positive programmatic `TTL` and `ErrorTTL` values, including
+values supplied by direct Redis functional options, are normalized to the
+framework defaults before either store is used.
+
+Final execution recording coordinates LLM evidence through the optional
+`LLMDebugRetentionPreserver` capability. The Redis implementation creates or
+extends a small retention-floor marker without creating an empty debug record,
+and applies the same floor to any existing metadata, interaction, or legacy
+record keys. Both DB 7 writers read that marker in their append script, which
+covers writes that begin after execution recording and writes from another
+process. Execution storage and each current/root LLM-retention target use
+separate bounded timeouts.
+Within one request, the recorder skips duplicate floor writes and repeats only
+when the selected retention increases. A failed execution-store write is
+logged but does not prevent the independent LLM-retention attempt. Custom
+stores without this capability fall back to `LLMDebugStore.ExtendTTL`; typed
+`ErrLLMDebugRecordNotFound` remains an expected no-op. Recorder goroutines are
+owned and drained by the existing orchestrator lifecycle; they are request
+work, not independent background `core.Runnable` jobs.
 
 HITL checkpoints use a framework-owned shallow clone of top-level application
 metadata. Framework additions, including `conversation_id` and
@@ -2375,17 +2451,24 @@ different by design: both checkpoint constructors resolve
 override. Task and workflow adapter constructors take their namespace through
 their explicit prefix or configuration arguments.
 
-Errors crossing downstream execution and backend observation boundaries are
-sanitized before entering logs, trace attributes/events, execution-debug
-records, or returned tool observations. `core.RedactSensitiveText` supplies the
-shared defense-in-depth transformation. While an error remains in in-process Go
-control flow, `core.RedactSensitiveError` protects its observable message and
-retains the original cause for `errors.Is` and `errors.As`. When orchestration
-normalizes a failure into string-only step, checkpoint, debug, or API state,
-only the sanitized message is carried and Go error identity is intentionally
-not serialized. This does not authorize recording raw endpoints, prompts,
-payloads, or provider diagnostics—callers and adapters must still avoid placing
-secrets in those values.
+**Legacy exception — pending dedicated audit:** Some error paths that predate
+the framework payload-fidelity policy still sanitize downstream failure bodies
+or error messages before they reach retry prompts, logs, trace events,
+execution-debug records, skills debug records, or returned observations. The
+executor currently uses `core.RedactSensitiveText` for a failed component body
+and `core.RedactSensitiveError` for its Go error; the latter retains the original
+cause for `errors.Is` and `errors.As` while exposing a transformed message.
+Skills authoring transforms an AI error returned to its caller, and skills AI
+observability transforms error text recorded for debugging. Selected
+Redis/provider construction and operational diagnostics contain similar legacy
+calls.
+
+This paragraph records current implementation behavior; it is not a normative
+sanitization guarantee and must not be copied into new or modified paths.
+Adopters remain responsible for payload classification and protection. Removal
+or redesign is deferred to a dedicated audit that must check retry behavior, Go
+error identity, stored evidence, returned observations, and log/trace output
+across every framework call site.
 
 ---
 
@@ -2540,6 +2623,11 @@ modularity and flexibility.
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.9 | 2026-08-28 | Clarified available-lineage retention extension and direct Redis option normalization, documented coupled record/projection updates, and explicitly inventoried the returned skills-authoring AI error among the legacy payload-fidelity exceptions pending audit |
+| 1.8 | 2026-08-28 | Reconciled exact-payload ownership with explicitly labeled legacy error transformations pending a separate audit; prohibited treating those paths as an adopter-facing sanitization guarantee |
+| 1.7 | 2026-08-28 | Made missing lineage evidence breaker-neutral and retention-link-only Store failures best-effort while preserving full-record fallback and sanitized diagnostics |
+| 1.6 | 2026-08-28 | Replaced request-local LLM write ordering with a cross-process retention floor; documented recursive retention links, typed execution absence, independent timeouts, and bounded floor writes |
+| 1.5 | 2026-08-28 | Documented atomic minimum retention, execution/HITL lineage promotion, final-outcome LLM retention, provider capability, and adopter-owned debug-data protection |
 | 1.4 | 2026-08-12 | Added the shipped Agent Skills V1 ownership, request pinning, progressive-disclosure, prompt, management, backend, and observability contracts |
 | 1.3 | 2026-08-09 | Documented canonical configuration/cache eligibility, shared request recording, authoritative HITL suspension, and provider-neutral expiry lifecycle contracts |
 | 1.2 | 2026-08-07 | Corrected the summary to state the canonical `orchestration -> core + telemetry` module boundary |

--- a/orchestration/ARCHITECTURE.md
+++ b/orchestration/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # TruvaG3 Orchestration Module Architecture
 
-**Version**: 1.9
+**Version**: 1.10
 **Purpose**: Comprehensive architectural documentation for the orchestration module
 **Audience**: Core contributors, module developers, system architects, LLM-based coding agents
 
@@ -1646,8 +1646,10 @@ The store name is historical: it now carries both true LLM calls and selected no
 
 Conversation identity is stored in the existing `StoredExecution.Metadata` and
 `ExecutionSummary.Metadata` maps. `ExecutionConversationID` and
-`ExecutionSummaryConversationID` are the canonical accessors; the exported
-record field sets remain unchanged.
+`ExecutionSummaryConversationID` are the canonical accessors; the conversation
+contract does not require a dedicated conversation field on either record. The
+separate terminal-response fields described below are not conversation
+identity.
 
 `ExecutionStore` keeps its minimal required method set.
 `ConversationExecutionLister` is a separate optional capability discovered by
@@ -1683,6 +1685,32 @@ returned records. `ConversationIndexScanLimit` defaults to 5000 and bounds
 work when stale entries are encountered. Explicit positive config values win;
 otherwise environment values are normalized by the factory and invalid or
 non-positive values fall back to defaults.
+
+#### Terminal application-response evidence
+
+`StoredExecution.FinalResponse` is a pointer so an absent terminal response is
+different from an application that intentionally returned an empty string.
+`StoredExecution.FinalResponseSource` identifies the capture boundary. The
+normal buffered and native-streaming `ProcessRequest` paths run
+`AfterSynthesis` hooks and then persist the resulting application response with
+source `FinalResponseSourceAfterSynthesisHooks` (`after_synthesis_hooks`).
+
+This record is deliberately separate from the synthesis interaction in the LLM
+debug store. The synthesis interaction is the model output before application
+governance; it remains useful evidence but is not proof of the final business
+response. Registry Viewer therefore shows synthesis under LLM Calls and the
+governed terminal value under Post-Execution.
+
+On native streaming, synthesis tokens have already been delivered when
+`AfterSynthesis` runs. `FinalResponse` is therefore the post-hook response
+object, not a claim that the hook-mutated text was the byte stream observed by
+the client.
+
+Workflow-mode `ExecutePlanWithSynthesis` executes a caller-supplied plan and
+synthesizes its results, but it does not run pipeline hooks and does not
+currently persist `FinalResponse`. Older records also predate these fields.
+Consumers must treat a missing value as "no post-hook terminal evidence was
+stored," not as proof that the application returned the raw synthesis.
 
 #### Lineage-aware debug retention
 
@@ -2623,6 +2651,7 @@ modularity and flexibility.
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.10 | 2026-08-29 | Documented governed terminal-response evidence separately from raw LLM synthesis, including workflow-mode and historical-record absence cases |
 | 1.9 | 2026-08-28 | Clarified available-lineage retention extension and direct Redis option normalization, documented coupled record/projection updates, and explicitly inventoried the returned skills-authoring AI error among the legacy payload-fidelity exceptions pending audit |
 | 1.8 | 2026-08-28 | Reconciled exact-payload ownership with explicitly labeled legacy error transformations pending a separate audit; prohibited treating those paths as an adopter-facing sanitization guarantee |
 | 1.7 | 2026-08-28 | Made missing lineage evidence breaker-neutral and retention-link-only Store failures best-effort while preserving full-record fallback and sanitized diagnostics |

--- a/orchestration/README.md
+++ b/orchestration/README.md
@@ -1323,8 +1323,8 @@ if metrics.ComponentCallsFailed > 10 {
 | `TRUVAG3_TIERED_RESOLUTION_ENABLED` | `true` | Enable tiered capability resolution for LLM token optimization. Automatically selects relevant tools before plan generation. |
 | `TRUVAG3_TIERED_MIN_TOOLS` | `20` | Minimum tool count to trigger tiered resolution. Below this threshold, all tools are sent directly. |
 | `TRUVAG3_LLM_DEBUG_ENABLED` | `false` | Enable LLM debug payload capture for production debugging |
-| `TRUVAG3_LLM_DEBUG_TTL` | `24h` | TTL for successful debug records |
-| `TRUVAG3_LLM_DEBUG_ERROR_TTL` | `168h` | TTL for error debug records (7 days) |
+| `TRUVAG3_LLM_DEBUG_TTL` | `24h` | Base TTL for successful debug records; longer lineage floors are preserved |
+| `TRUVAG3_LLM_DEBUG_ERROR_TTL` | `168h` | Base TTL for error debug records; HITL or investigation retention may extend it |
 | `TRUVAG3_LLM_DEBUG_REDIS_DB` | `7` | Redis database index for debug storage |
 | `TRUVAG3_EXECUTION_DEBUG_CONVERSATION_QUERY_LIMIT` | `1000` | Maximum records returned by `ListByConversationID` |
 | `TRUVAG3_EXECUTION_DEBUG_INDEX_SCAN_LIMIT` | `5000` | Maximum conversation-index members inspected by one lookup, including stale entries |
@@ -1845,6 +1845,8 @@ These features are not yet implemented but could be added:
 - `LLMDebugRecordSummary` - Lightweight summary with `SourceComponents` for agent name listing
 - `LLMCallRecorderAdapter` - Bridges `LLMDebugStore` to `telemetry.LLMCallRecorder`
 - `ExecutionStore` - Required request-oriented execution persistence contract
+- `StoredExecution` - DAG evidence, including optional post-hook terminal response
+- `FinalResponseSourceAfterSynthesisHooks` - Source label for governed terminal responses
 - `ErrExecutionRecordNotFound` - Typed absence for optional execution evidence
 - `ConversationExecutionLister` - Optional capability for bounded chronological conversation lookup
 - `IndexTTLManager` - Optional `StorageProvider` capability for extending conversation-index TTL
@@ -1867,7 +1869,7 @@ These features are not yet implemented but could be added:
 - `ProcessRequest(ctx, request, metadata)` - Process natural language request
 - `ProcessRequestStreaming(ctx, query, tools, callback)` - Stream orchestration response with real-time tokens
 - `ExecutePlan(ctx, plan)` - Execute pre-defined routing plan (raw results, no synthesis)
-- `ExecutePlanWithSynthesis(ctx, plan, originalRequest)` - Execute plan with synthesis + DAG storage
+- `ExecutePlanWithSynthesis(ctx, plan, originalRequest)` - Workflow-mode plan execution and synthesis with DAG storage; it does not run pipeline hooks or store a governed final response
 - `WithStepCallback(ctx, callback)` - Add per-request step completion callback
 - `ExecuteWorkflow(ctx, workflow, inputs)` - Execute defined workflow
 - `ParseWorkflowYAML(data)` - Parse workflow from YAML
@@ -1912,6 +1914,25 @@ retained ancestor with cycle protection. A missing requested execution returns
 returns success after extending the available chain and does not recreate the
 missing record. Non-positive direct Redis TTL options are normalized to the
 framework defaults after all options are applied.
+
+### Terminal response evidence
+
+The normal buffered and native-streaming `ProcessRequest` paths persist the
+response produced after `AfterSynthesis` hooks in
+`StoredExecution.FinalResponse`. The corresponding
+`FinalResponseSource` is `FinalResponseSourceAfterSynthesisHooks`. This is the
+application-level outcome evidence; the synthesis interaction in the LLM debug
+store remains the model's pre-hook draft.
+
+For native streaming, emitted tokens precede `AfterSynthesis`; the stored value
+is the post-hook response object and may differ from the text already streamed
+to the client.
+
+`ExecutePlanWithSynthesis` intentionally has a narrower workflow-mode contract:
+it executes a supplied plan and synthesizes the result, but it does not invoke
+the pipeline-hook chain and does not currently populate `FinalResponse`.
+Historical records also omit the field. Consumers must not substitute the raw
+synthesis response when post-hook evidence is absent.
 
 ### Configuration Options
 - `WithCapabilityProvider(type, url)` - Configure capability provider type and URL

--- a/orchestration/README.md
+++ b/orchestration/README.md
@@ -1840,12 +1840,16 @@ These features are not yet implemented but could be added:
 - `StreamingOrchestratorResponse` - Streaming response with accumulated content and metadata
 - `StepCallback` - Callback type for per-step progress notifications
 - `LLMDebugStore` - Interface for LLM debug payload storage
+- `LLMDebugRetentionPreserver` - Optional late/cross-process retention-floor capability
 - `LLMInteraction` - Single LLM call record with `SourceComponent` and `CallDescription` attribution
 - `LLMDebugRecordSummary` - Lightweight summary with `SourceComponents` for agent name listing
 - `LLMCallRecorderAdapter` - Bridges `LLMDebugStore` to `telemetry.LLMCallRecorder`
 - `ExecutionStore` - Required request-oriented execution persistence contract
+- `ErrExecutionRecordNotFound` - Typed absence for optional execution evidence
 - `ConversationExecutionLister` - Optional capability for bounded chronological conversation lookup
 - `IndexTTLManager` - Optional `StorageProvider` capability for extending conversation-index TTL
+- `KeyTTLManager` - Atomic minimum-retention extension and TTL-preserving value rewrites
+- `ExecutionStorageProvider` - Required composite provider contract: `StorageProvider` + `KeyTTLManager`
 - `ExecutionStoreConfig` - Includes conversation query and stale-index scan limits
 - `OrchestrationBackends` - Provider-neutral bundle of optional storage and coordination capabilities
 - `BackendRequirements` / `BackendFeature` - Effective capability requirements and validation inputs
@@ -1885,20 +1889,29 @@ if lister, ok := store.(orchestration.ConversationExecutionLister); ok {
 }
 ```
 
-Do capability discovery with a type assertion. `ExecutionStore` and
-`StorageProvider` deliberately keep their existing required method sets, and
-the NoOp store does not claim conversation lookup support.
+Do conversation-listing capability discovery with a type assertion. The NoOp
+store does not claim conversation lookup support.
 
-Provider-backed stores may additionally implement `IndexTTLManager`. If they
-do not, writes and queries still work; bounded lazy cleanup removes stale
-membership as records expire. Execution record metadata is the source of truth
-and the hashed conversation index is only an accelerator. Optional
-conversation-index or TTL failures never fail the orchestration request.
+Provider-backed execution stores require `ExecutionStorageProvider`, which
+composes the base `StorageProvider` operations with `KeyTTLManager`'s atomic
+minimum-retention operations. This makes lineage promotion and
+rewrite-with-retention preservation compile-time requirements. Providers may
+additionally implement `IndexTTLManager` to extend conversation-index
+retention. Without it, bounded lazy cleanup removes stale membership as
+records expire. Execution record metadata is the source of truth and the
+hashed conversation index is only an accelerator.
 
 `MetadataConversationID` should be supplied whenever a conversation exists,
 including the first turn when `MetadataConversationTurns` is empty. It is
 separate from application `session_id`; an application may intentionally map
 the same opaque UUID to both concepts.
+
+`ExecutionStore.ExtendTTL` extends the requested execution and every available
+retained ancestor with cycle protection. A missing requested execution returns
+`ErrExecutionRecordNotFound`. If only a later ancestor has expired, the method
+returns success after extending the available chain and does not recreate the
+missing record. Non-positive direct Redis TTL options are normalized to the
+framework defaults after all options are applied.
 
 ### Configuration Options
 - `WithCapabilityProvider(type, url)` - Configure capability provider type and URL
@@ -2124,7 +2137,8 @@ This is the **same reasoning a human developer would apply** when debugging a fa
 The orchestration module captures complete LLM request/response payloads for production debugging. Unlike Jaeger spans which truncate large payloads, the debug store preserves full prompts and responses.
 
 **Key Features:**
-- **Complete Payload Visibility**: No truncation of prompts or responses
+- **Complete Payload Visibility**: No truncation or framework-inferred
+  redaction of prompts or responses
 - **Request Correlation**: Query by the stable prefix-aware `request_id` carried
   across logs, traces, and execution records
 - **Typed Recording Families**: core orchestration calls include `plan_generation`, `correction`, `synthesis`, `synthesis_streaming`, `micro_resolution`, `semantic_retry`, `tiered_selection`, and `hallucination_detection`; optional memory/compaction features add their own types, and `ai.InstrumentedAIClient` contributes `agent_llm_call`
@@ -2132,7 +2146,16 @@ The orchestration module captures complete LLM request/response payloads for pro
 - **Source Attribution**: `SourceComponent` field identifies which agent/component made each LLM call; `SourceComponents` on summaries provides per-record agent name listing
 - **Three-Layer Resilience**: Built-in retry → optional circuit breaker → NoOp fallback
 - **Provider Tracking**: Captures the normalized provider identity returned by the selected client (for example `openai`, `anthropic`, `gemini`, `azureopenai`, `bedrock`, or a custom provider name)
-- **Atomic Storage**: List-based storage (RPUSH) safe for concurrent writes from orchestrator and agents
+- **Atomic Storage and Retention**: One Redis operation appends the interaction,
+  updates metadata/index data, and preserves any longer or persistent TTL from
+  final execution, HITL, lineage, or investigation retention
+- **Adopter-Owned Protection**: Built-in writers preserve exact application
+  and model payloads. Applications that require sanitization must supply it
+  through their logger, telemetry pipeline, store, recorder, middleware, or
+  processing hooks
+- **Lineage Retention**: Final execution recording promotes current and root
+  LLM evidence through a non-displayable retention floor. Late agent-pod and
+  orchestrator writes inherit it atomically without creating an empty record
 
 **Configuration:**
 ```bash
@@ -2172,6 +2195,15 @@ aiClient := ai.NewInstrumentedClient(baseClient, recorder,
 ```
 
 The orchestrator propagates `X-TruvaG3-Request-ID` and `X-TruvaG3-Step-ID` headers to agents during plan execution. Agents extract these via `core.ExtractRequestContext()` in their HTTP handlers, which enables `InstrumentedAIClient` to correlate recordings back to the orchestration request.
+
+`telemetry.RedisLLMCallRecorder` is a persistence-format twin of
+`orchestration.RedisLLMDebugStore`. Both preserve exact payloads and apply the
+same atomic minimum-retention rules, so either writer can append to a shared
+request record without reducing retention already promoted by the other. Both
+also consult the same request-scoped retention-floor key, so the guarantee does
+not depend on which process writes first. Enabling either built-in writer is an
+informed opt-in: the adopter owns access control, encryption, retention, and
+any required sanitization.
 
 **LLMCallRecorderAdapter:**
 

--- a/orchestration/conversation_debug_persistence_test.go
+++ b/orchestration/conversation_debug_persistence_test.go
@@ -3,7 +3,9 @@ package orchestration
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
@@ -341,6 +343,73 @@ func TestLLMDebugRedisWritersUseCompatibleConversationField(t *testing.T) {
 		if got := LLMDebugConversationID(record); got != "conversation-format" {
 			t.Fatalf("%s typed conversation ID = %q", requestID, got)
 		}
+	}
+}
+
+func TestLLMDebugRedisWritersShareMinimumRetentionContract(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis.Run: %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	orchestrationStore := &RedisLLMDebugStore{
+		client:   redis.NewClient(&redis.Options{Addr: mr.Addr()}),
+		logger:   &core.NoOpLogger{},
+		ttl:      defaultDebugTTL,
+		errorTTL: errorDebugTTL,
+	}
+	recorder, err := telemetry.NewRedisLLMCallRecorder(
+		telemetry.WithRecorderRedisURL("redis://"+mr.Addr()),
+		telemetry.WithRecorderRedisDB(0),
+	)
+	if err != nil {
+		t.Fatalf("NewRedisLLMCallRecorder: %v", err)
+	}
+	t.Cleanup(func() { _ = recorder.Close() })
+
+	const requestID = "request-shared-retention"
+	const promotedTTL = 14 * 24 * time.Hour
+	if err := orchestrationStore.PreserveRetention(
+		context.Background(),
+		requestID,
+		promotedTTL,
+	); err != nil {
+		t.Fatalf("establish retention floor: %v", err)
+	}
+	if _, err := orchestrationStore.GetRecord(context.Background(), requestID); !errors.Is(err, ErrLLMDebugRecordNotFound) {
+		t.Fatalf("retention floor created a visible record: %v", err)
+	}
+	if err := recorder.RecordLLMCall(
+		context.Background(),
+		requestID,
+		telemetry.LLMCallRecord{CallType: "agent_llm_call", Success: true},
+	); err != nil {
+		t.Fatalf("telemetry writer: %v", err)
+	}
+	if err := orchestrationStore.RecordInteraction(
+		context.Background(),
+		requestID,
+		LLMInteraction{Type: "plan_generation", Success: true},
+	); err != nil {
+		t.Fatalf("orchestration writer: %v", err)
+	}
+
+	for _, key := range []string{
+		llmDebugKeyPrefix + requestID + llmDebugFloorSuffix,
+		llmDebugKeyPrefix + requestID + llmDebugMetaSuffix,
+		llmDebugKeyPrefix + requestID + llmDebugInterSuffix,
+	} {
+		if got := mr.TTL(key); got != promotedTTL {
+			t.Fatalf("%s TTL = %v, want %v", key, got, promotedTTL)
+		}
+	}
+	record, err := orchestrationStore.GetRecord(context.Background(), requestID)
+	if err != nil {
+		t.Fatalf("GetRecord: %v", err)
+	}
+	if got := len(record.Interactions); got != 2 {
+		t.Fatalf("interaction count = %d, want 2", got)
 	}
 }
 

--- a/orchestration/execution_conversation_store_test.go
+++ b/orchestration/execution_conversation_store_test.go
@@ -913,12 +913,12 @@ func TestDirectRedisIndexTTLHelperHandlesMissingAndPersistentKeys(t *testing.T) 
 	)
 	ctx := context.Background()
 
-	if err := store.extendIndexTTLWithoutDowngrade(
+	if exists, err := extendRedisKeyMinimumTTL(
 		ctx,
+		store.client,
 		"missing-index",
 		time.Hour,
-		false,
-	); err != nil {
+	); err != nil || exists {
 		t.Fatalf("missing index: %v", err)
 	}
 
@@ -930,12 +930,12 @@ func TestDirectRedisIndexTTLHelperHandlesMissingAndPersistentKeys(t *testing.T) 
 	).Err(); err != nil {
 		t.Fatalf("seed persistent index: %v", err)
 	}
-	if err := store.extendIndexTTLWithoutDowngrade(
+	if exists, err := extendRedisKeyMinimumTTL(
 		ctx,
+		store.client,
 		persistentKey,
 		time.Hour,
-		false,
-	); err != nil {
+	); err != nil || !exists {
 		t.Fatalf("preserve persistent index: %v", err)
 	}
 	if got, err := store.client.TTL(ctx, persistentKey).Result(); err != nil ||
@@ -943,17 +943,6 @@ func TestDirectRedisIndexTTLHelperHandlesMissingAndPersistentKeys(t *testing.T) 
 		t.Fatalf("persistent TTL = (%v, %v), want Redis persistent sentinel", got, err)
 	}
 
-	if err := store.extendIndexTTLWithoutDowngrade(
-		ctx,
-		persistentKey,
-		time.Hour,
-		true,
-	); err != nil {
-		t.Fatalf("expire newly-created persistent index: %v", err)
-	}
-	if got, err := store.client.TTL(ctx, persistentKey).Result(); err != nil || got != time.Hour {
-		t.Fatalf("initialized TTL = (%v, %v), want 1h", got, err)
-	}
 }
 
 func TestExecutionStoreCanonicalKeysMatchAcrossImplementations(t *testing.T) {
@@ -1081,7 +1070,9 @@ func TestExecutionStoreConversationLimitConfiguration(t *testing.T) {
 	normalized := normalizeExecutionStoreConfig(ExecutionStoreConfig{})
 	if normalized.ConversationQueryLimit != defaultConversationQueryLimit ||
 		normalized.ConversationIndexScanLimit != defaultConversationIndexScanLimit ||
-		normalized.KeyPrefix != DefaultExecutionKeyPrefix {
+		normalized.KeyPrefix != DefaultExecutionKeyPrefix ||
+		normalized.TTL != defaults.TTL ||
+		normalized.ErrorTTL != defaults.ErrorTTL {
 		t.Fatalf("zero-value normalization = %+v", normalized)
 	}
 }

--- a/orchestration/execution_lineage_retention_test.go
+++ b/orchestration/execution_lineage_retention_test.go
@@ -1,0 +1,865 @@
+package orchestration
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+type failureCountingCircuitBreaker struct {
+	mu       sync.Mutex
+	failures int
+	open     bool
+}
+
+func (b *failureCountingCircuitBreaker) Execute(
+	ctx context.Context,
+	operation func() error,
+) error {
+	b.mu.Lock()
+	if b.open {
+		b.mu.Unlock()
+		return errors.New("test circuit breaker is open")
+	}
+	b.mu.Unlock()
+
+	err := operation()
+	if err != nil {
+		b.mu.Lock()
+		b.failures++
+		b.open = true
+		b.mu.Unlock()
+	}
+	return err
+}
+
+func (b *failureCountingCircuitBreaker) ExecuteWithTimeout(
+	ctx context.Context,
+	_ time.Duration,
+	operation func() error,
+) error {
+	return b.Execute(ctx, operation)
+}
+
+func (b *failureCountingCircuitBreaker) GetState() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.open {
+		return "open"
+	}
+	return "closed"
+}
+
+func (b *failureCountingCircuitBreaker) GetMetrics() map[string]interface{} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return map[string]interface{}{"failure": b.failures}
+}
+
+func (b *failureCountingCircuitBreaker) Reset() {
+	b.mu.Lock()
+	b.failures = 0
+	b.open = false
+	b.mu.Unlock()
+}
+
+func (b *failureCountingCircuitBreaker) CanExecute() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return !b.open
+}
+
+type failRedisScriptForKeyOnceHook struct {
+	mu     sync.Mutex
+	key    string
+	err    error
+	failed bool
+}
+
+func (h *failRedisScriptForKeyOnceHook) DialHook(next redis.DialHook) redis.DialHook {
+	return next
+}
+
+func (h *failRedisScriptForKeyOnceHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, command redis.Cmder) error {
+		name := command.Name()
+		if name == "eval" || name == "evalsha" {
+			h.mu.Lock()
+			if !h.failed {
+				for _, argument := range command.Args() {
+					if key, ok := argument.(string); ok && key == h.key {
+						h.failed = true
+						h.mu.Unlock()
+						return h.err
+					}
+				}
+			}
+			h.mu.Unlock()
+		}
+		return next(ctx, command)
+	}
+}
+
+func (h *failRedisScriptForKeyOnceHook) ProcessPipelineHook(
+	next redis.ProcessPipelineHook,
+) redis.ProcessPipelineHook {
+	return next
+}
+
+type retentionLinkFailingProvider struct {
+	*mockStorageProvider
+	failKey string
+	err     error
+}
+
+func (p *retentionLinkFailingProvider) SetKeyWithMinimumTTL(
+	ctx context.Context,
+	key string,
+	value string,
+	minimumTTL time.Duration,
+) error {
+	if key == p.failKey {
+		return p.err
+	}
+	return p.mockStorageProvider.SetKeyWithMinimumTTL(ctx, key, value, minimumTTL)
+}
+
+func TestExecutionRetentionTTLAt(t *testing.T) {
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		execution *StoredExecution
+		normalTTL time.Duration
+		errorTTL  time.Duration
+		want      time.Duration
+	}{
+		{
+			name:      "success",
+			execution: &StoredExecution{Result: &ExecutionResult{Success: true}},
+			normalTTL: 24 * time.Hour,
+			errorTTL:  7 * 24 * time.Hour,
+			want:      24 * time.Hour,
+		},
+		{
+			name:      "failure",
+			execution: &StoredExecution{Result: &ExecutionResult{Success: false}},
+			normalTTL: 24 * time.Hour,
+			errorTTL:  7 * 24 * time.Hour,
+			want:      7 * 24 * time.Hour,
+		},
+		{
+			name: "interrupted uses longer configured retention",
+			execution: &StoredExecution{
+				Interrupted: true,
+				Result:      &ExecutionResult{Success: false},
+			},
+			normalTTL: 24 * time.Hour,
+			errorTTL:  7 * 24 * time.Hour,
+			want:      7 * 24 * time.Hour,
+		},
+		{
+			name: "checkpoint window is authoritative minimum",
+			execution: &StoredExecution{
+				Interrupted: true,
+				Checkpoint:  &ExecutionCheckpoint{ExpiresAt: now.Add(10 * 24 * time.Hour)},
+			},
+			normalTTL: 24 * time.Hour,
+			errorTTL:  7 * 24 * time.Hour,
+			want:      10 * 24 * time.Hour,
+		},
+		{
+			name: "expired checkpoint cannot reduce retention",
+			execution: &StoredExecution{
+				Interrupted: true,
+				Checkpoint:  &ExecutionCheckpoint{ExpiresAt: now.Add(-time.Hour)},
+			},
+			normalTTL: 24 * time.Hour,
+			errorTTL:  time.Hour,
+			want:      24 * time.Hour,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := executionRetentionTTLAt(
+				test.execution,
+				test.normalTTL,
+				test.errorTTL,
+				now,
+			); got != test.want {
+				t.Fatalf("retention = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestDirectRedisFailedChildPromotesRootEvidence(t *testing.T) {
+	config := DefaultExecutionStoreConfig()
+	config.TTL = time.Hour
+	config.ErrorTTL = 7 * time.Hour
+	mr, store := newRedisExecutionConversationTestStore(t, config)
+	ctx := context.Background()
+	now := time.Now()
+
+	root := sampleExecution("lineage-root", true)
+	root.CreatedAt = now
+	if err := store.Store(ctx, root); err != nil {
+		t.Fatalf("store root: %v", err)
+	}
+	child := sampleExecution("lineage-child", false)
+	child.CreatedAt = now.Add(time.Minute)
+	child.OriginalRequestID = root.RequestID
+	if err := store.Store(ctx, child); err != nil {
+		t.Fatalf("store child: %v", err)
+	}
+
+	for label, key := range map[string]string{
+		"root record":  root.RequestID,
+		"root trace":   store.traceKey(root.TraceID),
+		"child record": child.RequestID,
+	} {
+		if label != "root trace" {
+			key = store.recordKey(key)
+		}
+		if got := mr.TTL(key); got != config.ErrorTTL {
+			t.Fatalf("%s TTL = %v, want %v", label, got, config.ErrorTTL)
+		}
+	}
+}
+
+func TestZeroValueExecutionStoreConfigUsesRetentionDefaults(t *testing.T) {
+	defaults := DefaultExecutionStoreConfig()
+	ctx := context.Background()
+
+	provider := newMockStorageProvider()
+	providerStore := NewExecutionStoreWithProvider(
+		provider,
+		ExecutionStoreConfig{},
+		nil,
+	)
+	providerExecution := sampleExecution("zero-config-provider", true)
+	if err := providerStore.Store(ctx, providerExecution); err != nil {
+		t.Fatalf("provider Store with zero config: %v", err)
+	}
+	providerKey := DefaultExecutionKeyPrefix + providerExecution.RequestID
+	provider.mu.RLock()
+	providerTTL := provider.ttls[providerKey]
+	provider.mu.RUnlock()
+	if providerTTL != defaults.TTL {
+		t.Fatalf("provider zero-config TTL = %v, want %v", providerTTL, defaults.TTL)
+	}
+
+	mr, redisStore := newRedisExecutionConversationTestStore(
+		t,
+		ExecutionStoreConfig{},
+	)
+	redisExecution := sampleExecution("zero-config-redis", true)
+	if err := redisStore.Store(ctx, redisExecution); err != nil {
+		t.Fatalf("Redis Store with zero config: %v", err)
+	}
+	if got := mr.TTL(redisStore.recordKey(redisExecution.RequestID)); got != defaults.TTL {
+		t.Fatalf("Redis zero-config TTL = %v, want %v", got, defaults.TTL)
+	}
+}
+
+func TestRedisExecutionStoreOptionsNormalizeNonPositiveTTLs(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	store, err := NewRedisExecutionDebugStoreWithClient(
+		client,
+		DefaultExecutionStoreConfig(),
+		WithExecutionDebugTTL(0),
+		WithExecutionDebugErrorTTL(-time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewRedisExecutionDebugStoreWithClient: %v", err)
+	}
+	defaults := DefaultExecutionStoreConfig()
+	if store.ttl != defaults.TTL || store.errorTTL != defaults.ErrorTTL {
+		t.Fatalf(
+			"normalized TTLs = (%v, %v), want (%v, %v)",
+			store.ttl,
+			store.errorTTL,
+			defaults.TTL,
+			defaults.ErrorTTL,
+		)
+	}
+
+	ctx := context.Background()
+	for _, test := range []struct {
+		requestID string
+		success   bool
+		wantTTL   time.Duration
+	}{
+		{requestID: "zero-option-success", success: true, wantTTL: defaults.TTL},
+		{requestID: "zero-option-failure", success: false, wantTTL: defaults.ErrorTTL},
+	} {
+		execution := sampleExecution(test.requestID, test.success)
+		if err := store.Store(ctx, execution); err != nil {
+			t.Fatalf("Store(%s): %v", test.requestID, err)
+		}
+		if got := mr.TTL(store.recordKey(test.requestID)); got != test.wantTTL {
+			t.Fatalf("%s TTL = %v, want %v", test.requestID, got, test.wantTTL)
+		}
+	}
+}
+
+func TestDirectRedisExtendChildPromotesCompleteRetentionChain(t *testing.T) {
+	config := DefaultExecutionStoreConfig()
+	config.TTL = time.Hour
+	config.ErrorTTL = 7 * time.Hour
+	mr, store := newRedisExecutionConversationTestStore(t, config)
+	ctx := context.Background()
+	const conversationID = "conversation-retention-chain"
+
+	root := sampleExecution("retention-chain-root", true)
+	root.Metadata = map[string]string{MetadataConversationID: conversationID}
+	child := sampleExecution("retention-chain-child", true)
+	child.OriginalRequestID = root.RequestID
+	child.Metadata = map[string]string{MetadataConversationID: conversationID}
+	grandchild := sampleExecution("retention-chain-grandchild", true)
+	grandchild.OriginalRequestID = child.RequestID
+	grandchild.Metadata = map[string]string{MetadataConversationID: conversationID}
+	for _, execution := range []*StoredExecution{root, child, grandchild} {
+		if err := store.Store(ctx, execution); err != nil {
+			t.Fatalf("Store(%s): %v", execution.RequestID, err)
+		}
+	}
+
+	const promotedTTL = 14 * 24 * time.Hour
+	if err := store.ExtendTTL(ctx, grandchild.RequestID, promotedTTL); err != nil {
+		t.Fatalf("ExtendTTL(grandchild): %v", err)
+	}
+	for _, execution := range []*StoredExecution{root, child, grandchild} {
+		for label, key := range map[string]string{
+			"record":         store.recordKey(execution.RequestID),
+			"retention link": store.retentionLinkKey(execution.RequestID),
+			"trace mapping":  store.traceKey(execution.TraceID),
+		} {
+			if got := mr.TTL(key); got != promotedTTL {
+				t.Fatalf("%s %s TTL = %v, want %v", execution.RequestID, label, got, promotedTTL)
+			}
+		}
+	}
+	if got := mr.TTL(store.conversationIndexKey(conversationID)); got != promotedTTL {
+		t.Fatalf("conversation index TTL = %v, want %v", got, promotedTTL)
+	}
+}
+
+func TestProviderExtendChildPromotesCompleteRetentionChain(t *testing.T) {
+	provider := newMockStorageProvider()
+	config := DefaultExecutionStoreConfig()
+	config.TTL = time.Hour
+	store := NewExecutionStoreWithProvider(provider, config, nil)
+	ctx := context.Background()
+
+	root := sampleExecution("provider-chain-root", true)
+	child := sampleExecution("provider-chain-child", true)
+	child.OriginalRequestID = root.RequestID
+	grandchild := sampleExecution("provider-chain-grandchild", true)
+	grandchild.OriginalRequestID = child.RequestID
+	for _, execution := range []*StoredExecution{root, child, grandchild} {
+		if err := store.Store(ctx, execution); err != nil {
+			t.Fatalf("Store(%s): %v", execution.RequestID, err)
+		}
+	}
+
+	const promotedTTL = 14 * 24 * time.Hour
+	if err := store.ExtendTTL(ctx, grandchild.RequestID, promotedTTL); err != nil {
+		t.Fatalf("ExtendTTL(grandchild): %v", err)
+	}
+	provider.mu.RLock()
+	defer provider.mu.RUnlock()
+	for _, execution := range []*StoredExecution{root, child, grandchild} {
+		for label, key := range map[string]string{
+			"record":         normalizeExecutionKeyPrefix(config.KeyPrefix) + execution.RequestID,
+			"retention link": executionRetentionLinkKey(config.KeyPrefix, execution.RequestID),
+			"trace mapping":  normalizeExecutionKeyPrefix(config.KeyPrefix) + "trace:" + execution.TraceID,
+		} {
+			if got := provider.ttls[key]; got != promotedTTL {
+				t.Fatalf("%s %s TTL = %v, want %v", execution.RequestID, label, got, promotedTTL)
+			}
+		}
+	}
+}
+
+func TestDirectRedisExtendTTLUsesRetentionLinkAndCircuitBreaker(t *testing.T) {
+	_, store := newRedisExecutionConversationTestStore(t, DefaultExecutionStoreConfig())
+	ctx := context.Background()
+	execution := sampleExecution("retention-link-extension", true)
+	if err := store.Store(ctx, execution); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if err := store.client.Set(
+		ctx,
+		store.recordKey(execution.RequestID),
+		"not-a-valid-execution-payload",
+		time.Hour,
+	).Err(); err != nil {
+		t.Fatalf("corrupt full record fixture: %v", err)
+	}
+
+	breakerCalls := 0
+	store.circuitBreaker = &mockCircuitBreaker{executeFunc: func(
+		_ context.Context,
+		operation func() error,
+	) error {
+		breakerCalls++
+		return operation()
+	}}
+	if err := store.ExtendTTL(ctx, execution.RequestID, 14*24*time.Hour); err != nil {
+		t.Fatalf("ExtendTTL: %v", err)
+	}
+	if breakerCalls != 1 {
+		t.Fatalf("circuit breaker calls = %d, want 1", breakerCalls)
+	}
+}
+
+func TestDirectRedisMissingExecutionDoesNotTripCircuitBreaker(t *testing.T) {
+	_, store := newRedisExecutionConversationTestStore(t, DefaultExecutionStoreConfig())
+	breaker := &failureCountingCircuitBreaker{}
+	store.circuitBreaker = breaker
+	ctx := context.Background()
+
+	err := store.ExtendTTL(ctx, "expired-or-never-recorded", 24*time.Hour)
+	if !errors.Is(err, ErrExecutionRecordNotFound) {
+		t.Fatalf("ExtendTTL error = %v, want typed not-found", err)
+	}
+	if breaker.GetState() != "closed" {
+		t.Fatalf("expected absence opened circuit breaker")
+	}
+	if failures := breaker.GetMetrics()["failure"]; failures != 0 {
+		t.Fatalf("expected absence counted as breaker failure: %v", failures)
+	}
+
+	execution := sampleExecution("store-after-expected-absence", true)
+	if err := store.Store(ctx, execution); err != nil {
+		t.Fatalf("Store after expected absence: %v", err)
+	}
+}
+
+func TestExtendTTLSucceedsWhenOnlyAncestorIsMissing(t *testing.T) {
+	const promotedTTL = 14 * 24 * time.Hour
+	ctx := context.Background()
+
+	t.Run("direct Redis", func(t *testing.T) {
+		mr, store := newRedisExecutionConversationTestStore(t, DefaultExecutionStoreConfig())
+		child := sampleExecution("redis-child-with-expired-ancestor", true)
+		child.OriginalRequestID = "redis-expired-ancestor"
+		if err := store.Store(ctx, child); err != nil {
+			t.Fatalf("Store child: %v", err)
+		}
+		if err := store.ExtendTTL(ctx, child.RequestID, promotedTTL); err != nil {
+			t.Fatalf("ExtendTTL child with missing ancestor: %v", err)
+		}
+		if got := mr.TTL(store.recordKey(child.RequestID)); got != promotedTTL {
+			t.Fatalf("child TTL = %v, want %v", got, promotedTTL)
+		}
+	})
+
+	t.Run("provider", func(t *testing.T) {
+		provider := newMockStorageProvider()
+		config := DefaultExecutionStoreConfig()
+		storeAPI := NewExecutionStoreWithProvider(provider, config, nil)
+		store, ok := storeAPI.(*executionStoreImpl)
+		if !ok {
+			t.Fatalf("provider constructor returned %T, want *executionStoreImpl", storeAPI)
+		}
+		child := sampleExecution("provider-child-with-expired-ancestor", true)
+		child.OriginalRequestID = "provider-expired-ancestor"
+		if err := store.Store(ctx, child); err != nil {
+			t.Fatalf("Store child: %v", err)
+		}
+		if err := store.ExtendTTL(ctx, child.RequestID, promotedTTL); err != nil {
+			t.Fatalf("ExtendTTL child with missing ancestor: %v", err)
+		}
+		provider.mu.RLock()
+		got := provider.ttls[store.recordKey(child.RequestID)]
+		provider.mu.RUnlock()
+		if got != promotedTTL {
+			t.Fatalf("child TTL = %v, want %v", got, promotedTTL)
+		}
+		if err := store.ExtendTTL(ctx, "missing-target", promotedTTL); !errors.Is(err, ErrExecutionRecordNotFound) {
+			t.Fatalf("missing target error = %v, want typed not-found", err)
+		}
+	})
+}
+
+func TestDirectRedisUpdateKeepsRecordAndRetentionLinkCoupled(t *testing.T) {
+	_, store := newRedisExecutionConversationTestStore(t, DefaultExecutionStoreConfig())
+	ctx := context.Background()
+	execution := sampleExecution("atomic-update", true)
+	if err := store.Store(ctx, execution); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	linkKey := store.retentionLinkKey(execution.RequestID)
+	beforeLink, err := store.client.Get(ctx, linkKey).Result()
+	if err != nil {
+		t.Fatalf("read original retention link: %v", err)
+	}
+
+	store.client.AddHook(&failRedisScriptForKeyOnceHook{
+		key: linkKey,
+		err: errors.New("injected coupled update failure"),
+	})
+	store.circuitBreaker = &mockCircuitBreaker{executeFunc: func(
+		_ context.Context,
+		operation func() error,
+	) error {
+		return operation()
+	}}
+	updated := *execution
+	updated.OriginalRequest = "updated request"
+	updated.TraceID = "updated-trace"
+	updated.OriginalRequestID = "updated-root"
+	if err := store.Update(ctx, execution.RequestID, &updated); err == nil {
+		t.Fatal("Update succeeded despite injected coupled write failure")
+	}
+
+	after, err := store.Get(ctx, execution.RequestID)
+	if err != nil {
+		t.Fatalf("Get after failed Update: %v", err)
+	}
+	if after.OriginalRequest != execution.OriginalRequest ||
+		after.TraceID != execution.TraceID ||
+		after.OriginalRequestID != execution.OriginalRequestID {
+		t.Fatalf("authoritative record changed after failed coupled update: %#v", after)
+	}
+	afterLink, err := store.client.Get(ctx, linkKey).Result()
+	if err != nil {
+		t.Fatalf("read retention link after failed Update: %v", err)
+	}
+	if afterLink != beforeLink {
+		t.Fatalf("retention link changed after failed coupled update: %q != %q", afterLink, beforeLink)
+	}
+}
+
+func TestProviderStoreContinuesWhenRetentionLinkWriteFails(t *testing.T) {
+	config := DefaultExecutionStoreConfig()
+	execution := sampleExecution("provider-sidecar-write-failure", true)
+	baseProvider := newMockStorageProvider()
+	provider := &retentionLinkFailingProvider{
+		mockStorageProvider: baseProvider,
+		failKey:             executionRetentionLinkKey(config.KeyPrefix, execution.RequestID),
+		err:                 errors.New("injected retention-link failure"),
+	}
+	warningCount := 0
+	logger := &mockLogger{warnFunc: func(_ string, fields map[string]interface{}) {
+		if fields["operation"] == "execution_store_retention_link" {
+			warningCount++
+		}
+	}}
+	storeAPI := NewExecutionStoreWithProvider(provider, config, logger)
+	store, ok := storeAPI.(*executionStoreImpl)
+	if !ok {
+		t.Fatalf("provider constructor returned %T, want *executionStoreImpl", storeAPI)
+	}
+	ctx := context.Background()
+
+	if err := store.Store(ctx, execution); err != nil {
+		t.Fatalf("Store returned an error after the primary write succeeded: %v", err)
+	}
+	if warningCount != 1 {
+		t.Fatalf("retention-link warnings = %d, want 1", warningCount)
+	}
+	if _, err := store.Get(ctx, execution.RequestID); err != nil {
+		t.Fatalf("Get persisted execution: %v", err)
+	}
+
+	baseProvider.mu.RLock()
+	_, linkExists := baseProvider.data[provider.failKey]
+	_, indexed := baseProvider.indexes[store.indexKey()][execution.RequestID]
+	baseProvider.mu.RUnlock()
+	if linkExists {
+		t.Fatalf("failed retention link unexpectedly exists")
+	}
+	if !indexed {
+		t.Fatalf("primary execution was not indexed after sidecar failure")
+	}
+
+	const promotedTTL = 14 * 24 * time.Hour
+	if err := store.ExtendTTL(ctx, execution.RequestID, promotedTTL); err != nil {
+		t.Fatalf("fallback ExtendTTL without retention link: %v", err)
+	}
+	baseProvider.mu.RLock()
+	retention := baseProvider.ttls[store.recordKey(execution.RequestID)]
+	baseProvider.mu.RUnlock()
+	if retention != promotedTTL {
+		t.Fatalf("fallback retention = %v, want %v", retention, promotedTTL)
+	}
+}
+
+func TestDirectRedisStoreContinuesWhenRetentionLinkWriteFails(t *testing.T) {
+	mr, store := newRedisExecutionConversationTestStore(t, DefaultExecutionStoreConfig())
+	execution := sampleExecution("redis-sidecar-write-failure", true)
+	linkKey := store.retentionLinkKey(execution.RequestID)
+	store.client.AddHook(&failRedisScriptForKeyOnceHook{
+		key: linkKey,
+		err: errors.New("injected retention-link failure"),
+	})
+	warningCount := 0
+	store.logger = &mockLogger{warnFunc: func(_ string, fields map[string]interface{}) {
+		if fields["operation"] == "execution_store_retention_link" {
+			warningCount++
+		}
+	}}
+	ctx := context.Background()
+
+	if err := store.Store(ctx, execution); err != nil {
+		t.Fatalf("Store returned an error after the primary write succeeded: %v", err)
+	}
+	if warningCount != 1 {
+		t.Fatalf("retention-link warnings = %d, want 1", warningCount)
+	}
+	if _, err := store.Get(ctx, execution.RequestID); err != nil {
+		t.Fatalf("Get persisted execution: %v", err)
+	}
+	if exists, err := store.client.Exists(ctx, linkKey).Result(); err != nil || exists != 0 {
+		t.Fatalf("retention link existence = (%d, %v), want absent", exists, err)
+	}
+	if err := store.client.ZScore(ctx, store.indexKey(), execution.RequestID).Err(); err != nil {
+		t.Fatalf("primary execution was not indexed after sidecar failure: %v", err)
+	}
+
+	const promotedTTL = 14 * 24 * time.Hour
+	if err := store.ExtendTTL(ctx, execution.RequestID, promotedTTL); err != nil {
+		t.Fatalf("fallback ExtendTTL without retention link: %v", err)
+	}
+	if retention := mr.TTL(store.recordKey(execution.RequestID)); retention != promotedTTL {
+		t.Fatalf("fallback retention = %v, want %v", retention, promotedTTL)
+	}
+}
+
+func TestProviderBackedFailedChildPromotesRootAndRewritesPreserveIt(t *testing.T) {
+	provider := newMockStorageProvider()
+	config := DefaultExecutionStoreConfig()
+	config.TTL = time.Hour
+	config.ErrorTTL = 7 * time.Hour
+	store := NewExecutionStoreWithProvider(provider, config, nil)
+	ctx := context.Background()
+
+	root := sampleExecution("provider-root", true)
+	if err := store.Store(ctx, root); err != nil {
+		t.Fatalf("store root: %v", err)
+	}
+	child := sampleExecution("provider-child", false)
+	child.OriginalRequestID = root.RequestID
+	if err := store.Store(ctx, child); err != nil {
+		t.Fatalf("store child: %v", err)
+	}
+	rootKey := normalizeExecutionKeyPrefix(config.KeyPrefix) + root.RequestID
+	provider.mu.RLock()
+	retention := provider.ttls[rootKey]
+	provider.mu.RUnlock()
+	if retention != config.ErrorTTL {
+		t.Fatalf("promoted provider root TTL = %v, want %v", retention, config.ErrorTTL)
+	}
+
+	if err := store.ExtendTTL(ctx, root.RequestID, 14*24*time.Hour); err != nil {
+		t.Fatalf("ExtendTTL: %v", err)
+	}
+	if err := store.SetMetadata(ctx, root.RequestID, "audit", "preserved"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	provider.mu.RLock()
+	retention = provider.ttls[rootKey]
+	provider.mu.RUnlock()
+	if retention != 14*24*time.Hour {
+		t.Fatalf("provider metadata rewrite TTL = %v, want 14d", retention)
+	}
+}
+
+func TestDirectRedisContentRewritesPreservePromotedTTL(t *testing.T) {
+	config := DefaultExecutionStoreConfig()
+	config.TTL = time.Hour
+	config.ErrorTTL = 7 * time.Hour
+	mr, store := newRedisExecutionConversationTestStore(t, config)
+	ctx := context.Background()
+
+	root := sampleExecution("rewrite-root", true)
+	if err := store.Store(ctx, root); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if err := store.ExtendTTL(ctx, root.RequestID, 14*24*time.Hour); err != nil {
+		t.Fatalf("ExtendTTL: %v", err)
+	}
+
+	root.OriginalRequest = "updated"
+	if err := store.Update(ctx, root.RequestID, root); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if err := store.SetMetadata(ctx, root.RequestID, "audit", "retained"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	if got := mr.TTL(store.recordKey(root.RequestID)); got != 14*24*time.Hour {
+		t.Fatalf("record TTL after rewrites = %v, want 14d", got)
+	}
+
+	if err := store.client.Persist(ctx, store.recordKey(root.RequestID)).Err(); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	if err := store.SetMetadata(ctx, root.RequestID, "persistent", "true"); err != nil {
+		t.Fatalf("SetMetadata persistent: %v", err)
+	}
+	if got := mr.TTL(store.recordKey(root.RequestID)); got != 0 {
+		t.Fatalf("persistent record gained TTL %v", got)
+	}
+}
+
+func TestDirectRedisMissingRootIsNotCreated(t *testing.T) {
+	config := DefaultExecutionStoreConfig()
+	_, store := newRedisExecutionConversationTestStore(t, config)
+	logger := &TestLogger{}
+	store.logger = logger
+	ctx := context.Background()
+	child := sampleExecution("child-with-missing-root", false)
+	child.OriginalRequestID = "missing-root"
+	if err := store.Store(ctx, child); err != nil {
+		t.Fatalf("child Store: %v", err)
+	}
+	if exists, err := store.client.Exists(ctx, store.recordKey("missing-root")).Result(); err != nil || exists != 0 {
+		t.Fatalf("missing root existence = (%d, %v), want absent", exists, err)
+	}
+	if logs := logger.GetLogsByOperation("execution_store_lineage_retention"); len(logs) != 0 {
+		t.Fatalf("expected missing root emitted warnings: %#v", logs)
+	}
+	if _, err := store.Get(ctx, "missing-root"); !errors.Is(err, ErrExecutionRecordNotFound) {
+		t.Fatalf("missing Get error = %v, want typed not-found", err)
+	}
+}
+
+func TestAtomicMinimumTTLConcurrentRequestsKeepLongest(t *testing.T) {
+	config := DefaultExecutionStoreConfig()
+	_, store := newRedisExecutionConversationTestStore(t, config)
+	ctx := context.Background()
+	key := "concurrent-retention"
+	if err := store.client.Set(ctx, key, "value", time.Minute).Err(); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for index := 0; index < 40; index++ {
+		requested := time.Hour
+		if index%2 == 0 {
+			requested = 14 * 24 * time.Hour
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := extendRedisKeyMinimumTTL(ctx, store.client, key, requested); err != nil {
+				t.Errorf("extend minimum TTL: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if ttl, err := store.client.TTL(ctx, key).Result(); err != nil || ttl < 14*24*time.Hour-time.Second {
+		t.Fatalf("final TTL = (%v, %v), want at least 14d", ttl, err)
+	}
+}
+
+func TestRedisLLMRetentionIsNonDowngradingAndTypedWhenMissing(t *testing.T) {
+	mr, store := setupRedisLLMDebugTestStore(t)
+	ctx := context.Background()
+	requestID := "llm-retention"
+	if err := store.RecordInteraction(ctx, requestID, LLMInteraction{Success: true}); err != nil {
+		t.Fatalf("RecordInteraction: %v", err)
+	}
+	if err := store.ExtendTTL(ctx, requestID, 7*24*time.Hour); err != nil {
+		t.Fatalf("ExtendTTL: %v", err)
+	}
+	if err := store.RecordInteraction(ctx, requestID, LLMInteraction{Success: true}); err != nil {
+		t.Fatalf("second RecordInteraction: %v", err)
+	}
+	for _, key := range []string{
+		store.recordPrefix() + requestID + llmDebugMetaSuffix,
+		store.recordPrefix() + requestID + llmDebugInterSuffix,
+	} {
+		if got := mr.TTL(key); got != 7*24*time.Hour {
+			t.Fatalf("%s TTL = %v, want 7d", key, got)
+		}
+	}
+	legacyID := "legacy-llm-retention"
+	legacyData, err := store.serialize(&LLMDebugRecord{
+		RequestID: legacyID,
+		CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("serialize legacy record: %v", err)
+	}
+	legacyKey := store.recordPrefix() + legacyID
+	if err := store.client.Set(ctx, legacyKey, legacyData, time.Hour).Err(); err != nil {
+		t.Fatalf("seed legacy record: %v", err)
+	}
+	if err := store.ExtendTTL(ctx, legacyID, 7*24*time.Hour); err != nil {
+		t.Fatalf("extend legacy record: %v", err)
+	}
+	if got := mr.TTL(legacyKey); got != 7*24*time.Hour {
+		t.Fatalf("legacy record TTL = %v, want 7d", got)
+	}
+
+	missingID := "llm-record-does-not-exist"
+	err = store.ExtendTTL(ctx, missingID, time.Hour)
+	if !errors.Is(err, ErrLLMDebugRecordNotFound) {
+		t.Fatalf("missing ExtendTTL error = %v, want typed not-found", err)
+	}
+	keys, scanErr := store.client.Keys(ctx, "*"+missingID+"*").Result()
+	if scanErr != nil || len(keys) != 0 {
+		t.Fatalf("missing extension created keys = (%v, %v)", keys, scanErr)
+	}
+}
+
+func TestRedisLLMRetentionFloorRepairsShorterExistingKeys(t *testing.T) {
+	mr, store := setupRedisLLMDebugTestStore(t)
+	ctx := context.Background()
+	const requestID = "llm-retention-floor-repair"
+	const promotedTTL = 14 * 24 * time.Hour
+	if err := store.PreserveRetention(ctx, requestID, promotedTTL); err != nil {
+		t.Fatalf("PreserveRetention: %v", err)
+	}
+	if err := store.RecordInteraction(
+		ctx,
+		requestID,
+		LLMInteraction{Type: "late_writer", Success: true},
+	); err != nil {
+		t.Fatalf("RecordInteraction: %v", err)
+	}
+	keys := []string{
+		store.recordPrefix() + requestID + llmDebugMetaSuffix,
+		store.recordPrefix() + requestID + llmDebugInterSuffix,
+	}
+	for _, key := range keys {
+		mr.SetTTL(key, time.Hour)
+	}
+	if err := store.PreserveRetention(ctx, requestID, time.Hour); err != nil {
+		t.Fatalf("shorter PreserveRetention: %v", err)
+	}
+	for _, key := range keys {
+		if got := mr.TTL(key); got != promotedTTL {
+			t.Fatalf("%s repaired TTL = %v, want %v", key, got, promotedTTL)
+		}
+	}
+}
+
+func TestRedisSetWithMinimumTTLPreservesPersistentKey(t *testing.T) {
+	_, store := newRedisExecutionConversationTestStore(t, DefaultExecutionStoreConfig())
+	ctx := context.Background()
+	key := "persistent-rewrite"
+	if err := store.client.Set(ctx, key, "before", 0).Err(); err != nil {
+		t.Fatalf("seed persistent key: %v", err)
+	}
+	if err := setRedisValueWithMinimumTTL(ctx, store.client, key, "after", time.Hour); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if ttl, err := store.client.TTL(ctx, key).Result(); err != nil || ttl != redisTTLPersistent {
+		t.Fatalf("persistent TTL = (%v, %v)", ttl, err)
+	}
+	if value, err := store.client.Get(ctx, key).Result(); err != nil || value != "after" {
+		t.Fatalf("rewritten value = (%q, %v)", value, err)
+	}
+}

--- a/orchestration/execution_record_terminal_test.go
+++ b/orchestration/execution_record_terminal_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -110,7 +111,7 @@ func (hook *terminalHook) AfterSynthesis(
 	hook.mu.Lock()
 	hook.finished = true
 	hook.mu.Unlock()
-	return response, nil
+	return "governed: " + response, nil
 }
 
 func (hook *terminalHook) Finished() bool {
@@ -231,9 +232,11 @@ func TestRequestDeliveryModesPersistTerminalPostSynthesisView(t *testing.T) {
 
 			records, terminalBeforeHookEnd := store.snapshot()
 			terminalCount := 0
+			var terminalRecord *StoredExecution
 			for _, record := range records {
 				if storedExecutionHasResultTrim(record) {
 					terminalCount++
+					terminalRecord = record
 				}
 			}
 			if terminalCount != 1 {
@@ -244,6 +247,17 @@ func TestRequestDeliveryModesPersistTerminalPostSynthesisView(t *testing.T) {
 			}
 			if hook.Finished() != test.wantHookCalls {
 				t.Fatalf("AfterSynthesis finished = %v, want %v", hook.Finished(), test.wantHookCalls)
+			}
+			if test.wantHookCalls {
+				if terminalRecord == nil || terminalRecord.FinalResponse == nil ||
+					!strings.HasPrefix(*terminalRecord.FinalResponse, "governed: ") {
+					t.Fatalf("terminal final response = %#v, want governed post-hook output", terminalRecord)
+				}
+				if terminalRecord.FinalResponseSource != FinalResponseSourceAfterSynthesisHooks {
+					t.Errorf("final response source = %q", terminalRecord.FinalResponseSource)
+				}
+			} else if terminalRecord != nil && terminalRecord.FinalResponse != nil {
+				t.Errorf("partial/failed synthesis stored authoritative final response: %q", *terminalRecord.FinalResponse)
 			}
 		})
 	}

--- a/orchestration/execution_recorder.go
+++ b/orchestration/execution_recorder.go
@@ -3,6 +3,7 @@ package orchestration
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 	"time"
 
@@ -22,21 +23,27 @@ type executionRecordSnapshot struct {
 	ConversationID     string
 	CheckpointID       string
 	Interrupted        bool
+	RetentionTTL       time.Duration
 }
 
 type executionRecorder struct {
-	mu       sync.Mutex
-	tail     <-chan struct{}
-	lifetime context.Context
-	store    ExecutionStore
-	logger   core.Logger
-	wg       *sync.WaitGroup
-	timeout  time.Duration
+	mu         sync.Mutex
+	tail       <-chan struct{}
+	lifetime   context.Context
+	store      ExecutionStore
+	debugStore LLMDebugStore
+	logger     core.Logger
+	wg         *sync.WaitGroup
+	timeout    time.Duration
+
+	retentionMu     sync.Mutex
+	retentionFloors map[string]time.Duration
 }
 
 func newExecutionRecorder(
 	lifetime context.Context,
 	store ExecutionStore,
+	debugStore LLMDebugStore,
 	logger core.Logger,
 	wg *sync.WaitGroup,
 	timeout time.Duration,
@@ -47,7 +54,15 @@ func newExecutionRecorder(
 	if timeout <= 0 {
 		timeout = defaultExecutionStoreWriteTimeout
 	}
-	return &executionRecorder{lifetime: lifetime, store: store, logger: logger, wg: wg, timeout: timeout}
+	return &executionRecorder{
+		lifetime:        lifetime,
+		store:           store,
+		debugStore:      debugStore,
+		logger:          logger,
+		wg:              wg,
+		timeout:         timeout,
+		retentionFloors: make(map[string]time.Duration),
+	}
 }
 
 func cloneStoredExecution(source *StoredExecution) (*StoredExecution, error) {
@@ -103,11 +118,105 @@ func (r *executionRecorder) Record(snapshot executionRecordSnapshot) {
 
 		base := telemetry.CopyBaggage(r.lifetime, snapshot.CorrelationContext)
 		storeCtx, cancel := context.WithTimeout(base, r.timeout)
-		defer cancel()
-		if err := r.store.Store(storeCtx, snapshot.Record); err != nil {
-			r.logFailure(snapshot, err, "store_write")
+		storeErr := r.store.Store(storeCtx, snapshot.Record)
+		cancel()
+		if storeErr != nil {
+			r.logFailure(snapshot, storeErr, "store_write")
 		}
+		r.preserveLLMDebugRetention(base, snapshot)
 	}()
+}
+
+func (r *executionRecorder) preserveLLMDebugRetention(
+	ctx context.Context,
+	snapshot executionRecordSnapshot,
+) {
+	if r == nil || r.debugStore == nil || snapshot.RetentionTTL <= 0 {
+		return
+	}
+	requestIDs := []string{snapshot.RequestID}
+	if rootID := relatedRootID(snapshot.Record); rootID != "" {
+		requestIDs = append(requestIDs, rootID)
+	}
+	if preserver, ok := r.debugStore.(LLMDebugRetentionPreserver); ok {
+		for _, requestID := range requestIDs {
+			if !r.retentionIncreaseNeeded(requestID, snapshot.RetentionTTL) {
+				continue
+			}
+			retentionCtx, cancel := context.WithTimeout(ctx, r.timeout)
+			err := preserver.PreserveRetention(
+				retentionCtx,
+				requestID,
+				snapshot.RetentionTTL,
+			)
+			cancel()
+			if err != nil {
+				r.logLLMRetentionFailure(snapshot, requestID, err)
+				continue
+			}
+			r.rememberRetentionFloor(requestID, snapshot.RetentionTTL)
+		}
+		return
+	}
+
+	// Compatibility path for custom stores that have not implemented the
+	// retention-floor capability. Built-in stateful stores use PreserveRetention.
+	for _, requestID := range requestIDs {
+		if !r.retentionIncreaseNeeded(requestID, snapshot.RetentionTTL) {
+			continue
+		}
+		retentionCtx, cancel := context.WithTimeout(ctx, r.timeout)
+		err := r.debugStore.ExtendTTL(retentionCtx, requestID, snapshot.RetentionTTL)
+		cancel()
+		if err != nil {
+			if errors.Is(err, ErrLLMDebugRecordNotFound) {
+				continue
+			}
+			r.logLLMRetentionFailure(snapshot, requestID, err)
+			continue
+		}
+		r.rememberRetentionFloor(requestID, snapshot.RetentionTTL)
+	}
+}
+
+func (r *executionRecorder) retentionIncreaseNeeded(
+	requestID string,
+	duration time.Duration,
+) bool {
+	r.retentionMu.Lock()
+	defer r.retentionMu.Unlock()
+	return r.retentionFloors[requestID] < duration
+}
+
+func (r *executionRecorder) rememberRetentionFloor(
+	requestID string,
+	duration time.Duration,
+) {
+	r.retentionMu.Lock()
+	defer r.retentionMu.Unlock()
+	if r.retentionFloors == nil {
+		r.retentionFloors = make(map[string]time.Duration)
+	}
+	if r.retentionFloors[requestID] < duration {
+		r.retentionFloors[requestID] = duration
+	}
+}
+
+func (r *executionRecorder) logLLMRetentionFailure(
+	snapshot executionRecordSnapshot,
+	requestID string,
+	err error,
+) {
+	if r == nil || r.logger == nil {
+		return
+	}
+	r.logger.Warn("Failed to preserve LLM debug evidence retention", map[string]interface{}{
+		"operation":            "llm_debug_lineage_retention",
+		"request_id":           requestID,
+		"execution_request_id": snapshot.RequestID,
+		"error_type":           "retention_extension",
+		"error":                safeExecutionStoreError(err),
+	})
 }
 
 func (r *executionRecorder) logFailure(snapshot executionRecordSnapshot, err error, errorType string) {

--- a/orchestration/execution_recorder_test.go
+++ b/orchestration/execution_recorder_test.go
@@ -68,7 +68,7 @@ func TestExecutionRecorder_OrdersAndDefensivelyClonesRequestWrites(t *testing.T)
 	lifetime, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	var wg sync.WaitGroup
-	recorder := newExecutionRecorder(lifetime, store, nil, &wg, time.Second)
+	recorder := newExecutionRecorder(lifetime, store, nil, nil, &wg, time.Second)
 
 	first := &StoredExecution{RequestID: "request", OriginalRequest: "first"}
 	recorder.Record(executionRecordSnapshot{Record: first, RequestID: "request"})
@@ -97,7 +97,7 @@ func TestExecutionRecorder_SharedLifetimeCancelsBlockedTail(t *testing.T) {
 	store := newOrderedExecutionStore()
 	lifetime, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
-	recorder := newExecutionRecorder(lifetime, store, nil, &wg, time.Second)
+	recorder := newExecutionRecorder(lifetime, store, nil, nil, &wg, time.Second)
 	recorder.Record(executionRecordSnapshot{
 		Record: &StoredExecution{RequestID: "request", OriginalRequest: "first"}, RequestID: "request",
 	})
@@ -173,6 +173,279 @@ type contextIgnoringExecutionStore struct {
 	started chan struct{}
 	release chan struct{}
 	exited  chan struct{}
+}
+
+type retentionRecordingLLMDebugStore struct {
+	*NoOpLLMDebugStore
+	mu         sync.Mutex
+	extensions map[string]time.Duration
+	calls      map[string]int
+	errors     map[string]error
+	called     chan string
+}
+
+type delayedExecutionStore struct {
+	*NoOpExecutionStore
+	delay time.Duration
+}
+
+type failingExecutionStore struct {
+	*NoOpExecutionStore
+}
+
+func (s *failingExecutionStore) Store(context.Context, *StoredExecution) error {
+	return errors.New("execution persistence unavailable")
+}
+
+func (s *delayedExecutionStore) Store(ctx context.Context, _ *StoredExecution) error {
+	select {
+	case <-time.After(s.delay):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type deadlineObservingRetentionStore struct {
+	*NoOpLLMDebugStore
+	remaining chan time.Duration
+}
+
+type firstTimeoutRetentionStore struct {
+	*NoOpLLMDebugStore
+	rootCalled chan struct{}
+}
+
+func (s *firstTimeoutRetentionStore) PreserveRetention(
+	ctx context.Context,
+	requestID string,
+	_ time.Duration,
+) error {
+	if requestID == "timeout-child" {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	if requestID == "timeout-root" {
+		close(s.rootCalled)
+	}
+	return nil
+}
+
+func (s *deadlineObservingRetentionStore) PreserveRetention(
+	ctx context.Context,
+	_ string,
+	_ time.Duration,
+) error {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return errors.New("retention context has no deadline")
+	}
+	s.remaining <- time.Until(deadline)
+	return nil
+}
+
+func newRetentionRecordingLLMDebugStore() *retentionRecordingLLMDebugStore {
+	return &retentionRecordingLLMDebugStore{
+		NoOpLLMDebugStore: NewNoOpLLMDebugStore(),
+		extensions:        make(map[string]time.Duration),
+		calls:             make(map[string]int),
+		errors:            make(map[string]error),
+		called:            make(chan string, 4),
+	}
+}
+
+func (s *retentionRecordingLLMDebugStore) ExtendTTL(
+	_ context.Context,
+	requestID string,
+	duration time.Duration,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.errors[requestID]; err != nil {
+		return err
+	}
+	s.extensions[requestID] = duration
+	s.calls[requestID]++
+	s.called <- requestID
+	return nil
+}
+
+func TestExecutionRecorderPreservesCurrentAndRootLLMEvidence(t *testing.T) {
+	debugStore := newRetentionRecordingLLMDebugStore()
+	var wg sync.WaitGroup
+	recorder := newExecutionRecorder(
+		context.Background(),
+		NewNoOpExecutionStore(),
+		debugStore,
+		nil,
+		&wg,
+		time.Second,
+	)
+	recorder.Record(executionRecordSnapshot{
+		Record: &StoredExecution{
+			RequestID:         "resume-request",
+			OriginalRequestID: "root-request",
+		},
+		RequestID:    "resume-request",
+		RetentionTTL: 7 * 24 * time.Hour,
+	})
+	wg.Wait()
+
+	debugStore.mu.Lock()
+	defer debugStore.mu.Unlock()
+	for _, requestID := range []string{"resume-request", "root-request"} {
+		if got := debugStore.extensions[requestID]; got != 7*24*time.Hour {
+			t.Fatalf("%s LLM retention = %v, want 7d", requestID, got)
+		}
+	}
+}
+
+func TestExecutionRecorderIgnoresTypedMissingLLMEvidence(t *testing.T) {
+	debugStore := newRetentionRecordingLLMDebugStore()
+	debugStore.errors["no-llm-request"] = ErrLLMDebugRecordNotFound
+	logger := &TestLogger{}
+	var wg sync.WaitGroup
+	recorder := newExecutionRecorder(
+		context.Background(),
+		NewNoOpExecutionStore(),
+		debugStore,
+		logger,
+		&wg,
+		time.Second,
+	)
+	recorder.Record(executionRecordSnapshot{
+		Record:       &StoredExecution{RequestID: "no-llm-request"},
+		RequestID:    "no-llm-request",
+		RetentionTTL: time.Hour,
+	})
+	wg.Wait()
+	if logs := logger.GetLogsByOperation("llm_debug_lineage_retention"); len(logs) != 0 {
+		t.Fatalf("typed missing LLM evidence emitted warnings: %#v", logs)
+	}
+}
+
+func TestExecutionRecorderSkipsRedundantRetentionRoundTrips(t *testing.T) {
+	debugStore := newRetentionRecordingLLMDebugStore()
+	var wg sync.WaitGroup
+	recorder := newExecutionRecorder(
+		context.Background(),
+		NewNoOpExecutionStore(),
+		debugStore,
+		nil,
+		&wg,
+		time.Second,
+	)
+	for _, ttl := range []time.Duration{time.Hour, time.Hour, 7 * time.Hour} {
+		recorder.Record(executionRecordSnapshot{
+			Record:       &StoredExecution{RequestID: "bounded-retention-writes"},
+			RequestID:    "bounded-retention-writes",
+			RetentionTTL: ttl,
+		})
+	}
+	wg.Wait()
+
+	debugStore.mu.Lock()
+	defer debugStore.mu.Unlock()
+	if got := debugStore.calls["bounded-retention-writes"]; got != 2 {
+		t.Fatalf("retention calls = %d, want one initial write and one increase", got)
+	}
+	if got := debugStore.extensions["bounded-retention-writes"]; got != 7*time.Hour {
+		t.Fatalf("final retention = %v, want 7h", got)
+	}
+}
+
+func TestExecutionRecorderGivesRetentionAnIndependentTimeout(t *testing.T) {
+	const timeout = 100 * time.Millisecond
+	debugStore := &deadlineObservingRetentionStore{
+		NoOpLLMDebugStore: NewNoOpLLMDebugStore(),
+		remaining:         make(chan time.Duration, 1),
+	}
+	var wg sync.WaitGroup
+	recorder := newExecutionRecorder(
+		context.Background(),
+		&delayedExecutionStore{
+			NoOpExecutionStore: NewNoOpExecutionStore(),
+			delay:              60 * time.Millisecond,
+		},
+		debugStore,
+		nil,
+		&wg,
+		timeout,
+	)
+	recorder.Record(executionRecordSnapshot{
+		Record:       &StoredExecution{RequestID: "independent-timeout"},
+		RequestID:    "independent-timeout",
+		RetentionTTL: time.Hour,
+	})
+	wg.Wait()
+
+	select {
+	case remaining := <-debugStore.remaining:
+		if remaining < 70*time.Millisecond {
+			t.Fatalf("retention inherited spent store timeout; remaining = %v", remaining)
+		}
+	default:
+		t.Fatal("retention preservation was not called")
+	}
+}
+
+func TestExecutionRecorderPreservesLLMEvidenceAfterExecutionStoreFailure(t *testing.T) {
+	debugStore := &deadlineObservingRetentionStore{
+		NoOpLLMDebugStore: NewNoOpLLMDebugStore(),
+		remaining:         make(chan time.Duration, 1),
+	}
+	var wg sync.WaitGroup
+	recorder := newExecutionRecorder(
+		context.Background(),
+		&failingExecutionStore{NoOpExecutionStore: NewNoOpExecutionStore()},
+		debugStore,
+		nil,
+		&wg,
+		time.Second,
+	)
+	recorder.Record(executionRecordSnapshot{
+		Record:       &StoredExecution{RequestID: "failed-execution-store"},
+		RequestID:    "failed-execution-store",
+		RetentionTTL: 7 * 24 * time.Hour,
+	})
+	wg.Wait()
+
+	select {
+	case <-debugStore.remaining:
+	default:
+		t.Fatal("execution store failure skipped independent LLM retention")
+	}
+}
+
+func TestExecutionRecorderUsesIndependentTimeoutForEachRetentionTarget(t *testing.T) {
+	debugStore := &firstTimeoutRetentionStore{
+		NoOpLLMDebugStore: NewNoOpLLMDebugStore(),
+		rootCalled:        make(chan struct{}),
+	}
+	var wg sync.WaitGroup
+	recorder := newExecutionRecorder(
+		context.Background(),
+		NewNoOpExecutionStore(),
+		debugStore,
+		nil,
+		&wg,
+		20*time.Millisecond,
+	)
+	recorder.Record(executionRecordSnapshot{
+		Record: &StoredExecution{
+			RequestID:         "timeout-child",
+			OriginalRequestID: "timeout-root",
+		},
+		RequestID:    "timeout-child",
+		RetentionTTL: time.Hour,
+	})
+	wg.Wait()
+
+	select {
+	case <-debugStore.rootCalled:
+	default:
+		t.Fatal("current-record timeout consumed the root retention deadline")
+	}
 }
 
 func newContextIgnoringExecutionStore() *contextIgnoringExecutionStore {

--- a/orchestration/execution_store.go
+++ b/orchestration/execution_store.go
@@ -14,12 +14,18 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/truvaagents/truva-g3/core"
 )
+
+// ErrExecutionRecordNotFound identifies the expected absence of an execution
+// debug record. Callers may use errors.Is to distinguish missing optional
+// evidence from storage failures.
+var ErrExecutionRecordNotFound = errors.New("execution record not found")
 
 // ExecutionStore stores execution records (plan + result) for debugging and visualization.
 // Implementations must be safe for concurrent use.
@@ -135,11 +141,23 @@ type StoredExecution struct {
 	// prompt content remains governed by the separate opt-in LLM debug store.
 	Skills *SkillExecutionDebug `json:"skills,omitempty"`
 
+	// FinalResponse is the terminal application response after AfterSynthesis
+	// hooks have run. It is intentionally separate from the raw synthesis
+	// interaction retained in the opt-in LLM debug store.
+	FinalResponse       *string `json:"final_response,omitempty"`
+	FinalResponseSource string  `json:"final_response_source,omitempty"`
+
 	// Metadata contains framework-owned correlation metadata plus optional
 	// application investigation metadata. MetadataConversationID is reserved
 	// for the immutable conversation identity captured at execution time.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
+
+// FinalResponseSourceAfterSynthesisHooks identifies a terminal response after
+// every registered AfterSynthesis hook has run. Keeping this as a named API
+// value prevents producers and observability consumers from inventing subtly
+// different spellings for the same response boundary.
+const FinalResponseSourceAfterSynthesisHooks = "after_synthesis_hooks"
 
 // ExecutionSummary is a lightweight version for listing.
 // Used by ListRecent to avoid loading full payloads.
@@ -232,6 +250,32 @@ type IndexTTLManager interface {
 	) error
 }
 
+// KeyTTLManager defines atomic retention maintenance for ordinary values.
+type KeyTTLManager interface {
+	// ExtendKeyTTL keeps an existing key for at least minTTL from now. It must
+	// not create a missing key, shorten a longer TTL, or expire a persistent key.
+	ExtendKeyTTL(ctx context.Context, key string, minTTL time.Duration) error
+
+	// SetKeyWithMinimumTTL atomically writes value and keeps the key for at
+	// least max(previous remaining TTL, minTTL). It creates a missing key with
+	// minTTL and preserves persistent keys as persistent.
+	SetKeyWithMinimumTTL(
+		ctx context.Context,
+		key string,
+		value string,
+		minTTL time.Duration,
+	) error
+}
+
+// ExecutionStorageProvider is the complete provider contract required by the
+// provider-backed execution store. Keeping the capabilities as small embedded
+// interfaces preserves composition while making retention correctness a
+// compile-time requirement.
+type ExecutionStorageProvider interface {
+	StorageProvider
+	KeyTTLManager
+}
+
 // ExecutionStoreConfig holds configuration for execution storage.
 // This is embedded in OrchestratorConfig.
 //
@@ -297,15 +341,15 @@ const (
 // executionStoreImpl is the default implementation of ExecutionStore
 // backed by a StorageProvider.
 type executionStoreImpl struct {
-	provider StorageProvider
+	provider ExecutionStorageProvider
 	config   ExecutionStoreConfig
 	logger   core.Logger
 }
 
-// NewExecutionStoreWithProvider creates an ExecutionStore backed by the given StorageProvider.
-// This is the recommended way to create an ExecutionStore - the application provides
-// the storage backend implementation (Redis, PostgreSQL, etc.).
-func NewExecutionStoreWithProvider(provider StorageProvider, config ExecutionStoreConfig, logger core.Logger) ExecutionStore {
+// NewExecutionStoreWithProvider creates an ExecutionStore backed by the given
+// ExecutionStorageProvider. The application provides a backend implementation
+// (Redis, PostgreSQL, etc.) with atomic minimum-retention operations.
+func NewExecutionStoreWithProvider(provider ExecutionStorageProvider, config ExecutionStoreConfig, logger core.Logger) ExecutionStore {
 	config = normalizeExecutionStoreConfig(config)
 	return &executionStoreImpl{
 		provider: provider,
@@ -315,6 +359,13 @@ func NewExecutionStoreWithProvider(provider StorageProvider, config ExecutionSto
 }
 
 func normalizeExecutionStoreConfig(config ExecutionStoreConfig) ExecutionStoreConfig {
+	defaults := DefaultExecutionStoreConfig()
+	if config.TTL <= 0 {
+		config.TTL = defaults.TTL
+	}
+	if config.ErrorTTL <= 0 {
+		config.ErrorTTL = defaults.ErrorTTL
+	}
 	config.KeyPrefix = normalizeExecutionKeyPrefix(config.KeyPrefix)
 	if config.ConversationQueryLimit <= 0 {
 		config.ConversationQueryLimit = defaultConversationQueryLimit
@@ -366,6 +417,10 @@ func (s *executionStoreImpl) traceKey(traceID string) string {
 	return s.config.KeyPrefix + "trace:" + traceID
 }
 
+func (s *executionStoreImpl) retentionLinkKey(requestID string) string {
+	return executionRetentionLinkKey(s.config.KeyPrefix, requestID)
+}
+
 func (s *executionStoreImpl) conversationIndexKey(conversationID string) string {
 	return executionConversationIndexKey(s.config.KeyPrefix, conversationID)
 }
@@ -373,6 +428,129 @@ func (s *executionStoreImpl) conversationIndexKey(conversationID string) string 
 func executionConversationIndexKey(prefix, conversationID string) string {
 	digest := sha256.Sum256([]byte(conversationID))
 	return normalizeExecutionKeyPrefix(prefix) + fmt.Sprintf("conversation:%x", digest)
+}
+
+func executionRetentionLinkKey(prefix, requestID string) string {
+	digest := sha256.Sum256([]byte(requestID))
+	return normalizeExecutionKeyPrefix(prefix) + fmt.Sprintf("retention:%x", digest)
+}
+
+// executionRetentionLink is the small, backend-neutral projection needed to
+// preserve an execution's related evidence. Keeping it beside the full record
+// avoids loading and decoding a potentially large debug payload merely to
+// extend retention.
+type executionRetentionLink struct {
+	TraceID           string `json:"trace_id,omitempty"`
+	ConversationID    string `json:"conversation_id,omitempty"`
+	OriginalRequestID string `json:"original_request_id,omitempty"`
+}
+
+func executionRetentionLinkFromStored(execution *StoredExecution) executionRetentionLink {
+	return executionRetentionLink{
+		TraceID:           execution.TraceID,
+		ConversationID:    ExecutionConversationID(execution),
+		OriginalRequestID: relatedRootID(execution),
+	}
+}
+
+func marshalExecutionRetentionLink(execution *StoredExecution) (string, error) {
+	encoded, err := json.Marshal(executionRetentionLinkFromStored(execution))
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal execution retention link: %w", err)
+	}
+	return string(encoded), nil
+}
+
+func unmarshalExecutionRetentionLink(encoded string) (executionRetentionLink, error) {
+	var link executionRetentionLink
+	if err := json.Unmarshal([]byte(encoded), &link); err != nil {
+		return executionRetentionLink{}, fmt.Errorf("failed to unmarshal execution retention link: %w", err)
+	}
+	return link, nil
+}
+
+func maxDuration(left, right time.Duration) time.Duration {
+	if left >= right {
+		return left
+	}
+	return right
+}
+
+func executionRetentionTTL(
+	execution *StoredExecution,
+	normalTTL time.Duration,
+	errorTTL time.Duration,
+) time.Duration {
+	return executionRetentionTTLAt(execution, normalTTL, errorTTL, time.Now())
+}
+
+func executionRetentionTTLAt(
+	execution *StoredExecution,
+	normalTTL time.Duration,
+	errorTTL time.Duration,
+	now time.Time,
+) time.Duration {
+	if execution == nil {
+		return normalTTL
+	}
+	if execution.Interrupted {
+		retention := maxDuration(normalTTL, errorTTL)
+		if execution.Checkpoint != nil && execution.Checkpoint.ExpiresAt.After(now) {
+			retention = maxDuration(retention, execution.Checkpoint.ExpiresAt.Sub(now))
+		}
+		return retention
+	}
+	if execution.Result != nil && !execution.Result.Success {
+		return errorTTL
+	}
+	return normalTTL
+}
+
+func relatedRootID(execution *StoredExecution) string {
+	if execution == nil {
+		return ""
+	}
+	rootID := strings.TrimSpace(execution.OriginalRequestID)
+	if rootID == "" || rootID == execution.RequestID {
+		return ""
+	}
+	return rootID
+}
+
+func logLineageRetentionFailure(
+	ctx context.Context,
+	logger core.Logger,
+	execution *StoredExecution,
+	err error,
+) {
+	if logger == nil || execution == nil || err == nil ||
+		errors.Is(err, ErrExecutionRecordNotFound) {
+		return
+	}
+	logger.WarnWithContext(ctx, "Failed to preserve related execution root", map[string]interface{}{
+		"operation":           "execution_store_lineage_retention",
+		"request_id":          execution.RequestID,
+		"original_request_id": relatedRootID(execution),
+		"error_type":          "retention_extension",
+		"error":               safeExecutionStoreError(err),
+	})
+}
+
+func logExecutionRetentionLinkFailure(
+	ctx context.Context,
+	logger core.Logger,
+	requestID string,
+	err error,
+) {
+	if logger == nil || err == nil {
+		return
+	}
+	logger.WarnWithContext(ctx, "Failed to store execution retention link", map[string]interface{}{
+		"operation":  "execution_store_retention_link",
+		"request_id": requestID,
+		"error_type": "retention_link_write",
+		"error":      safeExecutionStoreError(err),
+	})
 }
 
 func sanitizeExecutionConversationMetadata(
@@ -459,6 +637,10 @@ func (s *executionStoreImpl) Store(ctx context.Context, execution *StoredExecuti
 		return fmt.Errorf("request_id is required")
 	}
 	storedExecution, conversationID := sanitizeExecutionConversationMetadata(execution)
+	retentionLink, err := marshalExecutionRetentionLink(storedExecution)
+	if err != nil {
+		return err
+	}
 
 	// Serialize to JSON
 	data, err := json.Marshal(storedExecution)
@@ -466,20 +648,24 @@ func (s *executionStoreImpl) Store(ctx context.Context, execution *StoredExecuti
 		return fmt.Errorf("failed to marshal execution: %w", err)
 	}
 
-	// Determine TTL based on success/failure.
-	// ORCH-022: interrupted records have Result.Success == false after the
-	// orchestrator fix (Result was nil pre-fix, bypassing this branch). Carve
-	// them out so pending HITL approvals keep the default TTL rather than the
-	// shorter ErrorTTL.
-	ttl := s.config.TTL
-	if storedExecution.Result != nil && !storedExecution.Result.Success && !storedExecution.Interrupted {
-		ttl = s.config.ErrorTTL
-	}
+	ttl := executionRetentionTTL(storedExecution, s.config.TTL, s.config.ErrorTTL)
 
 	// Store the main record
 	key := s.recordKey(storedExecution.RequestID)
-	if err := s.provider.Set(ctx, key, string(data), ttl); err != nil {
-		return fmt.Errorf("failed to store execution: %w", err)
+	storeErr := s.provider.SetKeyWithMinimumTTL(ctx, key, string(data), ttl)
+	if storeErr != nil {
+		return fmt.Errorf("failed to store execution: %w", storeErr)
+	}
+	if err := s.provider.SetKeyWithMinimumTTL(
+		ctx,
+		s.retentionLinkKey(storedExecution.RequestID),
+		retentionLink,
+		ttl,
+	); err != nil {
+		// The primary execution is authoritative. Retention extension can recover
+		// from a missing projection by reading that record, so do not report a
+		// failed Store after the primary write has already succeeded.
+		logExecutionRetentionLinkFailure(ctx, s.logger, storedExecution.RequestID, err)
 	}
 
 	// Add to index (sorted set by timestamp)
@@ -527,16 +713,28 @@ func (s *executionStoreImpl) Store(ctx context.Context, execution *StoredExecuti
 	// Store trace ID mapping if available
 	if storedExecution.TraceID != "" {
 		traceKey := s.traceKey(storedExecution.TraceID)
-		if err := s.provider.Set(ctx, traceKey, storedExecution.RequestID, ttl); err != nil {
+		traceErr := s.provider.SetKeyWithMinimumTTL(
+			ctx,
+			traceKey,
+			storedExecution.RequestID,
+			ttl,
+		)
+		if traceErr != nil {
 			if s.logger != nil {
 				s.logger.Warn("Failed to store trace ID mapping", map[string]interface{}{
 					"operation":  "execution_store_trace",
 					"request_id": storedExecution.RequestID,
 					"trace_id":   storedExecution.TraceID,
-					"error":      err.Error(),
+					"error":      safeExecutionStoreError(traceErr),
 				})
 			}
 			// Continue - main record is stored
+		}
+	}
+
+	if rootID := relatedRootID(storedExecution); rootID != "" {
+		if err := s.ExtendTTL(ctx, rootID, ttl); err != nil {
+			logLineageRetentionFailure(ctx, s.logger, storedExecution, err)
 		}
 	}
 
@@ -555,7 +753,7 @@ func (s *executionStoreImpl) Get(ctx context.Context, requestID string) (*Stored
 		return nil, fmt.Errorf("failed to get execution: %w", err)
 	}
 	if data == "" {
-		return nil, fmt.Errorf("execution not found: %s", requestID)
+		return nil, fmt.Errorf("%w: %s", ErrExecutionRecordNotFound, requestID)
 	}
 
 	var execution StoredExecution
@@ -579,7 +777,7 @@ func (s *executionStoreImpl) GetByTraceID(ctx context.Context, traceID string) (
 		return nil, fmt.Errorf("failed to lookup trace: %w", err)
 	}
 	if requestID == "" {
-		return nil, fmt.Errorf("execution not found for trace: %s", traceID)
+		return nil, fmt.Errorf("%w for trace: %s", ErrExecutionRecordNotFound, traceID)
 	}
 
 	// Get the execution by request ID
@@ -613,57 +811,74 @@ func (s *executionStoreImpl) SetMetadata(ctx context.Context, requestID string, 
 		return fmt.Errorf("failed to marshal execution: %w", err)
 	}
 
-	// Use original TTL (we can't know the remaining TTL without Redis-specific commands).
-	// ORCH-022: interrupted records have Result.Success == false after the
-	// orchestrator fix — carve them out so pending HITL approvals keep the
-	// default TTL rather than the shorter ErrorTTL.
-	ttl := s.config.TTL
-	if execution.Result != nil && !execution.Result.Success && !execution.Interrupted {
-		ttl = s.config.ErrorTTL
-	}
+	ttl := executionRetentionTTL(execution, s.config.TTL, s.config.ErrorTTL)
 
 	storeKey := s.recordKey(requestID)
-	return s.provider.Set(ctx, storeKey, string(data), ttl)
+	return s.provider.SetKeyWithMinimumTTL(ctx, storeKey, string(data), ttl)
 }
 
 // ExtendTTL extends retention for investigation.
 func (s *executionStoreImpl) ExtendTTL(ctx context.Context, requestID string, duration time.Duration) error {
-	// Get existing record
-	execution, err := s.Get(ctx, requestID)
+	if requestID == "" {
+		return fmt.Errorf("request_id is required")
+	}
+	if duration <= 0 {
+		return fmt.Errorf("duration must be positive")
+	}
+
+	return s.extendTTL(ctx, requestID, duration, make(map[string]struct{}), true)
+}
+
+func (s *executionStoreImpl) extendTTL(
+	ctx context.Context,
+	requestID string,
+	duration time.Duration,
+	visited map[string]struct{},
+	required bool,
+) error {
+	if _, seen := visited[requestID]; seen {
+		return nil
+	}
+	visited[requestID] = struct{}{}
+
+	exists, err := s.provider.Exists(ctx, s.recordKey(requestID))
 	if err != nil {
+		return fmt.Errorf("failed to check execution retention target: %w", err)
+	}
+	if !exists {
+		if !required {
+			return nil
+		}
+		return fmt.Errorf("%w: %s", ErrExecutionRecordNotFound, requestID)
+	}
+
+	linkKey := s.retentionLinkKey(requestID)
+	link, err := s.loadExecutionRetentionLink(ctx, requestID, linkKey)
+	if err != nil {
+		if !required && errors.Is(err, ErrExecutionRecordNotFound) {
+			return nil
+		}
 		return err
 	}
-
-	// Re-serialize and store with new TTL
-	data, err := json.Marshal(execution)
-	if err != nil {
-		return fmt.Errorf("failed to marshal execution: %w", err)
-	}
-
-	storeKey := s.recordKey(requestID)
-	if err := s.provider.Set(ctx, storeKey, string(data), duration); err != nil {
+	if err := s.provider.ExtendKeyTTL(ctx, s.recordKey(requestID), duration); err != nil {
 		return err
 	}
-
-	// Also extend trace ID mapping TTL if present
-	if execution.TraceID != "" {
-		traceKey := s.traceKey(execution.TraceID)
-		if err := s.provider.Set(ctx, traceKey, requestID, duration); err != nil {
-			if s.logger != nil {
-				s.logger.Warn("Failed to extend trace ID mapping TTL", map[string]interface{}{
-					"operation":  "execution_store_extend_ttl",
-					"request_id": requestID,
-					"trace_id":   execution.TraceID,
-					"error":      err.Error(),
-				})
-			}
-			// Continue - main record TTL is extended
+	if err := s.provider.ExtendKeyTTL(ctx, linkKey, duration); err != nil {
+		return err
+	}
+	if link.TraceID != "" {
+		if err := s.provider.ExtendKeyTTL(ctx, s.traceKey(link.TraceID), duration); err != nil && s.logger != nil {
+			s.logger.Warn("Failed to extend trace ID mapping TTL", map[string]interface{}{
+				"operation":  "execution_store_extend_ttl",
+				"request_id": requestID,
+				"trace_id":   link.TraceID,
+				"error":      safeExecutionStoreError(err),
+			})
 		}
 	}
-
-	if conversationID := ExecutionConversationID(execution); conversationID != "" {
+	if link.ConversationID != "" {
 		if ttlManager, ok := s.provider.(IndexTTLManager); ok {
-			conversationKey := s.conversationIndexKey(conversationID)
+			conversationKey := s.conversationIndexKey(link.ConversationID)
 			if err := ttlManager.ExtendIndexTTL(ctx, conversationKey, duration); err != nil && s.logger != nil {
 				s.logger.WarnWithContext(ctx, "Failed to extend conversation index TTL", map[string]interface{}{
 					"operation":  "execution_store_conversation_index_ttl",
@@ -674,8 +889,31 @@ func (s *executionStoreImpl) ExtendTTL(ctx context.Context, requestID string, du
 			}
 		}
 	}
-
+	if rootID := strings.TrimSpace(link.OriginalRequestID); rootID != "" && rootID != requestID {
+		return s.extendTTL(ctx, rootID, duration, visited, false)
+	}
 	return nil
+}
+
+func (s *executionStoreImpl) loadExecutionRetentionLink(
+	ctx context.Context,
+	requestID string,
+	linkKey string,
+) (executionRetentionLink, error) {
+	encoded, err := s.provider.Get(ctx, linkKey)
+	if err != nil {
+		return executionRetentionLink{}, fmt.Errorf("failed to get execution retention link: %w", err)
+	}
+	if encoded != "" {
+		return unmarshalExecutionRetentionLink(encoded)
+	}
+
+	// Compatibility fallback for records stored before retention links existed.
+	execution, err := s.Get(ctx, requestID)
+	if err != nil {
+		return executionRetentionLink{}, err
+	}
+	return executionRetentionLinkFromStored(execution), nil
 }
 
 // ListRecent returns recent records for UI listing.

--- a/orchestration/execution_store_test.go
+++ b/orchestration/execution_store_test.go
@@ -2,6 +2,7 @@ package orchestration
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"sync"
@@ -13,6 +14,7 @@ import (
 type mockStorageProvider struct {
 	mu                 sync.RWMutex
 	data               map[string]string
+	ttls               map[string]time.Duration
 	indexes            map[string]map[string]float64 // Sorted indexes (was zsets)
 	setErr             error
 	getErr             error
@@ -23,6 +25,7 @@ type mockStorageProvider struct {
 func newMockStorageProvider() *mockStorageProvider {
 	return &mockStorageProvider{
 		data:    make(map[string]string),
+		ttls:    make(map[string]time.Duration),
 		indexes: make(map[string]map[string]float64),
 	}
 }
@@ -42,7 +45,58 @@ func (m *mockStorageProvider) Set(ctx context.Context, key string, value string,
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.ttls == nil {
+		m.ttls = make(map[string]time.Duration)
+	}
 	m.data[key] = value
+	m.ttls[key] = ttl
+	return nil
+}
+
+func (m *mockStorageProvider) ExtendKeyTTL(
+	_ context.Context,
+	key string,
+	minTTL time.Duration,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.ttls == nil {
+		m.ttls = make(map[string]time.Duration)
+	}
+	if _, exists := m.data[key]; !exists {
+		return nil
+	}
+	current := m.ttls[key]
+	if current == 0 || current >= minTTL {
+		return nil
+	}
+	m.ttls[key] = minTTL
+	return nil
+}
+
+func (m *mockStorageProvider) SetKeyWithMinimumTTL(
+	_ context.Context,
+	key string,
+	value string,
+	minTTL time.Duration,
+) error {
+	if m.setErr != nil {
+		return m.setErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.ttls == nil {
+		m.ttls = make(map[string]time.Duration)
+	}
+	current, exists := m.ttls[key]
+	m.data[key] = value
+	if exists && current == 0 {
+		m.ttls[key] = 0
+	} else if exists && current > minTTL {
+		m.ttls[key] = current
+	} else {
+		m.ttls[key] = minTTL
+	}
 	return nil
 }
 
@@ -51,6 +105,7 @@ func (m *mockStorageProvider) Del(ctx context.Context, keys ...string) error {
 	defer m.mu.Unlock()
 	for _, key := range keys {
 		delete(m.data, key)
+		delete(m.ttls, key)
 	}
 	return nil
 }
@@ -202,6 +257,34 @@ func TestExecutionStore_Store(t *testing.T) {
 	traceKey := DefaultExecutionKeyPrefix + "trace:" + execution.TraceID
 	if provider.data[traceKey] != execution.RequestID {
 		t.Errorf("Trace mapping not stored: got %q, want %q", provider.data[traceKey], execution.RequestID)
+	}
+}
+
+func TestExecutionStore_StorePreservesFinalResponse(t *testing.T) {
+	provider := newMockStorageProvider()
+	store := NewExecutionStoreWithProvider(provider, DefaultExecutionStoreConfig(), nil)
+	execution := sampleExecution("req-final-response-fidelity", true)
+	finalResponse := `The application returned password=local-debug-value`
+	execution.FinalResponse = &finalResponse
+	execution.FinalResponseSource = FinalResponseSourceAfterSynthesisHooks
+
+	if err := store.Store(context.Background(), execution); err != nil {
+		t.Fatalf("Store failed: %v", err)
+	}
+
+	var persisted StoredExecution
+	key := DefaultExecutionKeyPrefix + execution.RequestID
+	if err := json.Unmarshal([]byte(provider.data[key]), &persisted); err != nil {
+		t.Fatalf("decode persisted execution: %v", err)
+	}
+	if persisted.FinalResponse == nil {
+		t.Fatal("persisted final response is nil")
+	}
+	if *persisted.FinalResponse != finalResponse {
+		t.Errorf("persisted final response = %q, want %q", *persisted.FinalResponse, finalResponse)
+	}
+	if *execution.FinalResponse != finalResponse {
+		t.Errorf("runtime final response was mutated: %q", *execution.FinalResponse)
 	}
 }
 

--- a/orchestration/executor.go
+++ b/orchestration/executor.go
@@ -3333,6 +3333,11 @@ func (e *SmartExecutor) executeStep(ctx context.Context, step RoutingStep) StepR
 				})
 			}
 			result.Success = true
+			// A StepResult describes the terminal attempt, not its retry
+			// history. Clear an earlier attempt's error before publishing a
+			// successful result so consumers never receive Success=true and a
+			// stale failure at the same time.
+			result.Error = ""
 			result.Response = response
 
 			// Aggregate child orchestrator's token usage into parent accumulator
@@ -3355,7 +3360,12 @@ func (e *SmartExecutor) executeStep(ctx context.Context, step RoutingStep) StepR
 		// in an upstream URL or error body from spreading through the lifecycle.
 		responseBody = core.RedactSensitiveText(responseBody)
 		err = sanitizeExecutionError(err)
-
+		// Preserve the sanitized component failure before any analyzer or
+		// non-retryable branch can exit the loop. Several intentional 4xx
+		// guards (including stale HITL decision bases) stop before the legacy
+		// retry block below; leaving Error empty makes downstream callbacks
+		// unable to classify the authoritative tool outcome.
+		result.Error = err.Error()
 		// Layer 3: LLM-based Error Analysis (Phase 4 Enhancement)
 		// When ErrorAnalyzer is configured, use LLM to determine if error can be fixed
 		// with different parameters. This replaces the need for tools to set Retryable flags.

--- a/orchestration/executor_test.go
+++ b/orchestration/executor_test.go
@@ -365,6 +365,9 @@ func TestSmartExecutor_Retry(t *testing.T) {
 	if !result.Success {
 		t.Errorf("Expected successful execution after retries, got: %s", result.Error)
 	}
+	if result.Error != "" {
+		t.Errorf("successful retry retained stale error: %q", result.Error)
+	}
 
 	if result.Attempts != 2 {
 		t.Errorf("Expected 2 attempts (succeeds on retry 1), got %d", result.Attempts)
@@ -426,6 +429,153 @@ func TestSmartExecutor_OrchestratorNoRetry(t *testing.T) {
 	}
 	if result.Success {
 		t.Error("Expected failure (orchestrator should not retry)")
+	}
+}
+
+func TestSmartExecutor_PreservesNonRetryableComponentError(t *testing.T) {
+	catalog := &AgentCatalog{agents: map[string]*AgentInfo{
+		"tool-1": {
+			Registration: &core.ServiceRegistration{ID: "tool-1", Name: "guarded-tool", Address: "localhost", Port: 8080},
+			Capabilities: []EnhancedCapability{{Name: "execute_guarded_action", Endpoint: "/execute"}},
+		},
+	}}
+	executor := NewSmartExecutor(catalog)
+	mockRT := NewMockRoundTripper()
+	mockRT.SetResponse("http://localhost:8080/execute", http.StatusConflict, `{"success":false,"error":{"code":"DECISION_BASIS_CHANGED","message":"decision basis changed","retryable":false}}`)
+	executor.httpClient = &http.Client{Transport: mockRT}
+	step := RoutingStep{StepID: "execute", AgentName: "guarded-tool", Metadata: map[string]interface{}{
+		"capability": "execute_guarded_action", "parameters": map[string]interface{}{"operation_reference": "ref-1"},
+	}}
+
+	result := executor.executeStep(context.Background(), step)
+	if result.Success {
+		t.Fatal("expected guarded component failure")
+	}
+	if !strings.Contains(result.Error, "DECISION_BASIS_CHANGED") {
+		t.Fatalf("result error lost guarded component code: %q", result.Error)
+	}
+}
+
+func TestSmartExecutor_PreservesPreResolvedApplicationData(t *testing.T) {
+	catalog := &AgentCatalog{agents: map[string]*AgentInfo{
+		"tool-1": {
+			Registration: &core.ServiceRegistration{ID: "tool-1", Name: "guarded-tool", Address: "localhost", Port: 8080},
+			Capabilities: []EnhancedCapability{{Name: "execute_guarded_action", Endpoint: "/execute"}},
+		},
+	}}
+	executor := NewSmartExecutor(catalog)
+	logger := &TestLogger{}
+	executor.SetLogger(logger)
+	var capturedBody []byte
+	executor.httpClient = &http.Client{Transport: &paramCapturingRoundTripper{capturedBody: &capturedBody}}
+	applicationParameters := map[string]interface{}{
+		"operation_reference": "ref-1",
+		"application_value":   "password=local-debug-value",
+	}
+	step := RoutingStep{StepID: "execute", AgentName: "guarded-tool", Metadata: map[string]interface{}{
+		"capability": "execute_guarded_action",
+		"parameters": map[string]interface{}{"operation_reference": "{{evaluate.response.data.reference}}"},
+	}}
+
+	ctx := WithPreResolvedParams(context.Background(), applicationParameters, step.StepID)
+	result := executor.executeStep(ctx, step)
+	if !result.Success {
+		t.Fatalf("executeStep failed: %s", result.Error)
+	}
+	if result.Parameters["application_value"] != applicationParameters["application_value"] {
+		t.Fatalf("recorded parameters changed application data: %#v", result.Parameters)
+	}
+	if !strings.Contains(string(capturedBody), `"application_value":"password=local-debug-value"`) {
+		t.Fatalf("dispatch did not receive the exact application value: %s", capturedBody)
+	}
+	resolution, ok := result.Metadata["resolution"].(*ResolutionMetadata)
+	if !ok {
+		t.Fatalf("resolution metadata type = %T", result.Metadata["resolution"])
+	}
+	foundApplicationValue := false
+	for _, parameter := range resolution.Parameters {
+		if parameter.Name == "application_value" {
+			foundApplicationValue = true
+			if parameter.Value != applicationParameters["application_value"] {
+				t.Fatalf("resolution metadata changed application data: %#v", parameter.Value)
+			}
+		}
+	}
+	if !foundApplicationValue {
+		t.Fatal("application value is missing from resolution metadata")
+	}
+	logged := fmt.Sprint(logger.GetLogs())
+	if !strings.Contains(logged, "password=local-debug-value") {
+		t.Fatalf("executor observability did not preserve application data: %s", logged)
+	}
+}
+
+func TestSmartExecutor_ApplicationDataDoesNotDisableLLMErrorAnalysis(t *testing.T) {
+	catalog := &AgentCatalog{agents: map[string]*AgentInfo{
+		"tool-1": {
+			Registration: &core.ServiceRegistration{ID: "tool-1", Name: "guarded-tool", Address: "localhost", Port: 8080},
+			Capabilities: []EnhancedCapability{{Name: "execute_guarded_action", Endpoint: "/execute"}},
+		},
+	}}
+	executor := NewSmartExecutor(catalog)
+	aiClient := NewMockAIClient()
+	executor.SetErrorAnalyzer(NewErrorAnalyzer(aiClient, nil))
+	mockRT := NewMockRoundTripper()
+	mockRT.SetResponse("http://localhost:8080/execute", http.StatusConflict, `{"success":false,"error":{"code":"RESOURCE_VERSION_CHANGED","message":"resource changed","retryable":false}}`)
+	executor.httpClient = &http.Client{Transport: mockRT}
+	step := RoutingStep{StepID: "execute", AgentName: "guarded-tool", Metadata: map[string]interface{}{
+		"capability": "execute_guarded_action",
+		"parameters": map[string]interface{}{"operation_reference": "{{evaluate.response.data.reference}}"},
+	}}
+	applicationParameters := map[string]interface{}{
+		"operation_reference": "ref-1",
+		"application_value":   "password=local-debug-value",
+	}
+
+	result := executor.executeStep(WithPreResolvedParams(context.Background(), applicationParameters, step.StepID), step)
+	if result.Success || !strings.Contains(result.Error, "RESOURCE_VERSION_CHANGED") {
+		t.Fatalf("expected authoritative guarded failure, got %+v", result)
+	}
+	if len(aiClient.calls) == 0 {
+		t.Fatal("application data unexpectedly disabled LLM error analysis")
+	}
+}
+
+// The sanitized component error is recorded before the analyzer branches so
+// guarded 4xx exits keep it. That branch retries via `continue` and skips the
+// end-of-loop error assignment, so a repaired attempt must still clear the
+// first attempt's error rather than report success and failure together.
+func TestSmartExecutor_ClearsErrorAfterSuccessfulLLMRepairRetry(t *testing.T) {
+	catalog := &AgentCatalog{agents: map[string]*AgentInfo{
+		"tool-1": {
+			Registration: &core.ServiceRegistration{ID: "tool-1", Name: "weather-tool", Address: "localhost", Port: 8080},
+			Capabilities: []EnhancedCapability{{Name: "get_weather", Endpoint: "/weather"}},
+		},
+	}}
+	executor := NewSmartExecutor(catalog)
+	executor.SetErrorAnalyzer(NewErrorAnalyzer(&errorAnalyzerMockAI{
+		response: `{"should_retry": true, "reason": "Location typo", "suggested_changes": {"city": "Tokyo"}}`,
+	}, nil))
+	mockRT := NewMockRoundTripper()
+	mockRT.SetRetryResponses("http://localhost:8080/weather", []struct {
+		StatusCode int
+		Body       string
+	}{
+		{StatusCode: http.StatusBadRequest, Body: `{"error":"unknown city Tokyoo"}`},
+		{StatusCode: http.StatusOK, Body: `{"result":"sunny"}`},
+	})
+	executor.httpClient = &http.Client{Transport: mockRT}
+	step := RoutingStep{StepID: "weather", AgentName: "weather-tool", Metadata: map[string]interface{}{
+		"capability": "get_weather",
+		"parameters": map[string]interface{}{"city": "Tokyoo"},
+	}}
+
+	result := executor.executeStep(context.Background(), step)
+	if !result.Success {
+		t.Fatalf("expected success after LLM parameter repair, got error %q", result.Error)
+	}
+	if result.Error != "" {
+		t.Fatalf("repaired step reports success and error together: %q", result.Error)
 	}
 }
 
@@ -654,6 +804,9 @@ func TestSmartExecutor_NonOrchestratorRetryUnaffected(t *testing.T) {
 
 	if !result.Success {
 		t.Errorf("Expected success after retry, got: %s", result.Error)
+	}
+	if result.Error != "" {
+		t.Errorf("successful retry retained stale error: %q", result.Error)
 	}
 	if result.Attempts != 2 {
 		t.Errorf("Expected 2 attempts for tool capability, got %d", result.Attempts)

--- a/orchestration/factory.go
+++ b/orchestration/factory.go
@@ -1120,9 +1120,9 @@ func WithExecutionStore(store ExecutionStore) OrchestratorOption {
 	}
 }
 
-// WithExecutionStoreProvider is a convenience function that creates an ExecutionStore
-// from a StorageProvider. The application provides the StorageProvider implementation.
-func WithExecutionStoreProvider(provider StorageProvider, logger core.Logger) OrchestratorOption {
+// WithExecutionStoreProvider is a convenience function that creates an
+// ExecutionStore from an ExecutionStorageProvider supplied by the application.
+func WithExecutionStoreProvider(provider ExecutionStorageProvider, logger core.Logger) OrchestratorOption {
 	return func(c *OrchestratorConfig) {
 		c.ExecutionStore.Enabled = true // Auto-enable when provider is provided
 		c.ExecutionStoreBackend = NewExecutionStoreWithProvider(provider, c.ExecutionStore, logger)

--- a/orchestration/hitl_api.go
+++ b/orchestration/hitl_api.go
@@ -220,7 +220,6 @@ func (h *HITLHandler) HandleCommand(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to process command: %s", err.Error()))
 		return
 	}
-
 	// Add span event for successful processing
 	telemetry.AddSpanEvent(ctx, "hitl.api.command.processed",
 		attribute.String("checkpoint_id", command.CheckpointID),

--- a/orchestration/llm_debug_store.go
+++ b/orchestration/llm_debug_store.go
@@ -10,11 +10,18 @@ package orchestration
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/truvaagents/truva-g3/core"
 	"github.com/truvaagents/truva-g3/telemetry"
 )
+
+// ErrLLMDebugRecordNotFound identifies the expected absence of an LLM debug
+// record. Valid executions do not necessarily call an LLM, so retention
+// coordination uses errors.Is to suppress this condition without hiding real
+// backend failures.
+var ErrLLMDebugRecordNotFound = errors.New("LLM debug record not found")
 
 // LLMDebugStore stores LLM interaction payloads for debugging.
 // Implementations must be safe for concurrent use.
@@ -42,6 +49,14 @@ type LLMDebugStore interface {
 	// ListRecent returns recent records for UI listing.
 	// Results are ordered by creation time, newest first.
 	ListRecent(ctx context.Context, limit int) ([]LLMDebugRecordSummary, error)
+}
+
+// LLMDebugRetentionPreserver is the optional capability used when final
+// execution retention must survive LLM writes that have not started yet or
+// originate in another process. Implementations establish a retention floor
+// without creating an empty debug record and apply it to any existing record.
+type LLMDebugRetentionPreserver interface {
+	PreserveRetention(ctx context.Context, requestID string, duration time.Duration) error
 }
 
 // LLMDebugRecord stores all LLM interactions for a single orchestration request.

--- a/orchestration/llm_debug_store_test.go
+++ b/orchestration/llm_debug_store_test.go
@@ -84,6 +84,40 @@ func TestMemoryLLMDebugStore_RecordInteraction(t *testing.T) {
 	}
 }
 
+func TestMemoryLLMDebugStore_PreservesApplicationPayloads(t *testing.T) {
+	store := NewMemoryLLMDebugStore()
+	payload := "password=local-debug-value"
+	requestID := "test-payload-fidelity"
+	interaction := LLMInteraction{
+		Type:         "error_analysis",
+		Prompt:       "prompt " + payload,
+		SystemPrompt: "system " + payload,
+		Response:     "response " + payload,
+		Error:        "error " + payload,
+		Success:      false,
+	}
+	if err := store.RecordInteraction(context.Background(), requestID, interaction); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(context.Background(), requestID, "application_value", payload); err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.GetRecord(context.Background(), requestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), payload) || strings.Contains(string(encoded), "[REDACTED]") {
+		t.Fatalf("memory debug record changed application payloads: %s", encoded)
+	}
+	if record.Metadata["application_value"] != payload {
+		t.Fatalf("memory debug metadata = %q, want %q", record.Metadata["application_value"], payload)
+	}
+}
+
 func TestLLMInteraction_HookPhase_RoundTrip(t *testing.T) {
 	store := NewMemoryLLMDebugStore()
 	ctx := context.Background()

--- a/orchestration/memory_llm_debug_store.go
+++ b/orchestration/memory_llm_debug_store.go
@@ -93,7 +93,7 @@ func (s *MemoryLLMDebugStore) GetRecord(ctx context.Context, requestID string) (
 
 	record, exists := s.records[requestID]
 	if !exists {
-		return nil, fmt.Errorf("record not found: %s", requestID)
+		return nil, fmt.Errorf("%w: %s", ErrLLMDebugRecordNotFound, requestID)
 	}
 
 	// Return a copy to prevent external modification
@@ -121,7 +121,7 @@ func (s *MemoryLLMDebugStore) SetMetadata(ctx context.Context, requestID string,
 
 	record, exists := s.records[requestID]
 	if !exists {
-		return fmt.Errorf("record not found: %s", requestID)
+		return fmt.Errorf("%w: %s", ErrLLMDebugRecordNotFound, requestID)
 	}
 
 	if record.Metadata == nil {
@@ -138,7 +138,23 @@ func (s *MemoryLLMDebugStore) ExtendTTL(ctx context.Context, requestID string, d
 	defer s.mu.RUnlock()
 
 	if _, exists := s.records[requestID]; !exists {
-		return fmt.Errorf("record not found: %s", requestID)
+		return fmt.Errorf("%w: %s", ErrLLMDebugRecordNotFound, requestID)
+	}
+	return nil
+}
+
+// PreserveRetention is a validated no-op because in-memory records do not
+// expire. It deliberately does not create an empty record.
+func (s *MemoryLLMDebugStore) PreserveRetention(
+	ctx context.Context,
+	requestID string,
+	duration time.Duration,
+) error {
+	if requestID == "" {
+		return fmt.Errorf("request_id is required")
+	}
+	if duration <= 0 {
+		return fmt.Errorf("duration must be positive")
 	}
 	return nil
 }
@@ -223,6 +239,8 @@ func (s *MemoryLLMDebugStore) Count() int {
 	defer s.mu.RUnlock()
 	return len(s.records)
 }
+
+var _ LLMDebugRetentionPreserver = (*MemoryLLMDebugStore)(nil)
 
 // getTraceIDFromContext extracts trace ID from context if available.
 func getTraceIDFromContext(ctx context.Context) string {

--- a/orchestration/metadata_keys.go
+++ b/orchestration/metadata_keys.go
@@ -9,7 +9,7 @@ const (
 	// for all turns and delegated executions in one multi-turn conversation.
 	// Applications may supply it at orchestration ingress, but execution-store
 	// investigation metadata must not mutate it after persistence.
-	MetadataConversationID = "conversation_id"
+	MetadataConversationID = core.MetadataConversationID
 )
 
 type conversationIDCandidate struct {

--- a/orchestration/orch_022_test.go
+++ b/orchestration/orch_022_test.go
@@ -299,8 +299,8 @@ func TestRebuildCheckpointCompletedSteps_NilOrEmpty(t *testing.T) {
 // Set call so tests can assert on it.
 type ttlCapturingProvider struct {
 	mockStorageProvider
-	ttlsMu sync.Mutex
-	ttls   map[string]time.Duration
+	ttlsMu       sync.Mutex
+	capturedTTLs map[string]time.Duration
 }
 
 func newTTLCapturingProvider() *ttlCapturingProvider {
@@ -309,22 +309,40 @@ func newTTLCapturingProvider() *ttlCapturingProvider {
 			data:    make(map[string]string),
 			indexes: make(map[string]map[string]float64),
 		},
-		ttls: make(map[string]time.Duration),
+		capturedTTLs: make(map[string]time.Duration),
 	}
 	return p
 }
 
 func (p *ttlCapturingProvider) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
 	p.ttlsMu.Lock()
-	p.ttls[key] = ttl
+	p.capturedTTLs[key] = ttl
 	p.ttlsMu.Unlock()
 	return p.mockStorageProvider.Set(ctx, key, value, ttl)
+}
+
+func (p *ttlCapturingProvider) SetKeyWithMinimumTTL(
+	ctx context.Context,
+	key string,
+	value string,
+	minTTL time.Duration,
+) error {
+	if err := p.mockStorageProvider.SetKeyWithMinimumTTL(ctx, key, value, minTTL); err != nil {
+		return err
+	}
+	p.mu.RLock()
+	retention := p.ttls[key]
+	p.mu.RUnlock()
+	p.ttlsMu.Lock()
+	p.capturedTTLs[key] = retention
+	p.ttlsMu.Unlock()
+	return nil
 }
 
 func (p *ttlCapturingProvider) lastTTL(key string) time.Duration {
 	p.ttlsMu.Lock()
 	defer p.ttlsMu.Unlock()
-	return p.ttls[key]
+	return p.capturedTTLs[key]
 }
 
 func ttlStoreFixture(t *testing.T) (*ttlCapturingProvider, ExecutionStore) {

--- a/orchestration/orchestrator.go
+++ b/orchestration/orchestrator.go
@@ -1332,6 +1332,40 @@ func (o *AIOrchestrator) storeExecutionAsync(
 	result *ExecutionResult,
 	checkpoint *ExecutionCheckpoint,
 ) {
+	o.storeExecutionSnapshotAsync(ctx, request, requestID, plan, result, checkpoint, nil, "")
+}
+
+func (o *AIOrchestrator) storeExecutionWithFinalResponseAsync(
+	ctx context.Context,
+	request string,
+	requestID string,
+	plan *RoutingPlan,
+	result *ExecutionResult,
+	finalResponse string,
+) {
+	responseCopy := finalResponse
+	o.storeExecutionSnapshotAsync(
+		ctx,
+		request,
+		requestID,
+		plan,
+		result,
+		nil,
+		&responseCopy,
+		FinalResponseSourceAfterSynthesisHooks,
+	)
+}
+
+func (o *AIOrchestrator) storeExecutionSnapshotAsync(
+	ctx context.Context,
+	request string,
+	requestID string,
+	plan *RoutingPlan,
+	result *ExecutionResult,
+	checkpoint *ExecutionCheckpoint,
+	finalResponse *string,
+	finalResponseSource string,
+) {
 	if o.executionStore == nil {
 		return
 	}
@@ -1362,16 +1396,18 @@ func (o *AIOrchestrator) storeExecutionAsync(
 	resumeCheckpointID, isResume := IsResumeMode(ctx)
 
 	stored := &StoredExecution{
-		RequestID:         requestID,
-		OriginalRequestID: originalRequestID,
-		TraceID:           traceID,
-		AgentName:         agentName,
-		OriginalRequest:   request,
-		Plan:              plan,
-		Result:            result,
-		Interrupted:       checkpoint != nil,
-		Checkpoint:        checkpoint,
-		CreatedAt:         createdAt,
+		RequestID:           requestID,
+		OriginalRequestID:   originalRequestID,
+		TraceID:             traceID,
+		AgentName:           agentName,
+		OriginalRequest:     request,
+		Plan:                plan,
+		Result:              result,
+		Interrupted:         checkpoint != nil,
+		Checkpoint:          checkpoint,
+		CreatedAt:           createdAt,
+		FinalResponse:       finalResponse,
+		FinalResponseSource: finalResponseSource,
 	}
 	if holder, ok := skillExecutionHolderFromContext(ctx); ok {
 		skillState, _ := holder.Snapshot()
@@ -1436,12 +1472,17 @@ func (o *AIOrchestrator) storeExecutionAsync(
 		ConversationID:     conversationID,
 		CheckpointID:       checkpointID,
 		Interrupted:        checkpoint != nil,
+		RetentionTTL: executionRetentionTTL(
+			stored,
+			o.config.ExecutionStore.TTL,
+			o.config.ExecutionStore.ErrorTTL,
+		),
 	})
 }
 
 func (o *AIOrchestrator) executionRecorderFor(requestID string) *executionRecorder {
 	created := newExecutionRecorder(
-		o.recordingCtx, o.executionStore, o.logger, &o.executionWg,
+		o.recordingCtx, o.executionStore, o.debugStore, o.logger, &o.executionWg,
 		o.config.executionStoreWriteTimeout,
 	)
 	actual, _ := o.executionRecorders.LoadOrStore(requestID, created)
@@ -2861,7 +2902,14 @@ func (o *AIOrchestrator) synthesizeBuffered(state *executionRunState) (*Orchestr
 	// Second store: persist result_trim metadata written by Synthesize into StepResult.Metadata.
 	// The first store (inside executePhaseLoop) fires before synthesis runs, so result_trim is absent.
 	// This second fire-and-forget write picks up the metadata without blocking the response path.
-	o.storeExecutionAsync(ctx, request, requestID, loopResult.LastPlan, loopResult.CombinedResult, nil)
+	o.storeExecutionWithFinalResponseAsync(
+		ctx,
+		request,
+		requestID,
+		loopResult.LastPlan,
+		loopResult.CombinedResult,
+		synthesizedResponse,
+	)
 
 	// --- Build response ---
 	totalUsage, usageByPhase := usageAcc.Snapshot()
@@ -3114,7 +3162,14 @@ func (o *AIOrchestrator) synthesizeNativeStreaming(state *executionRunState) (*S
 	// and AfterSynthesis hooks reach their terminal outcome. Request-local
 	// ordering prevents this view from being overwritten by an earlier phase
 	// snapshot.
-	o.storeExecutionAsync(ctx, request, requestID, loopResult.LastPlan, loopResult.CombinedResult, nil)
+	o.storeExecutionWithFinalResponseAsync(
+		ctx,
+		request,
+		requestID,
+		loopResult.LastPlan,
+		loopResult.CombinedResult,
+		finalContent,
+	)
 
 	// Build final response with all enhanced fields
 	totalUsage, usageByPhase := usageAcc.Snapshot()

--- a/orchestration/redis_execution_store.go
+++ b/orchestration/redis_execution_store.go
@@ -5,8 +5,10 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -22,11 +24,11 @@ const (
 	executionCompressionThreshold = 100 * 1024  // 100KB
 	executionMaxPayloadSize       = 1024 * 1024 // 1MB
 
-	// go-redis preserves the Redis TTL sentinel integers as raw duration
-	// values rather than multiplying them by the command's one-second
-	// precision.
-	redisTTLKeyMissing time.Duration = -2
-	redisTTLPersistent time.Duration = -1
+	// go-redis preserves the Redis persistent-key sentinel as a raw duration
+	// value rather than multiplying it by the command's precision. Lua PTTL
+	// scripts return their missing-key sentinel as a plain integer instead.
+	redisTTLPersistent  time.Duration = -1
+	redisPTTLKeyMissing int64         = -2
 )
 
 var conversationIndexUpsertScript = redis.NewScript(`
@@ -174,7 +176,7 @@ func NewRedisExecutionDebugStoreWithConfig(
 	for _, opt := range opts {
 		opt(cfg)
 	}
-	cfg.keyPrefix = normalizeExecutionKeyPrefix(cfg.keyPrefix)
+	normalizeRedisExecutionDebugStoreConfig(cfg)
 
 	// Parse Redis URL and create client
 	redisOpt, err := redis.ParseURL(cfg.redisURL)
@@ -232,8 +234,19 @@ func NewRedisExecutionDebugStoreWithClient(
 			opt(cfg)
 		}
 	}
-	cfg.keyPrefix = normalizeExecutionKeyPrefix(cfg.keyPrefix)
+	normalizeRedisExecutionDebugStoreConfig(cfg)
 	return newRedisExecutionDebugStore(client, false, cfg), nil
+}
+
+func normalizeRedisExecutionDebugStoreConfig(cfg *redisExecutionDebugStoreConfig) {
+	defaults := DefaultExecutionStoreConfig()
+	if cfg.ttl <= 0 {
+		cfg.ttl = defaults.TTL
+	}
+	if cfg.errorTTL <= 0 {
+		cfg.errorTTL = defaults.ErrorTTL
+	}
+	cfg.keyPrefix = normalizeExecutionKeyPrefix(cfg.keyPrefix)
 }
 
 func redisExecutionDebugStoreConfigForClient(config ExecutionStoreConfig) *redisExecutionDebugStoreConfig {
@@ -283,6 +296,11 @@ func (s *RedisExecutionDebugStore) Store(ctx context.Context, execution *StoredE
 		return fmt.Errorf("request_id is required")
 	}
 	storedExecution, conversationID := sanitizeExecutionConversationMetadata(execution)
+	ttl := executionRetentionTTL(storedExecution, s.ttl, s.errorTTL)
+	retentionLink, err := marshalExecutionRetentionLink(storedExecution)
+	if err != nil {
+		return err
+	}
 
 	operation := func() error {
 		// Serialize with optional compression
@@ -291,21 +309,21 @@ func (s *RedisExecutionDebugStore) Store(ctx context.Context, execution *StoredE
 			return fmt.Errorf("serialization failed: %w", err)
 		}
 
-		// Determine TTL based on success/failure.
-		// ORCH-022: interrupted records have Result.Success == false (Result was nil
-		// pre-fix, bypassing this branch). Carve them out so pending HITL approvals
-		// keep the default TTL rather than the shorter errorTTL.
-		ttl := s.ttl
-		if storedExecution.Result != nil &&
-			!storedExecution.Result.Success &&
-			!storedExecution.Interrupted {
-			ttl = s.errorTTL
-		}
-
 		// Store the main record
 		key := s.recordKey(storedExecution.RequestID)
-		if err := s.client.Set(ctx, key, data, ttl).Err(); err != nil {
+		if err := setRedisValueWithMinimumTTL(ctx, s.client, key, data, ttl); err != nil {
 			return fmt.Errorf("redis set failed: %w", err)
+		}
+		if err := setRedisValueWithMinimumTTL(
+			ctx,
+			s.client,
+			s.retentionLinkKey(storedExecution.RequestID),
+			retentionLink,
+			ttl,
+		); err != nil {
+			// The primary execution is authoritative. Retention extension can
+			// recover from a missing projection by reading that record.
+			logExecutionRetentionLinkFailure(ctx, s.logger, storedExecution.RequestID, err)
 		}
 
 		// Update index for listing (sorted set by timestamp) - best effort
@@ -348,12 +366,18 @@ func (s *RedisExecutionDebugStore) Store(ctx context.Context, execution *StoredE
 		// Store trace ID mapping if available - best effort
 		if storedExecution.TraceID != "" {
 			traceKey := s.traceKey(storedExecution.TraceID)
-			if err := s.client.Set(ctx, traceKey, storedExecution.RequestID, ttl).Err(); err != nil {
+			if err := setRedisValueWithMinimumTTL(
+				ctx,
+				s.client,
+				traceKey,
+				storedExecution.RequestID,
+				ttl,
+			); err != nil {
 				if s.logger != nil {
 					s.logger.Warn("Failed to store trace ID mapping", map[string]interface{}{
 						"request_id": storedExecution.RequestID,
 						"trace_id":   storedExecution.TraceID,
-						"error":      err.Error(),
+						"error":      safeExecutionStoreError(err),
 					})
 				}
 				// Don't fail - trace mapping is for convenience
@@ -363,13 +387,23 @@ func (s *RedisExecutionDebugStore) Store(ctx context.Context, execution *StoredE
 		return nil
 	}
 
+	var storeErr error
 	// Layer 2: Use injected circuit breaker if available
 	if s.circuitBreaker != nil {
-		return s.circuitBreaker.Execute(ctx, operation)
+		storeErr = s.circuitBreaker.Execute(ctx, operation)
+	} else {
+		// Layer 1: Built-in simple retry with exponential backoff
+		storeErr = s.executeWithRetry(ctx, operation)
 	}
-
-	// Layer 1: Built-in simple retry with exponential backoff
-	return s.executeWithRetry(ctx, operation)
+	if storeErr != nil {
+		return storeErr
+	}
+	if rootID := relatedRootID(storedExecution); rootID != "" {
+		if err := s.ExtendTTL(ctx, rootID, ttl); err != nil {
+			logLineageRetentionFailure(ctx, s.logger, storedExecution, err)
+		}
+	}
+	return nil
 }
 
 // Get retrieves the complete execution record by request ID.
@@ -381,7 +415,7 @@ func (s *RedisExecutionDebugStore) Get(ctx context.Context, requestID string) (*
 	key := s.recordKey(requestID)
 	data, err := s.client.Get(ctx, key).Bytes()
 	if err == redis.Nil {
-		return nil, fmt.Errorf("execution not found: %s", requestID)
+		return nil, fmt.Errorf("%w: %s", ErrExecutionRecordNotFound, requestID)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("redis get failed: %w", err)
@@ -400,7 +434,7 @@ func (s *RedisExecutionDebugStore) GetByTraceID(ctx context.Context, traceID str
 	traceKey := s.traceKey(traceID)
 	requestID, err := s.client.Get(ctx, traceKey).Result()
 	if err == redis.Nil {
-		return nil, fmt.Errorf("execution not found for trace: %s", traceID)
+		return nil, fmt.Errorf("%w for trace: %s", ErrExecutionRecordNotFound, traceID)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup trace: %w", err)
@@ -440,19 +474,22 @@ func (s *RedisExecutionDebugStore) Update(ctx context.Context, requestID string,
 		if err != nil {
 			return fmt.Errorf("serialization failed: %w", err)
 		}
-
-		// Use original TTL (we can't know the remaining TTL without Redis-specific commands).
-		// ORCH-022: interrupted records have Result.Success == false after the
-		// orchestrator fix — carve them out so pending HITL approvals keep the
-		// default TTL rather than the shorter errorTTL.
-		ttl := s.ttl
-		if storedExecution.Result != nil &&
-			!storedExecution.Result.Success &&
-			!storedExecution.Interrupted {
-			ttl = s.errorTTL
+		retentionLink, err := marshalExecutionRetentionLink(storedExecution)
+		if err != nil {
+			return err
 		}
 
-		return s.client.Set(ctx, s.recordKey(requestID), data, ttl).Err()
+		ttl := executionRetentionTTL(storedExecution, s.ttl, s.errorTTL)
+		return setRedisValuesWithMinimumTTL(
+			ctx,
+			s.client,
+			[]string{
+				s.recordKey(requestID),
+				s.retentionLinkKey(requestID),
+			},
+			[]interface{}{data, retentionLink},
+			ttl,
+		)
 	}
 
 	// Layer 2: Use injected circuit breaker if available
@@ -473,48 +510,93 @@ func (s *RedisExecutionDebugStore) ExtendTTL(ctx context.Context, requestID stri
 		return fmt.Errorf("duration must be positive")
 	}
 
-	execution, err := s.Get(ctx, requestID)
+	operation := func() error {
+		return s.extendTTL(ctx, requestID, duration, make(map[string]struct{}), true)
+	}
+	if s.circuitBreaker != nil {
+		// A missing execution is an expected investigation outcome, not a
+		// storage-health failure. Keep it outside the breaker result so an
+		// expired or never-recorded lineage ID cannot open the same breaker that
+		// protects authoritative Store writes.
+		var expectedAbsence error
+		breakerOperation := func() error {
+			err := operation()
+			if errors.Is(err, ErrExecutionRecordNotFound) {
+				expectedAbsence = err
+				return nil
+			}
+			return err
+		}
+		if err := s.circuitBreaker.Execute(ctx, breakerOperation); err != nil {
+			return err
+		}
+		return expectedAbsence
+	}
+	return s.executeWithRetry(ctx, operation)
+}
+
+func (s *RedisExecutionDebugStore) extendTTL(
+	ctx context.Context,
+	requestID string,
+	duration time.Duration,
+	visited map[string]struct{},
+	required bool,
+) error {
+	if _, seen := visited[requestID]; seen {
+		return nil
+	}
+	visited[requestID] = struct{}{}
+
+	linkKey := s.retentionLinkKey(requestID)
+	link, err := s.loadExecutionRetentionLink(ctx, requestID, linkKey)
+	if err != nil {
+		if !required && errors.Is(err, ErrExecutionRecordNotFound) {
+			return nil
+		}
+		return err
+	}
+	keys := []string{s.recordKey(requestID), linkKey}
+	if link.TraceID != "" {
+		keys = append(keys, s.traceKey(link.TraceID))
+	}
+	if link.ConversationID != "" {
+		keys = append(keys, s.conversationIndexKey(link.ConversationID))
+	}
+	exists, err := extendRedisKeysMinimumTTL(ctx, s.client, keys, duration)
 	if err != nil {
 		return err
 	}
-	key := s.recordKey(requestID)
-
-	if err := s.extendIndexTTLWithoutDowngrade(ctx, key, duration, false); err != nil {
-		return err
-	}
-
-	if execution.TraceID != "" {
-		traceKey := s.traceKey(execution.TraceID)
-		if err := s.extendIndexTTLWithoutDowngrade(ctx, traceKey, duration, false); err != nil {
-			if s.logger != nil {
-				s.logger.Warn("Failed to extend trace ID mapping TTL", map[string]interface{}{
-					"request_id": requestID,
-					"trace_id":   execution.TraceID,
-					"error":      err.Error(),
-				})
-			}
-			// Don't fail - trace mapping TTL extension is best effort
+	if !exists {
+		if !required {
+			return nil
 		}
+		return fmt.Errorf("%w: %s", ErrExecutionRecordNotFound, requestID)
 	}
-
-	if conversationID := ExecutionConversationID(execution); conversationID != "" {
-		conversationKey := s.conversationIndexKey(conversationID)
-		if err := s.extendIndexTTLWithoutDowngrade(
-			ctx,
-			conversationKey,
-			duration,
-			false,
-		); err != nil && s.logger != nil {
-			s.logger.WarnWithContext(ctx, "Failed to extend conversation index TTL", map[string]interface{}{
-				"operation":  "execution_store_conversation_index_ttl",
-				"request_id": requestID,
-				"error_type": "ttl_update",
-				"error":      safeExecutionStoreError(err),
-			})
-		}
+	if rootID := strings.TrimSpace(link.OriginalRequestID); rootID != "" && rootID != requestID {
+		return s.extendTTL(ctx, rootID, duration, visited, false)
 	}
-
 	return nil
+}
+
+func (s *RedisExecutionDebugStore) loadExecutionRetentionLink(
+	ctx context.Context,
+	requestID string,
+	linkKey string,
+) (executionRetentionLink, error) {
+	encoded, err := s.client.Get(ctx, linkKey).Result()
+	if err == nil {
+		return unmarshalExecutionRetentionLink(encoded)
+	}
+	if err != redis.Nil {
+		return executionRetentionLink{}, fmt.Errorf("redis retention link get failed: %w", err)
+	}
+
+	// Compatibility fallback for records stored before retention links existed.
+	execution, err := s.Get(ctx, requestID)
+	if err != nil {
+		return executionRetentionLink{}, err
+	}
+	return executionRetentionLinkFromStored(execution), nil
 }
 
 // SetMetadata adds metadata to an existing record.
@@ -546,14 +628,9 @@ func (s *RedisExecutionDebugStore) SetMetadata(ctx context.Context, requestID st
 			return fmt.Errorf("serialization failed: %w", err)
 		}
 
-		// Get current TTL to preserve it
 		redisKey := s.recordKey(requestID)
-		ttl, err := s.client.TTL(ctx, redisKey).Result()
-		if err != nil || ttl < 0 {
-			ttl = s.ttl
-		}
-
-		return s.client.Set(ctx, redisKey, data, ttl).Err()
+		ttl := executionRetentionTTL(execution, s.ttl, s.errorTTL)
+		return setRedisValueWithMinimumTTL(ctx, s.client, redisKey, data, ttl)
 	}
 
 	// Layer 2: Use injected circuit breaker if available
@@ -722,6 +799,10 @@ func (s *RedisExecutionDebugStore) traceKey(traceID string) string {
 	return normalizeExecutionKeyPrefix(s.keyPrefix) + "trace:" + traceID
 }
 
+func (s *RedisExecutionDebugStore) retentionLinkKey(requestID string) string {
+	return executionRetentionLinkKey(s.keyPrefix, requestID)
+}
+
 func (s *RedisExecutionDebugStore) conversationIndexKey(conversationID string) string {
 	return executionConversationIndexKey(s.keyPrefix, conversationID)
 }
@@ -747,31 +828,6 @@ func (s *RedisExecutionDebugStore) upsertConversationIndex(
 	).Err()
 }
 
-func (s *RedisExecutionDebugStore) extendIndexTTLWithoutDowngrade(
-	ctx context.Context,
-	key string,
-	minTTL time.Duration,
-	expirePersistent bool,
-) error {
-	currentTTL, err := s.client.TTL(ctx, key).Result()
-	if err != nil {
-		return err
-	}
-	switch {
-	case currentTTL == redisTTLKeyMissing:
-		return nil
-	case currentTTL == redisTTLPersistent:
-		if !expirePersistent {
-			return nil
-		}
-		return s.client.Expire(ctx, key, minTTL).Err()
-	case currentTTL >= minTTL:
-		return nil
-	default:
-		return s.client.Expire(ctx, key, minTTL).Err()
-	}
-}
-
 // Layer 1 Resilience Constants (same as LLM Debug Store)
 const (
 	execLayer1MaxRetries     = 3
@@ -789,10 +845,12 @@ func (s *RedisExecutionDebugStore) executeWithRetry(ctx context.Context, operati
 	s.failureMu.Lock()
 	if s.failureCount >= execLayer1MaxFailures && time.Since(s.lastFailure) < execLayer1FailureWindow {
 		s.failureMu.Unlock()
-		s.logger.Warn("Layer 1 resilience: in cooldown period", map[string]interface{}{
-			"failures":     s.failureCount,
-			"cooldown_sec": execLayer1FailureWindow.Seconds(),
-		})
+		if s.logger != nil {
+			s.logger.Warn("Layer 1 resilience: in cooldown period", map[string]interface{}{
+				"failures":     s.failureCount,
+				"cooldown_sec": execLayer1FailureWindow.Seconds(),
+			})
+		}
 		return fmt.Errorf("execution debug store in cooldown after %d failures", s.failureCount)
 	}
 	s.failureMu.Unlock()
@@ -816,14 +874,19 @@ func (s *RedisExecutionDebugStore) executeWithRetry(ctx context.Context, operati
 			s.failureMu.Unlock()
 			return nil
 		}
+		if errors.Is(err, ErrExecutionRecordNotFound) {
+			return err
+		}
 
 		lastErr = err
-		s.logger.Warn("Layer 1 resilience: operation failed, retrying", map[string]interface{}{
-			"attempt": attempt,
-			"max":     execLayer1MaxRetries,
-			"backoff": backoff.String(),
-			"error":   err.Error(),
-		})
+		if s.logger != nil {
+			s.logger.Warn("Layer 1 resilience: operation failed, retrying", map[string]interface{}{
+				"attempt": attempt,
+				"max":     execLayer1MaxRetries,
+				"backoff": backoff.String(),
+				"error":   err.Error(),
+			})
+		}
 
 		// Don't sleep on last attempt
 		if attempt < execLayer1MaxRetries {

--- a/orchestration/redis_llm_debug_store.go
+++ b/orchestration/redis_llm_debug_store.go
@@ -23,6 +23,7 @@ const (
 	llmDebugKeyPrefix   = "truvag3:llm:debug:"
 	llmDebugMetaSuffix  = ":meta"
 	llmDebugInterSuffix = ":interactions"
+	llmDebugFloorSuffix = ":retention-floor"
 
 	// Size thresholds for compression
 	compressionThreshold = 100 * 1024  // 100KB
@@ -32,6 +33,67 @@ const (
 	defaultDebugTTL = 24 * time.Hour
 	errorDebugTTL   = 7 * 24 * time.Hour
 )
+
+var recordLLMInteractionScript = redis.NewScript(`
+local meta_ttl = redis.call("PTTL", KEYS[1])
+local interaction_ttl = redis.call("PTTL", KEYS[2])
+local floor_ttl = redis.call("PTTL", KEYS[4])
+redis.call("RPUSH", KEYS[2], ARGV[1])
+redis.call("HSETNX", KEYS[1], "created_at", ARGV[2])
+redis.call("HSET", KEYS[1], "updated_at", ARGV[2])
+redis.call("HSET", KEYS[1], "trace_id", ARGV[3])
+redis.call("HSET", KEYS[1], "request_id", ARGV[4])
+redis.call("HSET", KEYS[1], "original_request_id", ARGV[5])
+if ARGV[6] ~= "" then
+	redis.call("HSETNX", KEYS[1], ARGV[6], ARGV[7])
+end
+if ARGV[8] ~= "" then
+	redis.call("HSETNX", KEYS[1], "source_component", ARGV[8])
+end
+if ARGV[9] ~= "" then
+	redis.call("HSETNX", KEYS[1], "originating_agent", ARGV[9])
+end
+redis.call("ZADD", KEYS[3], ARGV[10], ARGV[4])
+local requested = tonumber(ARGV[11])
+if floor_ttl == -1 then
+	requested = -1
+elseif floor_ttl > requested then
+	requested = floor_ttl
+end
+if requested == -1 then
+	redis.call("PERSIST", KEYS[1])
+	redis.call("PERSIST", KEYS[2])
+else
+	if meta_ttl == -2 or (meta_ttl >= 0 and meta_ttl < requested) then
+		redis.call("PEXPIRE", KEYS[1], requested)
+	end
+	if interaction_ttl == -2 or (interaction_ttl >= 0 and interaction_ttl < requested) then
+		redis.call("PEXPIRE", KEYS[2], requested)
+	end
+end
+return 1
+`)
+
+var preserveLLMDebugRetentionScript = redis.NewScript(`
+local requested = tonumber(ARGV[1])
+local floor_ttl = redis.call("PTTL", KEYS[1])
+if floor_ttl == -2 then
+	redis.call("SET", KEYS[1], "1", "PX", requested)
+elseif floor_ttl >= 0 and floor_ttl < requested then
+	redis.call("PEXPIRE", KEYS[1], requested)
+elseif floor_ttl > requested then
+	requested = floor_ttl
+end
+for index = 2, #KEYS do
+	local current = redis.call("PTTL", KEYS[index])
+	if floor_ttl == -1 and current >= 0 then
+		redis.call("PERSIST", KEYS[index])
+	elseif current >= 0 and current < requested then
+		redis.call("PEXPIRE", KEYS[index], requested)
+	end
+end
+return floor_ttl
+`)
 
 // RedisLLMDebugStoreOption configures the Redis debug store
 type RedisLLMDebugStoreOption func(*redisDebugStoreConfig)
@@ -129,8 +191,11 @@ func NewRedisLLMDebugStore(opts ...RedisLLMDebugStoreOption) (*RedisLLMDebugStor
 
 	// Apply explicit options (override defaults)
 	for _, opt := range opts {
-		opt(cfg)
+		if opt != nil {
+			opt(cfg)
+		}
 	}
+	normalizeRedisLLMDebugStoreConfig(cfg)
 
 	// Parse Redis URL and create client
 	redisOpt, err := redis.ParseURL(cfg.redisURL)
@@ -184,7 +249,17 @@ func NewRedisLLMDebugStoreWithClient(client redis.UniversalClient, opts ...Redis
 			opt(cfg)
 		}
 	}
+	normalizeRedisLLMDebugStoreConfig(cfg)
 	return newRedisLLMDebugStore(client, false, cfg), nil
+}
+
+func normalizeRedisLLMDebugStoreConfig(cfg *redisDebugStoreConfig) {
+	if cfg.ttl <= 0 {
+		cfg.ttl = defaultDebugTTL
+	}
+	if cfg.errorTTL <= 0 {
+		cfg.errorTTL = errorDebugTTL
+	}
 }
 
 func defaultRedisLLMDebugStoreConfig() *redisDebugStoreConfig {
@@ -211,8 +286,9 @@ func newRedisLLMDebugStore(client redis.UniversalClient, ownsClient bool, cfg *r
 }
 
 // RecordInteraction appends an LLM interaction to the debug record.
-// Uses list-based atomic storage (RPUSH) — safe for concurrent writes from
-// multiple processes (orchestrator + agents).
+// A Redis script atomically appends the interaction, updates metadata/index
+// fields, and preserves any longer or persistent retention already applied.
+// It is safe for concurrent writes from multiple processes (orchestrator + agents).
 // Uses Layer 2 circuit breaker if injected, otherwise falls back to Layer 1 simple retry.
 func (s *RedisLLMDebugStore) RecordInteraction(ctx context.Context, requestID string, interaction LLMInteraction) error {
 	operation := func() error {
@@ -249,38 +325,36 @@ func (s *RedisLLMDebugStore) RecordInteraction(ctx context.Context, requestID st
 			ttl = s.errorTTL
 		}
 
-		// Prevent TTL downgrade: if the key already has a longer TTL (e.g., from
-		// a prior error interaction with errorTTL=7d), keep the longer one.
-		if existingTTL, err := s.client.TTL(ctx, metaKey).Result(); err == nil && existingTTL > ttl {
-			ttl = existingTTL
-		}
-
-		// Atomic pipeline — no read-modify-write, no race condition
-		pipe := s.client.Pipeline()
-		pipe.RPush(ctx, interKey, data)                                            // Append interaction
-		pipe.HSetNX(ctx, metaKey, "created_at", strconv.FormatInt(now.Unix(), 10)) // Set only if new
-		pipe.HSet(ctx, metaKey, "updated_at", strconv.FormatInt(now.Unix(), 10))   // Always update
-		pipe.HSet(ctx, metaKey, "trace_id", traceID)
-		pipe.HSet(ctx, metaKey, "request_id", requestID)
-		pipe.HSet(ctx, metaKey, "original_request_id", originalRequestID)
+		conversationMetadataKey := ""
 		if conversationID != "" {
-			pipe.HSetNX(ctx, metaKey, "meta:"+MetadataConversationID, conversationID)
+			conversationMetadataKey = "meta:" + MetadataConversationID
 		}
-		if interaction.SourceComponent != "" {
-			pipe.HSetNX(ctx, metaKey, "source_component", interaction.SourceComponent)
-		}
-		if originatingAgent != "" {
-			pipe.HSetNX(ctx, metaKey, "originating_agent", originatingAgent)
-		}
-		pipe.Expire(ctx, metaKey, ttl)
-		pipe.Expire(ctx, interKey, ttl)
-		pipe.ZAdd(ctx, s.indexKey(), redis.Z{
-			Score:  float64(now.Unix()),
-			Member: requestID,
-		})
-		_, err = pipe.Exec(ctx)
+		ttlMilliseconds, err := positiveTTLMilliseconds(ttl)
 		if err != nil {
-			return fmt.Errorf("redis pipeline failed: %w", err)
+			return err
+		}
+		if err := recordLLMInteractionScript.Run(
+			ctx,
+			s.client,
+			[]string{
+				metaKey,
+				interKey,
+				s.indexKey(),
+				s.retentionFloorKey(requestID),
+			},
+			data,
+			strconv.FormatInt(now.Unix(), 10),
+			traceID,
+			requestID,
+			originalRequestID,
+			conversationMetadataKey,
+			conversationID,
+			interaction.SourceComponent,
+			originatingAgent,
+			strconv.FormatInt(now.Unix(), 10),
+			strconv.FormatInt(ttlMilliseconds, 10),
+		).Err(); err != nil {
+			return fmt.Errorf("redis interaction write failed: %w", err)
 		}
 
 		return nil
@@ -325,7 +399,7 @@ func (s *RedisLLMDebugStore) getRecordFromList(ctx context.Context, requestID, m
 		return nil, fmt.Errorf("redis hgetall failed: %w", err)
 	}
 	if len(meta) == 0 {
-		return nil, fmt.Errorf("record not found: %s", requestID)
+		return nil, fmt.Errorf("%w: %s", ErrLLMDebugRecordNotFound, requestID)
 	}
 
 	// Get all interactions
@@ -380,7 +454,7 @@ func (s *RedisLLMDebugStore) getRecordFromList(ctx context.Context, requestID, m
 func (s *RedisLLMDebugStore) getRecordFromString(ctx context.Context, requestID, key string) (*LLMDebugRecord, error) {
 	data, err := s.client.Get(ctx, key).Bytes()
 	if err == redis.Nil {
-		return nil, fmt.Errorf("record not found: %s", requestID)
+		return nil, fmt.Errorf("%w: %s", ErrLLMDebugRecordNotFound, requestID)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("redis get failed: %w", err)
@@ -394,7 +468,6 @@ func (s *RedisLLMDebugStore) SetMetadata(ctx context.Context, requestID string, 
 	if key == MetadataConversationID {
 		return fmt.Errorf("%s is framework-owned and cannot be changed", MetadataConversationID)
 	}
-
 	operation := func() error {
 		metaKey := s.recordPrefix() + requestID + llmDebugMetaSuffix
 
@@ -424,11 +497,7 @@ func (s *RedisLLMDebugStore) SetMetadata(ctx context.Context, requestID string, 
 		if err != nil {
 			return err
 		}
-		ttl, err := s.client.TTL(ctx, oldKey).Result()
-		if err != nil || ttl < 0 {
-			ttl = s.ttl
-		}
-		return s.client.Set(ctx, oldKey, data, ttl).Err()
+		return setRedisValueWithMinimumTTL(ctx, s.client, oldKey, data, s.ttl)
 	}
 
 	if s.circuitBreaker != nil {
@@ -439,17 +508,66 @@ func (s *RedisLLMDebugStore) SetMetadata(ctx context.Context, requestID string, 
 
 // ExtendTTL extends retention for investigation.
 func (s *RedisLLMDebugStore) ExtendTTL(ctx context.Context, requestID string, duration time.Duration) error {
+	if requestID == "" {
+		return fmt.Errorf("request_id is required")
+	}
+	if duration <= 0 {
+		return fmt.Errorf("duration must be positive")
+	}
 	metaKey := s.recordPrefix() + requestID + llmDebugMetaSuffix
 	interKey := s.recordPrefix() + requestID + llmDebugInterSuffix
 
-	// Try new format first
-	pipe := s.client.Pipeline()
-	pipe.Expire(ctx, metaKey, duration)
-	pipe.Expire(ctx, interKey, duration)
-	// Also try old format key (backward compat)
-	pipe.Expire(ctx, s.recordPrefix()+requestID, duration)
-	_, err := pipe.Exec(ctx)
-	return err
+	found := false
+	for _, key := range []string{
+		metaKey,
+		interKey,
+		s.recordPrefix() + requestID,
+	} {
+		exists, err := extendRedisKeyMinimumTTL(ctx, s.client, key, duration)
+		if err != nil {
+			return err
+		}
+		found = found || exists
+	}
+	if !found {
+		return fmt.Errorf("%w: %s", ErrLLMDebugRecordNotFound, requestID)
+	}
+	return nil
+}
+
+// PreserveRetention establishes a request-level retention floor and applies it
+// to any existing debug keys in one Redis operation. The floor is intentionally
+// separate from the debug record, so late in-process or cross-process writers
+// inherit the final execution retention without creating an empty UI record.
+func (s *RedisLLMDebugStore) PreserveRetention(
+	ctx context.Context,
+	requestID string,
+	duration time.Duration,
+) error {
+	if requestID == "" {
+		return fmt.Errorf("request_id is required")
+	}
+	milliseconds, err := positiveTTLMilliseconds(duration)
+	if err != nil {
+		return err
+	}
+	operation := func() error {
+		return preserveLLMDebugRetentionScript.Run(
+			ctx,
+			s.client,
+			[]string{
+				s.retentionFloorKey(requestID),
+				s.recordPrefix() + requestID + llmDebugMetaSuffix,
+				s.recordPrefix() + requestID + llmDebugInterSuffix,
+				s.recordPrefix() + requestID,
+			},
+			strconv.FormatInt(milliseconds, 10),
+		).Err()
+	}
+	if s.circuitBreaker != nil {
+		return s.circuitBreaker.Execute(ctx, operation)
+	}
+	return s.executeWithRetry(ctx, operation)
 }
 
 // ListRecent returns recent records ordered by creation time.
@@ -576,6 +694,12 @@ func (s *RedisLLMDebugStore) recordPrefix() string {
 	return s.keyPrefix
 }
 
+func (s *RedisLLMDebugStore) retentionFloorKey(requestID string) string {
+	return s.recordPrefix() + requestID + llmDebugFloorSuffix
+}
+
+var _ LLMDebugRetentionPreserver = (*RedisLLMDebugStore)(nil)
+
 // Layer 1 Resilience Constants
 const (
 	layer1MaxRetries     = 3
@@ -593,10 +717,12 @@ func (s *RedisLLMDebugStore) executeWithRetry(ctx context.Context, operation fun
 	s.failureMu.Lock()
 	if s.failureCount >= layer1MaxFailures && time.Since(s.lastFailure) < layer1FailureWindow {
 		s.failureMu.Unlock()
-		s.logger.Warn("Layer 1 resilience: in cooldown period", map[string]interface{}{
-			"failures":     s.failureCount,
-			"cooldown_sec": layer1FailureWindow.Seconds(),
-		})
+		if s.logger != nil {
+			s.logger.Warn("Layer 1 resilience: in cooldown period", map[string]interface{}{
+				"failures":     s.failureCount,
+				"cooldown_sec": layer1FailureWindow.Seconds(),
+			})
+		}
 		return fmt.Errorf("debug store in cooldown after %d failures", s.failureCount)
 	}
 	s.failureMu.Unlock()
@@ -622,12 +748,14 @@ func (s *RedisLLMDebugStore) executeWithRetry(ctx context.Context, operation fun
 		}
 
 		lastErr = err
-		s.logger.Warn("Layer 1 resilience: operation failed, retrying", map[string]interface{}{
-			"attempt": attempt,
-			"max":     layer1MaxRetries,
-			"backoff": backoff.String(),
-			"error":   err.Error(),
-		})
+		if s.logger != nil {
+			s.logger.Warn("Layer 1 resilience: operation failed, retrying", map[string]interface{}{
+				"attempt": attempt,
+				"max":     layer1MaxRetries,
+				"backoff": backoff.String(),
+				"error":   err.Error(),
+			})
+		}
 
 		// Don't sleep on last attempt
 		if attempt < layer1MaxRetries {

--- a/orchestration/redis_llm_debug_store_test.go
+++ b/orchestration/redis_llm_debug_store_test.go
@@ -2,6 +2,8 @@ package orchestration
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +12,35 @@ import (
 	"github.com/truvaagents/truva-g3/core"
 	"github.com/truvaagents/truva-g3/telemetry"
 )
+
+func TestRedisLLMDebugStore_PreservesApplicationPayloads(t *testing.T) {
+	_, store := setupRedisLLMDebugTestStore(t)
+	payload := "password=local-debug-value"
+	requestID := "req-payload-fidelity"
+	if err := store.RecordInteraction(context.Background(), requestID, LLMInteraction{
+		Type: "semantic_retry", Prompt: "prompt " + payload,
+		Response: "response " + payload, Success: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(context.Background(), requestID, "application_value", payload); err != nil {
+		t.Fatal(err)
+	}
+	record, err := store.GetRecord(context.Background(), requestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), payload) || strings.Contains(string(encoded), "[REDACTED]") {
+		t.Fatalf("redis debug record changed application payloads: %s", encoded)
+	}
+	if record.Metadata["application_value"] != payload {
+		t.Fatalf("redis debug metadata = %q, want %q", record.Metadata["application_value"], payload)
+	}
+}
 
 // setupRedisLLMDebugTestStore creates a RedisLLMDebugStore backed by
 // miniredis. Mirrors the pattern in hitl_checkpoint_store_test.go. No
@@ -31,6 +62,70 @@ func setupRedisLLMDebugTestStore(t *testing.T) (*miniredis.Miniredis, *RedisLLMD
 		errorTTL: 7 * 24 * time.Hour,
 	}
 	return mr, store
+}
+
+func TestRedisLLMDebugStoreOptionsNormalizeNonPositiveTTLs(t *testing.T) {
+	mr := miniredis.RunT(t)
+
+	ownedStore, err := NewRedisLLMDebugStore(
+		WithDebugRedisURL(mr.Addr()),
+		WithDebugTTL(0),
+		WithDebugErrorTTL(-time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewRedisLLMDebugStore: %v", err)
+	}
+	t.Cleanup(func() { _ = ownedStore.Close() })
+	if ownedStore.ttl != defaultDebugTTL || ownedStore.errorTTL != errorDebugTTL {
+		t.Fatalf(
+			"owned store TTLs = (%v, %v), want (%v, %v)",
+			ownedStore.ttl,
+			ownedStore.errorTTL,
+			defaultDebugTTL,
+			errorDebugTTL,
+		)
+	}
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	injectedStore, err := NewRedisLLMDebugStoreWithClient(
+		client,
+		WithDebugTTL(0),
+		WithDebugErrorTTL(-time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewRedisLLMDebugStoreWithClient: %v", err)
+	}
+	if injectedStore.ttl != defaultDebugTTL || injectedStore.errorTTL != errorDebugTTL {
+		t.Fatalf(
+			"injected store TTLs = (%v, %v), want (%v, %v)",
+			injectedStore.ttl,
+			injectedStore.errorTTL,
+			defaultDebugTTL,
+			errorDebugTTL,
+		)
+	}
+
+	for _, test := range []struct {
+		requestID string
+		success   bool
+		wantTTL   time.Duration
+	}{
+		{requestID: "normalized-success", success: true, wantTTL: defaultDebugTTL},
+		{requestID: "normalized-error", success: false, wantTTL: errorDebugTTL},
+	} {
+		if err := injectedStore.RecordInteraction(
+			context.Background(),
+			test.requestID,
+			LLMInteraction{Type: "test", Success: test.success},
+		); err != nil {
+			t.Fatalf("RecordInteraction(%s): %v", test.requestID, err)
+		}
+		metaKey := llmDebugKeyPrefix + test.requestID + llmDebugMetaSuffix
+		if got := mr.TTL(metaKey); got != test.wantTTL {
+			t.Fatalf("TTL(%s) = %v, want %v", metaKey, got, test.wantTTL)
+		}
+	}
 }
 
 // TestRedisLLMDebugStore_ListRecent_DedupeShadowsInSummary is the

--- a/orchestration/redis_retention.go
+++ b/orchestration/redis_retention.go
@@ -1,0 +1,192 @@
+package orchestration
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var extendRedisMinimumTTLScript = redis.NewScript(`
+local current = redis.call("PTTL", KEYS[1])
+local requested = tonumber(ARGV[1])
+if current == -2 or current == -1 or current >= requested then
+	return current
+end
+redis.call("PEXPIRE", KEYS[1], requested)
+return current
+`)
+
+var extendRedisKeysMinimumTTLScript = redis.NewScript(`
+local primary = redis.call("PTTL", KEYS[1])
+if primary == -2 then
+	return primary
+end
+local requested = tonumber(ARGV[1])
+for index = 1, #KEYS do
+	local current = redis.call("PTTL", KEYS[index])
+	if current >= 0 and current < requested then
+		redis.call("PEXPIRE", KEYS[index], requested)
+	end
+end
+return primary
+`)
+
+var setRedisValueWithMinimumTTLScript = redis.NewScript(`
+local previous = redis.call("PTTL", KEYS[1])
+redis.call("SET", KEYS[1], ARGV[1])
+if previous == -1 then
+	return previous
+end
+local requested = tonumber(ARGV[2])
+local selected = requested
+if previous >= 0 and previous > selected then
+	selected = previous
+end
+redis.call("PEXPIRE", KEYS[1], selected)
+return previous
+`)
+
+var setRedisValuesWithMinimumTTLScript = redis.NewScript(`
+local requested = tonumber(ARGV[#ARGV])
+local previous_ttls = {}
+local entries = {}
+for index = 1, #KEYS do
+	previous_ttls[index] = redis.call("PTTL", KEYS[index])
+	table.insert(entries, KEYS[index])
+	table.insert(entries, ARGV[index])
+end
+redis.call("MSET", unpack(entries))
+for index = 1, #KEYS do
+	local previous = previous_ttls[index]
+	if previous ~= -1 then
+		local selected = requested
+		if previous >= 0 and previous > selected then
+			selected = previous
+		end
+		redis.call("PEXPIRE", KEYS[index], selected)
+	end
+end
+return #KEYS
+`)
+
+func positiveTTLMilliseconds(ttl time.Duration) (int64, error) {
+	if ttl <= 0 {
+		return 0, fmt.Errorf("duration must be positive")
+	}
+	milliseconds := ttl.Milliseconds()
+	if milliseconds <= 0 {
+		milliseconds = 1
+	}
+	return milliseconds, nil
+}
+
+// extendRedisKeyMinimumTTL atomically keeps an existing Redis key for at least
+// minTTL from now. Missing keys are not created and persistent keys remain
+// persistent. The boolean reports whether the key existed.
+func extendRedisKeyMinimumTTL(
+	ctx context.Context,
+	client redis.UniversalClient,
+	key string,
+	minTTL time.Duration,
+) (bool, error) {
+	milliseconds, err := positiveTTLMilliseconds(minTTL)
+	if err != nil {
+		return false, err
+	}
+	previous, err := extendRedisMinimumTTLScript.Run(
+		ctx,
+		client,
+		[]string{key},
+		strconv.FormatInt(milliseconds, 10),
+	).Int64()
+	if err != nil {
+		return false, err
+	}
+	return previous != redisPTTLKeyMissing, nil
+}
+
+// extendRedisKeysMinimumTTL atomically keeps an existing primary key and any
+// present related keys for at least minTTL. A missing primary key causes a
+// no-op for the whole key set. Missing related keys are never created and
+// persistent keys remain persistent.
+func extendRedisKeysMinimumTTL(
+	ctx context.Context,
+	client redis.UniversalClient,
+	keys []string,
+	minTTL time.Duration,
+) (bool, error) {
+	if len(keys) == 0 {
+		return false, fmt.Errorf("at least one retention key is required")
+	}
+	milliseconds, err := positiveTTLMilliseconds(minTTL)
+	if err != nil {
+		return false, err
+	}
+	previous, err := extendRedisKeysMinimumTTLScript.Run(
+		ctx,
+		client,
+		keys,
+		strconv.FormatInt(milliseconds, 10),
+	).Int64()
+	if err != nil {
+		return false, err
+	}
+	return previous != redisPTTLKeyMissing, nil
+}
+
+// setRedisValueWithMinimumTTL atomically writes a value and preserves the
+// larger of the key's previous remaining TTL and minTTL. A missing key is
+// created with minTTL; a previously persistent key remains persistent.
+func setRedisValueWithMinimumTTL(
+	ctx context.Context,
+	client redis.UniversalClient,
+	key string,
+	value interface{},
+	minTTL time.Duration,
+) error {
+	milliseconds, err := positiveTTLMilliseconds(minTTL)
+	if err != nil {
+		return err
+	}
+	return setRedisValueWithMinimumTTLScript.Run(
+		ctx,
+		client,
+		[]string{key},
+		value,
+		strconv.FormatInt(milliseconds, 10),
+	).Err()
+}
+
+// setRedisValuesWithMinimumTTL atomically writes related values while
+// preserving each key's larger previous remaining TTL. Missing keys are
+// created with minTTL and previously persistent keys remain persistent.
+func setRedisValuesWithMinimumTTL(
+	ctx context.Context,
+	client redis.UniversalClient,
+	keys []string,
+	values []interface{},
+	minTTL time.Duration,
+) error {
+	if len(keys) == 0 {
+		return fmt.Errorf("at least one retention key is required")
+	}
+	if len(keys) != len(values) {
+		return fmt.Errorf("retention key and value counts must match")
+	}
+	milliseconds, err := positiveTTLMilliseconds(minTTL)
+	if err != nil {
+		return err
+	}
+	args := make([]interface{}, 0, len(values)+1)
+	args = append(args, values...)
+	args = append(args, strconv.FormatInt(milliseconds, 10))
+	return setRedisValuesWithMinimumTTLScript.Run(
+		ctx,
+		client,
+		keys,
+		args...,
+	).Err()
+}

--- a/telemetry/ARCHITECTURE.md
+++ b/telemetry/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # TruvaG3 Telemetry Module Architecture
 
-**Version**: 1.4
+**Version**: 1.6
 **Module**: `github.com/truvaagents/truva-g3/telemetry`
 **Purpose**: Production-grade observability with OpenTelemetry integration
 **Audience**: Framework developers, application developers, operations teams
@@ -371,13 +371,14 @@ By placing the recorder interface and Redis implementation in telemetry, agents 
 │  3. Builds telemetry.LLMCallRecord                           │
 │  4. Fires async goroutine → recorder.RecordLLMCall()         │
 └──────────────────────┬───────────────────────────────────────┘
-                       │ Pipeline: RPUSH interaction + HSETNX metadata + index
+                       │ Atomic Lua: append + metadata + index + minimum TTL
                        ↓
 ┌─────────────────────────────────────────────────────────────┐
 │ Redis DB 7                                                   │
 │                                                              │
 │  truvag3:llm:debug:{requestID}:interactions  [JSON, JSON, …] │
 │  truvag3:llm:debug:{requestID}:meta          {hash fields}    │
+│  truvag3:llm:debug:{requestID}:retention-floor  {marker}      │
 │  truvag3:llm:debug:index                     {sorted set}     │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -398,14 +399,22 @@ created by those factories are wrapped normally.
 
 2. **Format-compatible**: The JSON structure written by `RedisLLMCallRecorder` matches `orchestration.LLMInteraction` exactly. Both writers produce records that the registry-viewer can read seamlessly.
 
-3. **No read-modify-write**: A Redis pipeline appends the interaction and
-   performs first-valid metadata backfill with `HSETNX`, then updates the
-   listing index and TTLs. Concurrent orchestration and agent writers share the
-   same format without replacing an established conversation ID.
+3. **Atomic write and minimum retention**: One Redis Lua operation appends the
+   interaction, performs first-valid metadata backfill with `HSETNX`, updates
+   the listing index, and applies TTLs. It also reads orchestration's
+   request-scoped retention-floor marker in the same operation. It therefore
+   preserves a longer or persistent lifetime even when the agent-side write
+   starts after final execution recording or runs in another pod.
 
 4. **Layer 1 resilience**: Built-in retry with exponential backoff (3 attempts, 100ms→2s) and failure cooldown (5 failures in 30s triggers 30s pause). Recording failures never impact the LLM call path.
 
-5. **Request context propagation**: The orchestrator's executor sends
+5. **Payload fidelity and adopter ownership**: The Redis recorder and its
+   orchestration format twin preserve the application and model payloads they
+   receive. They do not infer sensitive domain fields or alter content before
+   persistence. Applications own sanitization, access control, encryption, and
+   retention decisions for sensitive workloads.
+
+6. **Request context propagation**: The orchestrator's executor sends
    framework-managed request, step, plan, phase, original-request,
    conversation, agent, and investigation headers. Agents extract the request,
    step, plan, phase, original-request, conversation, and agent headers via
@@ -414,9 +423,9 @@ created by those factories are wrapped normally.
    W3C Trace Context and W3C Baggage; the explicit conversation header is a
    framework fallback, not a replacement for standard propagation.
 
-6. **Phase number propagation**: For multi-phase iterative planning, the executor also sends `X-TruvaG3-Phase-Number` as an HTTP header. `core.ExtractRequestContext()` extracts it into context, and `InstrumentedAIClient.resolvePhaseNumber()` reads it (with OTel baggage fallback). The `LLMCallRecord.PhaseNumber` field (`omitempty`, 0 = single-phase/Phase 1) enables the registry-viewer to correlate agent LLM calls to specific planning phases.
+7. **Phase number propagation**: For multi-phase iterative planning, the executor also sends `X-TruvaG3-Phase-Number` as an HTTP header. `core.ExtractRequestContext()` extracts it into context, and `InstrumentedAIClient.resolvePhaseNumber()` reads it (with OTel baggage fallback). The `LLMCallRecord.PhaseNumber` field (`omitempty`, 0 = single-phase/Phase 1) enables the registry-viewer to correlate agent LLM calls to specific planning phases.
 
-7. **Sanitized error ownership**: `LLMCallRecord.Error` is observation-only.
+8. **Sanitized error ownership**: `LLMCallRecord.Error` is observation-only.
    The producing caller—`ai.InstrumentedAIClient` for provider calls—must
    sanitize the string before invoking `RecordLLMCall`. Telemetry recorders
    store the supplied value verbatim; they do not parse provider-specific
@@ -424,7 +433,7 @@ created by those factories are wrapped normally.
    adapters must therefore keep raw response bodies out of returned errors,
    while the producer applies credential redaction as defense in depth.
 
-8. **Correlation is not a metric dimension**: The centralized
+9. **Correlation is not a metric dimension**: The centralized
    metric-enrichment boundary excludes reserved request-, user-, session-,
    trace-, plan-, step-, checkpoint-, investigation-, pass-, conversation-, and
    provider-request names even when an incoming baggage member carries
@@ -1665,6 +1674,8 @@ skills does not add a telemetry initialization requirement.
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.6 | 2026-08-28 | Documented the shared DB 7 retention-floor marker used by late and cross-process agent writers |
+| 1.5 | 2026-08-28 | Synchronized the standalone Redis LLM writer with orchestration's exact-payload and atomic minimum-retention contract |
 | 1.4 | 2026-08-20 | Excluded reserved correlation and provider-observation names from automatic metric-label enrichment without stripping existing baggage or changing documented log/span emission |
 | 1.3 | 2026-08-20 | Documented caller-owned sanitization and recorder-verbatim storage for `LLMCallRecord.Error` |
 | 1.2 | 2026-08-12 | Documented the provider-neutral Agent Skills span, metric-cardinality, and content-exclusion contract |

--- a/telemetry/redis_llm_recorder.go
+++ b/telemetry/redis_llm_recorder.go
@@ -7,7 +7,7 @@
 // Design: Phase 8 of AGENT_LLM_DEBUG_CAPTURE_DESIGN.md
 // - Write-only: agents append interactions, registry-viewer reads them
 // - Format-compatible: writes match orchestration.LLMInteraction JSON structure
-// - Atomic: uses RPUSH (no read-modify-write, safe for concurrent writes)
+// - Atomic: one Redis script appends data and preserves minimum retention
 // - Resilient: Layer 1 retry with exponential backoff
 package telemetry
 
@@ -26,10 +26,12 @@ import (
 
 const (
 	// Redis key patterns — must match orchestration/redis_llm_debug_store.go
-	recorderKeyPrefix   = "truvag3:llm:debug:"
-	recorderIndexKey    = "truvag3:llm:debug:index"
-	recorderMetaSuffix  = ":meta"
-	recorderInterSuffix = ":interactions"
+	recorderKeyPrefix                 = "truvag3:llm:debug:"
+	recorderIndexKey                  = "truvag3:llm:debug:index"
+	recorderMetaSuffix                = ":meta"
+	recorderInterSuffix               = ":interactions"
+	recorderFloorSuffix               = ":retention-floor"
+	recorderConversationMetadataField = "meta:" + core.MetadataConversationID
 
 	// Default TTLs — match orchestration defaults
 	recorderDefaultTTL = 24 * time.Hour
@@ -42,6 +44,51 @@ const (
 	recorderFailureWindow  = 30 * time.Second
 	recorderMaxFailures    = 5
 )
+
+// recordLLMCallScript is the format-twin of orchestration's LLM interaction
+// writer. Reading the prior TTL and applying the write in one script prevents
+// an agent-side success record from shortening retention already promoted by
+// the orchestrator. Missing keys receive the requested TTL; persistent and
+// longer-lived keys retain their existing lifetime.
+var recordLLMCallScript = redis.NewScript(`
+local meta_ttl = redis.call("PTTL", KEYS[1])
+local interaction_ttl = redis.call("PTTL", KEYS[2])
+local floor_ttl = redis.call("PTTL", KEYS[4])
+redis.call("RPUSH", KEYS[2], ARGV[1])
+redis.call("HSETNX", KEYS[1], "created_at", ARGV[2])
+redis.call("HSET", KEYS[1], "updated_at", ARGV[2])
+redis.call("HSET", KEYS[1], "trace_id", ARGV[3])
+redis.call("HSET", KEYS[1], "request_id", ARGV[4])
+redis.call("HSET", KEYS[1], "original_request_id", ARGV[5])
+if ARGV[6] ~= "" then
+	redis.call("HSETNX", KEYS[1], ARGV[11], ARGV[6])
+end
+if ARGV[7] ~= "" then
+	redis.call("HSETNX", KEYS[1], "source_component", ARGV[7])
+end
+if ARGV[8] ~= "" then
+	redis.call("HSETNX", KEYS[1], "originating_agent", ARGV[8])
+end
+redis.call("ZADD", KEYS[3], ARGV[9], ARGV[4])
+local requested = tonumber(ARGV[10])
+if floor_ttl == -1 then
+	requested = -1
+elseif floor_ttl > requested then
+	requested = floor_ttl
+end
+if requested == -1 then
+	redis.call("PERSIST", KEYS[1])
+	redis.call("PERSIST", KEYS[2])
+else
+	if meta_ttl == -2 or (meta_ttl >= 0 and meta_ttl < requested) then
+		redis.call("PEXPIRE", KEYS[1], requested)
+	end
+	if interaction_ttl == -2 or (interaction_ttl >= 0 and interaction_ttl < requested) then
+		redis.call("PEXPIRE", KEYS[2], requested)
+	end
+end
+return 1
+`)
 
 // RedisLLMCallRecorder is a write-only Redis-backed implementation of LLMCallRecorder.
 // It writes LLM call records to Redis DB 7 in the same format as the orchestration
@@ -108,8 +155,11 @@ func NewRedisLLMCallRecorder(opts ...RecorderOption) (*RedisLLMCallRecorder, err
 		errTTL:   recorderGetEnvDuration("TRUVAG3_LLM_DEBUG_ERROR_TTL", recorderErrorTTL),
 	}
 	for _, opt := range opts {
-		opt(cfg)
+		if opt != nil {
+			opt(cfg)
+		}
 	}
+	normalizeRecorderConfig(cfg)
 
 	redisOpt, err := redis.ParseURL(cfg.redisURL)
 	if err != nil {
@@ -143,6 +193,15 @@ func NewRedisLLMCallRecorder(opts ...RecorderOption) (*RedisLLMCallRecorder, err
 	}, nil
 }
 
+func normalizeRecorderConfig(cfg *recorderConfig) {
+	if cfg.ttl <= 0 {
+		cfg.ttl = recorderDefaultTTL
+	}
+	if cfg.errTTL <= 0 {
+		cfg.errTTL = recorderErrorTTL
+	}
+}
+
 // llmInteractionJSON matches the JSON structure of orchestration.LLMInteraction.
 // This is an internal serialization type — agents write this format, the registry-viewer
 // (which uses orchestration.RedisLLMDebugStore.GetRecord) reads it.
@@ -170,7 +229,8 @@ type llmInteractionJSON struct {
 }
 
 // RecordLLMCall appends an LLM call record to Redis DB 7.
-// Uses the same atomic pipeline format as orchestration.RedisLLMDebugStore.RecordInteraction.
+// Uses the same atomic minimum-retention format as
+// orchestration.RedisLLMDebugStore.RecordInteraction.
 func (r *RedisLLMCallRecorder) RecordLLMCall(ctx context.Context, requestID string, record LLMCallRecord) error {
 	if requestID == "" {
 		return nil // Not called from orchestration — skip silently
@@ -203,7 +263,6 @@ func (r *RedisLLMCallRecorder) RecordLLMCall(ctx context.Context, requestID stri
 			Attempt:          1, // Agent-side calls don't have retry visibility
 			PhaseNumber:      record.PhaseNumber,
 		}
-
 		data, err := json.Marshal(interaction)
 		if err != nil {
 			return fmt.Errorf("serialization failed: %w", err)
@@ -232,43 +291,49 @@ func (r *RedisLLMCallRecorder) RecordLLMCall(ctx context.Context, requestID stri
 		if !record.Success {
 			ttl = r.errTTL
 		}
-
-		// Prevent TTL downgrade
-		if existingTTL, err := r.client.TTL(ctx, metaKey).Result(); err == nil && existingTTL > ttl {
-			ttl = existingTTL
-		}
-
-		// Atomic pipeline — matches orchestration.RedisLLMDebugStore.RecordInteraction exactly
-		pipe := r.client.Pipeline()
-		pipe.RPush(ctx, interKey, data)
-		pipe.HSetNX(ctx, metaKey, "created_at", strconv.FormatInt(now.Unix(), 10))
-		pipe.HSet(ctx, metaKey, "updated_at", strconv.FormatInt(now.Unix(), 10))
-		pipe.HSet(ctx, metaKey, "trace_id", traceID)
-		pipe.HSet(ctx, metaKey, "request_id", requestID)
-		pipe.HSet(ctx, metaKey, "original_request_id", originalRequestID)
-		if conversationID != "" {
-			pipe.HSetNX(ctx, metaKey, "meta:conversation_id", conversationID)
-		}
-		if interaction.SourceComponent != "" {
-			pipe.HSetNX(ctx, metaKey, "source_component", interaction.SourceComponent)
-		}
-		if originatingAgent != "" {
-			pipe.HSetNX(ctx, metaKey, "originating_agent", originatingAgent)
-		}
-		pipe.Expire(ctx, metaKey, ttl)
-		pipe.Expire(ctx, interKey, ttl)
-		pipe.ZAdd(ctx, recorderIndexKey, redis.Z{
-			Score:  float64(now.Unix()),
-			Member: requestID,
-		})
-		_, err = pipe.Exec(ctx)
+		ttlMilliseconds, err := recorderTTLMilliseconds(ttl)
 		if err != nil {
-			return fmt.Errorf("redis pipeline failed: %w", err)
+			return err
+		}
+
+		if err := recordLLMCallScript.Run(
+			ctx,
+			r.client,
+			[]string{
+				metaKey,
+				interKey,
+				recorderIndexKey,
+				recorderKeyPrefix + requestID + recorderFloorSuffix,
+			},
+			data,
+			strconv.FormatInt(now.Unix(), 10),
+			traceID,
+			requestID,
+			originalRequestID,
+			conversationID,
+			interaction.SourceComponent,
+			originatingAgent,
+			strconv.FormatInt(now.Unix(), 10),
+			strconv.FormatInt(ttlMilliseconds, 10),
+			recorderConversationMetadataField,
+		).Err(); err != nil {
+			return fmt.Errorf("redis interaction write failed: %w", err)
 		}
 		return nil
 	}
 
 	return r.executeWithRetry(ctx, operation)
+}
+
+func recorderTTLMilliseconds(ttl time.Duration) (int64, error) {
+	if ttl <= 0 {
+		return 0, fmt.Errorf("duration must be positive")
+	}
+	milliseconds := ttl.Milliseconds()
+	if milliseconds <= 0 {
+		milliseconds = 1
+	}
+	return milliseconds, nil
 }
 
 func recorderConversationIDFromContext(ctx context.Context) string {
@@ -281,7 +346,7 @@ func recorderConversationIDFromContext(ctx context.Context) string {
 		return coreCandidate.Value
 	}
 
-	conversationID := GetBaggage(ctx)["conversation_id"]
+	conversationID := GetBaggage(ctx)[core.MetadataConversationID]
 	if core.ValidateConversationID(conversationID) != core.ConversationIDValidationNone {
 		return ""
 	}

--- a/telemetry/redis_llm_recorder_test.go
+++ b/telemetry/redis_llm_recorder_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -322,6 +323,56 @@ func TestRecorderConstants_MatchOrchestrationDefaults(t *testing.T) {
 	if recorderMaxBackoff != 2*time.Second {
 		t.Errorf("recorderMaxBackoff = %v, want 2s", recorderMaxBackoff)
 	}
+	if recorderConversationMetadataField != "meta:"+core.MetadataConversationID {
+		t.Errorf(
+			"recorderConversationMetadataField = %q, want shared core key",
+			recorderConversationMetadataField,
+		)
+	}
+}
+
+func TestRedisLLMCallRecorderOptionsNormalizeNonPositiveTTLs(t *testing.T) {
+	mr := miniredis.RunT(t)
+	recorder, err := NewRedisLLMCallRecorder(
+		WithRecorderRedisURL(mr.Addr()),
+		WithRecorderRedisDB(0),
+		WithRecorderTTL(0),
+		WithRecorderErrorTTL(-time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewRedisLLMCallRecorder: %v", err)
+	}
+	t.Cleanup(func() { _ = recorder.Close() })
+	if recorder.ttl != recorderDefaultTTL || recorder.errTTL != recorderErrorTTL {
+		t.Fatalf(
+			"recorder TTLs = (%v, %v), want (%v, %v)",
+			recorder.ttl,
+			recorder.errTTL,
+			recorderDefaultTTL,
+			recorderErrorTTL,
+		)
+	}
+
+	for _, test := range []struct {
+		requestID string
+		success   bool
+		wantTTL   time.Duration
+	}{
+		{requestID: "normalized-success", success: true, wantTTL: recorderDefaultTTL},
+		{requestID: "normalized-error", success: false, wantTTL: recorderErrorTTL},
+	} {
+		if err := recorder.RecordLLMCall(
+			context.Background(),
+			test.requestID,
+			LLMCallRecord{CallType: "test", Success: test.success},
+		); err != nil {
+			t.Fatalf("RecordLLMCall(%s): %v", test.requestID, err)
+		}
+		metaKey := recorderKeyPrefix + test.requestID + recorderMetaSuffix
+		if got := mr.TTL(metaKey); got != test.wantTTL {
+			t.Fatalf("TTL(%s) = %v, want %v", metaKey, got, test.wantTTL)
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -363,6 +414,105 @@ func setupRedisLLMRecorderTest(t *testing.T) (*miniredis.Miniredis, *RedisLLMCal
 		errTTL: recorderErrorTTL,
 	}
 	return mr, r
+}
+
+func TestRecordLLMCall_PreservesPromotedAndPersistentRetention(t *testing.T) {
+	mr, recorder := setupRedisLLMRecorderTest(t)
+	ctx := context.Background()
+	requestID := "request-retention"
+	record := LLMCallRecord{CallType: "agent_llm_call", Success: true}
+	if err := recorder.RecordLLMCall(ctx, requestID, record); err != nil {
+		t.Fatalf("initial write: %v", err)
+	}
+
+	keys := []string{
+		recorderKeyPrefix + requestID + recorderMetaSuffix,
+		recorderKeyPrefix + requestID + recorderInterSuffix,
+	}
+	for _, key := range keys {
+		if err := recorder.client.PExpire(ctx, key, 14*24*time.Hour).Err(); err != nil {
+			t.Fatalf("promote %s: %v", key, err)
+		}
+	}
+	if err := recorder.RecordLLMCall(ctx, requestID, record); err != nil {
+		t.Fatalf("write after promotion: %v", err)
+	}
+	for _, key := range keys {
+		if got := mr.TTL(key); got != 14*24*time.Hour {
+			t.Fatalf("%s TTL = %v, want 14d", key, got)
+		}
+		if err := recorder.client.Persist(ctx, key).Err(); err != nil {
+			t.Fatalf("persist %s: %v", key, err)
+		}
+	}
+	if err := recorder.RecordLLMCall(ctx, requestID, record); err != nil {
+		t.Fatalf("write after persist: %v", err)
+	}
+	for _, key := range keys {
+		if got := mr.TTL(key); got != 0 {
+			t.Fatalf("persistent %s gained TTL %v", key, got)
+		}
+	}
+}
+
+func TestRecordLLMCall_ConcurrentWritersKeepLongestRetention(t *testing.T) {
+	mr, recorder := setupRedisLLMRecorderTest(t)
+	ctx := context.Background()
+	requestID := "request-concurrent-retention"
+
+	var wg sync.WaitGroup
+	for index := 0; index < 40; index++ {
+		success := index%2 != 0
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := recorder.RecordLLMCall(ctx, requestID, LLMCallRecord{
+				CallType: "agent_llm_call",
+				Success:  success,
+			}); err != nil {
+				t.Errorf("concurrent write: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	for _, key := range []string{
+		recorderKeyPrefix + requestID + recorderMetaSuffix,
+		recorderKeyPrefix + requestID + recorderInterSuffix,
+	} {
+		if got := mr.TTL(key); got != recorderErrorTTL {
+			t.Fatalf("%s TTL = %v, want %v", key, got, recorderErrorTTL)
+		}
+	}
+}
+
+func TestRecordLLMCall_PreservesApplicationPayloadsAtPersistence(t *testing.T) {
+	mr, recorder := setupRedisLLMRecorderTest(t)
+	payload := "password=local-debug-value"
+	requestID := "request-payload-fidelity"
+	if err := recorder.RecordLLMCall(context.Background(), requestID, LLMCallRecord{
+		CallType:     "agent_llm_call",
+		Description:  "description " + payload,
+		Prompt:       "prompt " + payload,
+		SystemPrompt: "system " + payload,
+		Response:     "response " + payload,
+		Error:        "error " + payload,
+		Success:      false,
+	}); err != nil {
+		t.Fatalf("RecordLLMCall: %v", err)
+	}
+
+	key := recorderKeyPrefix + requestID + recorderInterSuffix
+	values, err := recorder.client.LRange(context.Background(), key, 0, -1).Result()
+	if err != nil || len(values) != 1 {
+		t.Fatalf("stored interactions = (%v, %v)", values, err)
+	}
+	if !strings.Contains(values[0], payload) || strings.Contains(values[0], "[REDACTED]") {
+		t.Fatalf("persisted interaction changed application payloads: %s", values[0])
+	}
+	if got := mr.TTL(key); got != recorderErrorTTL {
+		t.Fatalf("error interaction TTL = %v, want %v", got, recorderErrorTTL)
+	}
 }
 
 // TestRecordLLMCall_StampsOriginatingAgentFromBaggage is the format-twin


### PR DESCRIPTION
## Summary

- Preserve execution-family evidence by promoting root execution and LLM-debug retention without shortening an existing lifetime.
- Improve Registry Viewer conversation grouping, HITL lineage, elapsed-time calculation, Jaeger enrichment, terminal-response evidence, and DAG rendering.
- Align the public framework, observability, environment, port, and Registry Viewer documentation with the implemented behavior.

## Why

Successful root executions could expire before their longer-lived failed or HITL-related children. That left valid child records without their execution-family context and produced misleading parent relationships in Registry Viewer. Resume records could also include the human approval wait in their displayed runtime, while trace-backed hooks and the post-`AfterSynthesis` application response were not represented consistently.

This change makes lineage retention a domain-neutral storage invariant, keeps payload governance with adopters, and makes the Viewer distinguish verified relationships, unavailable parents, pre-hook synthesis output, and stored post-hook application responses.

The Registry Viewer adds `github.com/alicebob/miniredis/v2` as a test-only dependency for deterministic Redis index, grouping, and lineage tests. Its `gopher-lua` entry is transitive. No runtime service dependency is added.

## Test plan

- Rebased onto the latest `origin/main`; final branch is 0 behind and 4 commits ahead.
- Passed the release-state workspace/tag validation from `.github/workflows/ci.yml`.
- Passed `go vet ./...` for `.`, `ai`, `core`, `memory`, `orchestration`, `resilience`, and `telemetry`.
- Passed `go build ./...` and `go test -race -coverprofile=coverage.out -covermode=atomic ./...` for all seven workspace modules.
- Passed optional Bedrock build, race tests, lint, and vulnerability scan.
- Passed `goimports -l`, `golangci-lint` v2.13.1, `gosec`, and `govulncheck` for the complete workspace matrix.
- Built all 53 committed example modules using the same `go mod tidy && go build ./...` loop as CI.
- Passed Registry Viewer race tests, JavaScript unit tests, JavaScript syntax checks, and `bash -n setup.sh`.
- Passed `npm ci && npm run build` for the Docusaurus documentation site, including generated-doc synchronization and broken-link validation.
- Scanned all four branch commits with Gitleaks; no secrets found.

## Checklist

- [x] `go vet`, `go build`, `go test`, `goimports`, `golangci-lint`, `gosec`, `govulncheck` pass locally
- [x] No new external dependencies (or new dependencies justified above)
- [x] User-facing behavior change is reflected in docs / examples
